### PR TITLE
Fix/rtp padding handling

### DIFF
--- a/crates/media/rtp-core/src/packet/rtp.rs
+++ b/crates/media/rtp-core/src/packet/rtp.rs
@@ -8,20 +8,33 @@ use super::header::RtpHeader;
 use crate::error::Error;
 use crate::{Result, RtpSequenceNumber, RtpSsrc, RtpTimestamp};
 
-/// Given the bytes available after the RTP header and, if `header.padding`
-/// is set, the last of those bytes (RFC 3550 section 5.1's padding octet
-/// count), returns how many of those bytes are actual payload.
+/// Given the full packet bytes and the size of the RTP header already
+/// parsed out of them, returns how many of the remaining bytes are actual
+/// payload, accounting for RTP padding (RFC 3550 section 5.1).
 ///
-/// When `header.padding` is false this is just `raw_len`. When it's true,
-/// the last octet gives the padding length (itself included in that
-/// count), which must be nonzero and must not exceed the bytes available,
-/// or the packet is malformed.
-fn payload_len_without_padding(header: &RtpHeader, raw_len: usize, last_byte: u8) -> Result<usize> {
+/// When `header.padding` is false, this is just every byte after the
+/// header. When it's true, at least one byte must follow the header: the
+/// padding octet count, which is itself included in that count, must be
+/// nonzero, and must not exceed the bytes available. A packet with P=1 and
+/// nothing after the header, or a header.padding value that doesn't
+/// satisfy those constraints, is malformed.
+fn payload_len_without_padding(
+    header: &RtpHeader,
+    data: &[u8],
+    header_size: usize,
+) -> Result<usize> {
+    let raw_len = data.len().saturating_sub(header_size);
     if !header.padding {
         return Ok(raw_len);
     }
 
-    let padding_len = last_byte as usize;
+    if raw_len == 0 {
+        return Err(Error::InvalidPacket(
+            "RTP padding bit set but no bytes follow the header".to_string(),
+        ));
+    }
+
+    let padding_len = data[data.len() - 1] as usize;
     if padding_len == 0 {
         return Err(Error::InvalidPacket(
             "RTP padding bit set but padding octet count is zero".to_string(),
@@ -83,17 +96,9 @@ impl RtpPacket {
         debug!("Parsed header of size {}", header_size);
 
         // Extract the payload
-        let payload = if data.len() > header_size {
-            let payload_len = payload_len_without_padding(
-                &header,
-                data.len() - header_size,
-                data[data.len() - 1],
-            )?;
-            header.padding = false; // payload below has padding stripped, so the header should say so
-            Bytes::copy_from_slice(&data[header_size..header_size + payload_len])
-        } else {
-            Bytes::new()
-        };
+        let payload_len = payload_len_without_padding(&header, data, header_size)?;
+        header.padding = false; // payload below has any padding stripped, so the header should say so
+        let payload = Bytes::copy_from_slice(&data[header_size..header_size + payload_len]);
         debug!("Extracted payload of size {}", payload.len());
 
         Ok(Self { header, payload })
@@ -109,17 +114,9 @@ impl RtpPacket {
 
         // Zero-copy slice: `Bytes::slice` only bumps the underlying
         // refcount, no allocation.
-        let payload = if data.len() > header_size {
-            let payload_len = payload_len_without_padding(
-                &header,
-                data.len() - header_size,
-                data[data.len() - 1],
-            )?;
-            header.padding = false; // payload below has padding stripped, so the header should say so
-            data.slice(header_size..header_size + payload_len)
-        } else {
-            Bytes::new()
-        };
+        let payload_len = payload_len_without_padding(&header, &data, header_size)?;
+        header.padding = false; // payload below has any padding stripped, so the header should say so
+        let payload = data.slice(header_size..header_size + payload_len);
         debug!("Sliced payload of size {}", payload.len());
 
         Ok(Self { header, payload })
@@ -355,6 +352,21 @@ mod tests {
 
         assert!(RtpPacket::parse(&raw).is_err());
         assert!(RtpPacket::parse_from_bytes(raw).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_padding_bit_without_padding_count_octet() {
+        // P=1 requires at least one byte after the header (the padding
+        // count, itself included). A packet that ends exactly at the
+        // header boundary with P=1 is malformed, not a valid empty payload.
+        let mut header = plain_header();
+        header.padding = true;
+
+        let mut raw = BytesMut::new();
+        header.serialize(&mut raw).unwrap();
+
+        assert!(RtpPacket::parse(&raw).is_err());
+        assert!(RtpPacket::parse_from_bytes(raw.freeze()).is_err());
     }
 
     #[test]

--- a/crates/media/rtp-core/src/packet/rtp.rs
+++ b/crates/media/rtp-core/src/packet/rtp.rs
@@ -5,7 +5,36 @@ use std::fmt;
 use tracing::debug;
 
 use super::header::RtpHeader;
+use crate::error::Error;
 use crate::{Result, RtpSequenceNumber, RtpSsrc, RtpTimestamp};
+
+/// Given the bytes available after the RTP header and, if `header.padding`
+/// is set, the last of those bytes (RFC 3550 section 5.1's padding octet
+/// count), returns how many of those bytes are actual payload.
+///
+/// When `header.padding` is false this is just `raw_len`. When it's true,
+/// the last octet gives the padding length (itself included in that
+/// count), which must be nonzero and must not exceed the bytes available,
+/// or the packet is malformed.
+fn payload_len_without_padding(header: &RtpHeader, raw_len: usize, last_byte: u8) -> Result<usize> {
+    if !header.padding {
+        return Ok(raw_len);
+    }
+
+    let padding_len = last_byte as usize;
+    if padding_len == 0 {
+        return Err(Error::InvalidPacket(
+            "RTP padding bit set but padding octet count is zero".to_string(),
+        ));
+    }
+    if padding_len > raw_len {
+        return Err(Error::InvalidPacket(format!(
+            "RTP padding length {padding_len} exceeds available payload bytes {raw_len}"
+        )));
+    }
+
+    Ok(raw_len - padding_len)
+}
 
 /// An RTP packet with header and payload
 #[derive(Clone, PartialEq, Eq)]
@@ -13,7 +42,10 @@ pub struct RtpPacket {
     /// RTP header
     pub header: RtpHeader,
 
-    /// Payload data
+    /// Payload data. When parsed from the wire, this never includes RTP
+    /// padding (RFC 3550 section 5.1): [`Self::parse`] and
+    /// [`Self::parse_from_bytes`] strip the padding octets and the trailing
+    /// padding-length octet before returning.
     pub payload: Bytes,
 }
 
@@ -47,12 +79,18 @@ impl RtpPacket {
         debug!("Parsing RTP packet from {} bytes", data.len());
 
         // Parse the header without consuming the buffer
-        let (header, header_size) = RtpHeader::parse_without_consuming(data)?;
+        let (mut header, header_size) = RtpHeader::parse_without_consuming(data)?;
         debug!("Parsed header of size {}", header_size);
 
         // Extract the payload
         let payload = if data.len() > header_size {
-            Bytes::copy_from_slice(&data[header_size..])
+            let payload_len = payload_len_without_padding(
+                &header,
+                data.len() - header_size,
+                data[data.len() - 1],
+            )?;
+            header.padding = false; // payload below has padding stripped, so the header should say so
+            Bytes::copy_from_slice(&data[header_size..header_size + payload_len])
         } else {
             Bytes::new()
         };
@@ -66,13 +104,19 @@ impl RtpPacket {
     pub fn parse_from_bytes(data: Bytes) -> Result<Self> {
         debug!("Parsing RTP packet from {} bytes (zero-copy)", data.len());
 
-        let (header, header_size) = RtpHeader::parse_without_consuming(&data)?;
+        let (mut header, header_size) = RtpHeader::parse_without_consuming(&data)?;
         debug!("Parsed header of size {}", header_size);
 
         // Zero-copy slice: `Bytes::slice` only bumps the underlying
         // refcount, no allocation.
         let payload = if data.len() > header_size {
-            data.slice(header_size..)
+            let payload_len = payload_len_without_padding(
+                &header,
+                data.len() - header_size,
+                data[data.len() - 1],
+            )?;
+            header.padding = false; // payload below has padding stripped, so the header should say so
+            data.slice(header_size..header_size + payload_len)
         } else {
             Bytes::new()
         };
@@ -141,6 +185,7 @@ impl fmt::Debug for RtpPacket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::packet::extension::RtpHeaderExtensions;
     use bytes::Bytes;
 
     #[test]
@@ -228,5 +273,125 @@ mod tests {
         let debug_str = format!("{:?}", packet);
         assert!(debug_str.contains("payload_len: 12"));
         assert!(debug_str.contains("header:"));
+    }
+
+    /// Serializes `header` followed by `media`, and, if `padding_octets` is
+    /// `Some`, RFC 3550 section 5.1 padding: `padding_octets - 1` zero bytes
+    /// followed by the count byte itself (`padding_octets`). Sets
+    /// `header.padding` to match. `padding_octets` must be >= 1 when given,
+    /// since the count byte counts itself.
+    fn build_raw_packet(mut header: RtpHeader, media: &[u8], padding_octets: Option<u8>) -> Bytes {
+        header.padding = padding_octets.is_some();
+        let mut buf = BytesMut::new();
+        header.serialize(&mut buf).unwrap();
+        buf.extend_from_slice(media);
+        if let Some(count) = padding_octets {
+            assert!(count >= 1, "padding octet count must include itself");
+            buf.extend(std::iter::repeat(0u8).take((count - 1) as usize));
+            buf.extend_from_slice(&[count]);
+        }
+        buf.freeze()
+    }
+
+    fn plain_header() -> RtpHeader {
+        RtpHeader::new(96, 1000, 12345, 0xabcdef01)
+    }
+
+    #[test]
+    fn parse_packet_without_padding_bit_returns_full_payload_unchanged() {
+        let raw = build_raw_packet(plain_header(), b"media bytes", None);
+        let packet = RtpPacket::parse(&raw).unwrap();
+
+        assert_eq!(packet.payload, Bytes::from_static(b"media bytes"));
+        assert!(!packet.header.padding);
+    }
+
+    #[test]
+    fn parse_strips_valid_padding_from_the_payload() {
+        let raw = build_raw_packet(plain_header(), b"media", Some(4));
+        let packet = RtpPacket::parse(&raw).unwrap();
+
+        assert_eq!(packet.payload, Bytes::from_static(b"media"));
+        assert!(
+            !packet.header.padding,
+            "padding has been stripped, header should no longer claim it's present"
+        );
+    }
+
+    #[test]
+    fn parse_from_bytes_strips_valid_padding_the_same_way_as_parse() {
+        let raw = build_raw_packet(plain_header(), b"media", Some(4));
+
+        let via_slice = RtpPacket::parse(&raw).unwrap();
+        let via_bytes = RtpPacket::parse_from_bytes(raw).unwrap();
+
+        assert_eq!(via_bytes, via_slice);
+    }
+
+    #[test]
+    fn parse_rejects_padding_length_larger_than_the_payload() {
+        // Hand-craft a P=1 packet whose count byte claims more padding than
+        // bytes are actually available, without going through
+        // build_raw_packet's own bookkeeping.
+        let mut header = plain_header();
+        header.padding = true;
+        let mut buf = BytesMut::new();
+        header.serialize(&mut buf).unwrap();
+        buf.extend_from_slice(&[0xAA, 0xBB, 200]); // claims 200 bytes of padding, only 3 present
+        let raw = buf.freeze();
+
+        assert!(RtpPacket::parse(&raw).is_err());
+        assert!(RtpPacket::parse_from_bytes(raw).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_padding_bit_set_with_zero_count() {
+        let mut header = plain_header();
+        header.padding = true;
+        let mut buf = BytesMut::new();
+        header.serialize(&mut buf).unwrap();
+        buf.extend_from_slice(&[0xAA, 0xBB, 0]); // P=1 but count byte is 0
+        let raw = buf.freeze();
+
+        assert!(RtpPacket::parse(&raw).is_err());
+        assert!(RtpPacket::parse_from_bytes(raw).is_err());
+    }
+
+    #[test]
+    fn parse_handles_csrc_and_extension_and_padding_together() {
+        let mut header = plain_header();
+        header.csrc = vec![0x1111_1111, 0x2222_2222];
+        header.cc = header.csrc.len() as u8;
+        header.extension = true;
+        let mut extensions = RtpHeaderExtensions::new_one_byte();
+        extensions
+            .add_extension(1, Bytes::from_static(&[0xAA]))
+            .unwrap();
+        header.extensions = Some(extensions);
+
+        let raw = build_raw_packet(header, b"media", Some(4));
+        let packet = RtpPacket::parse(&raw).unwrap();
+
+        assert_eq!(packet.header.csrc, vec![0x1111_1111, 0x2222_2222]);
+        assert!(packet.header.extension);
+        assert!(packet.header.extensions.is_some());
+        assert_eq!(packet.payload, Bytes::from_static(b"media"));
+        assert!(!packet.header.padding);
+    }
+
+    #[test]
+    fn padded_packet_round_trips_through_serialize_as_an_unpadded_packet() {
+        // parse() strips padding and clears header.padding, so the
+        // resulting RtpPacket is self-consistent: serializing it again
+        // produces a packet with P=0 and just the media bytes, not a
+        // packet that claims padding it no longer carries.
+        let raw = build_raw_packet(plain_header(), b"media", Some(4));
+        let packet = RtpPacket::parse(&raw).unwrap();
+
+        let reserialized = packet.serialize().unwrap();
+        let reparsed = RtpPacket::parse(&reserialized).unwrap();
+
+        assert!(!reparsed.header.padding);
+        assert_eq!(reparsed.payload, Bytes::from_static(b"media"));
     }
 }


### PR DESCRIPTION
The padding fix in https://github.com/eisenzopf/rvoip/commit/5c4b77b80e782fd62f549f86b6b71d74f3b25301 only ran payload_len_without_padding
inside the data.len() > header_size branch. A packet with P=1 that
ends exactly at the header boundary, with nothing after it, took the
else branch instead and came back as a valid packet with an empty
payload, without ever checking header.padding. RFC 3550 section 5.1
requires at least one byte after the header when P=1 (the padding
count, itself included in that count), so this packet is malformed
and parse/parse_from_bytes should have rejected it.

Fixed by having payload_len_without_padding take the full data slice
and header_size directly instead of a pre-computed raw_len, so it can
see whether there's anything after the header at all rather than
relying on the caller to have already branched on that. Both parse
functions now call it unconditionally instead of special-casing the
no-trailing-bytes case.

Added a test building a header with padding=true and serializing it
with nothing appended, confirming both parse and parse_from_bytes
reject it. All 13 previously-added padding tests and the rest of the
crate's suite (276 tests) still pass.