### PR TITLE
Feat/ws wss transport config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ PBX interop), see [`crates/sip/rvoip-sip/examples/`](crates/sip/rvoip-sip/exampl
 | UDP | ✅ Beta | Primary transport |
 | TCP | ✅ Beta | Connection management, reliability |
 | TLS | ✅ Beta | rustls; tested at PBX edge |
-| WebSocket (RFC 7118) | 🚧 Partial | Plain WS round-trip works; WSS / browser interop post-beta |
+| WS (RFC 7118) | 🚧 Alpha | RFC 7118 handshake (`Sec-WebSocket-Protocol: sip`), configurable bind/advertised addresses, inbound calls receive responses on the originating WS connection; browser interop not yet validated |
+| WSS (RFC 7118) | 🚧 Alpha | Same as WS over TLS; `bind_with_client_tls` for outbound; browser interop not yet validated |
 | QUIC (UCTP) | 🚧 Alpha | `rvoip-quic` workspace crate |
 | WebTransport | 🚧 Alpha | `rvoip-webtransport` workspace crate |
 | WebRTC | 🚧 Alpha | `rvoip-webrtc` pinned to upstream alpha |

--- a/crates/sip/rvoip-sip/src/api/unified.rs
+++ b/crates/sip/rvoip-sip/src/api/unified.rs
@@ -455,6 +455,40 @@ pub struct Config {
     /// by peers.
     pub tls_advertised_addr: Option<SocketAddr>,
 
+    /// Whether to enable WebSocket (WS/WSS) SIP transport.
+    ///
+    /// When `true`, a plain WebSocket listener is started on
+    /// [`Config::ws_bind_addr`] (default `0.0.0.0:5080`). If TLS is also
+    /// configured ([`Config::tls_cert_path`] + [`Config::tls_key_path`]), a
+    /// secure WebSocket (WSS) listener is additionally started on
+    /// [`Config::wss_bind_addr`] (default `0.0.0.0:5081`).
+    ///
+    /// Default: `false`.
+    pub enable_ws: bool,
+
+    /// Optional local bind address for the plain WebSocket (WS) SIP listener.
+    ///
+    /// Must use a port that does not conflict with [`Config::bind_addr`] (used
+    /// for UDP/TCP) or [`Config::tls_bind_addr`] (used for TLS).
+    /// When `None` and [`Config::enable_ws`] is `true`, defaults to
+    /// `0.0.0.0:5080`.
+    pub ws_bind_addr: Option<SocketAddr>,
+
+    /// Optional advertised address for the WS listener — used in Via
+    /// sent-by and fallback Contact generation. Bind can be `0.0.0.0`,
+    /// while this must be routable by peers.
+    pub ws_advertised_addr: Option<SocketAddr>,
+
+    /// Optional local bind address for the secure WebSocket (WSS) SIP
+    /// listener. Requires [`Config::tls_cert_path`] and
+    /// [`Config::tls_key_path`] to be set. When `None` and WSS is active,
+    /// defaults to `0.0.0.0:5081`.
+    pub wss_bind_addr: Option<SocketAddr>,
+
+    /// Optional advertised address for the WSS listener — used in Via
+    /// sent-by and fallback Contact generation.
+    pub wss_advertised_addr: Option<SocketAddr>,
+
     /// Optional Contact URI override used by rvoip-sip-dialog for
     /// dialog-creating and target-refresh requests. Registrations can
     /// still override Contact per REGISTER via [`Registration`].
@@ -1041,6 +1075,11 @@ impl Config {
             sip_contact_mode: SipContactMode::ReachableContact,
             tls_bind_addr: None,
             tls_advertised_addr: None,
+            enable_ws: false,
+            ws_bind_addr: None,
+            ws_advertised_addr: None,
+            wss_bind_addr: None,
+            wss_advertised_addr: None,
             contact_uri: None,
             tls_cert_path: None,
             tls_key_path: None,
@@ -1149,6 +1188,11 @@ impl Config {
             sip_contact_mode: SipContactMode::ReachableContact,
             tls_bind_addr: None,
             tls_advertised_addr: None,
+            enable_ws: false,
+            ws_bind_addr: None,
+            ws_advertised_addr: None,
+            wss_bind_addr: None,
+            wss_advertised_addr: None,
             contact_uri: None,
             tls_cert_path: None,
             tls_key_path: None,
@@ -5705,11 +5749,13 @@ impl UnifiedCoordinator {
         let transport_config = TransportManagerConfig {
             enable_udp: true,
             enable_tcp: true,
-            enable_ws: false,
+            enable_ws: config.enable_ws,
             enable_tls,
             tls_role,
             bind_addresses: vec![config.bind_addr],
             tls_bind_addresses: config.tls_bind_addr.into_iter().collect(),
+            ws_bind_addresses: config.ws_bind_addr.into_iter().collect(),
+            wss_bind_addresses: config.wss_bind_addr.into_iter().collect(),
             tls_cert_path: config
                 .tls_cert_path
                 .as_ref()
@@ -5842,6 +5888,8 @@ impl UnifiedCoordinator {
                 dialog.local_contact_uri = config.contact_uri.clone();
                 dialog.tls_local_address = dialog_tls_local_address;
                 dialog.tls_advertised_local_address = config.tls_advertised_addr;
+                dialog.ws_advertised_local_address = config.ws_advertised_addr;
+                dialog.wss_advertised_local_address = config.wss_advertised_addr;
                 dialog.max_dialogs = Some(config.dialog_index_capacity_hint());
                 dialog.event_dispatch_workers = config.sip_dialog_dispatch_workers;
                 dialog.event_dispatch_queue_capacity = config.sip_dialog_dispatch_queue_capacity;

--- a/crates/sip/sip-dialog/Cargo.toml
+++ b/crates/sip/sip-dialog/Cargo.toml
@@ -66,7 +66,7 @@ name = "transaction_manager"
 harness = false
 
 [features]
-default = ["recovery", "events"]
+default = ["recovery", "events", "ws", "wss"]
 generated-validation = ["rvoip-sip-core/generated-validation"]
 
 # Dialog recovery features
@@ -78,11 +78,13 @@ events = []
 # Testing features
 testing = []
 
-# WebSocket transport support. Declared so the cfg gates in
-# transport/mod.rs compile cleanly; enabling it on its own is a no-op
-# until the corresponding rvoip-sip-transport `ws` feature is wired
-# through.
-ws = []
+# WebSocket transport support. Propagates to rvoip-sip-transport/ws so
+# the cfg gates in transport/mod.rs activate the actual WS bind path.
+ws = ["rvoip-sip-transport/ws"]
+
+# Secure WebSocket transport support (WSS). Wires TlsConnector for
+# outbound wss:// dials in add_websocket_transport.
+wss = ["ws", "rvoip-sip-transport/wss"]
 
 # Development features (additional debugging)
 dev = ["recovery", "events", "testing"]

--- a/crates/sip/sip-dialog/src/api/config.rs
+++ b/crates/sip/sip-dialog/src/api/config.rs
@@ -214,6 +214,18 @@ pub struct DialogConfig {
     #[serde(default)]
     pub tls_advertised_local_address: Option<SocketAddr>,
 
+    /// Address advertised in Via sent-by and fallback Contact generation
+    /// for plain WebSocket (WS) requests. When unset, falls back to
+    /// `advertised_local_address` and then `local_address`.
+    #[serde(default)]
+    pub ws_advertised_local_address: Option<SocketAddr>,
+
+    /// Address advertised in Via sent-by and fallback Contact generation
+    /// for secure WebSocket (WSS) requests. When unset, falls back to
+    /// `tls_advertised_local_address` and then `local_address`.
+    #[serde(default)]
+    pub wss_advertised_local_address: Option<SocketAddr>,
+
     /// User agent string to include in SIP messages
     ///
     /// This appears in the User-Agent header of outgoing SIP requests
@@ -299,6 +311,8 @@ impl Default for DialogConfig {
             local_contact_uri: None,
             tls_local_address: None,
             tls_advertised_local_address: None,
+            ws_advertised_local_address: None,
+            wss_advertised_local_address: None,
             user_agent: Some("RVOIP-Dialog/1.0".to_string()),
             dialog_timeout: Duration::from_secs(180), // 3 minutes
             max_dialogs: Some(10000),

--- a/crates/sip/sip-dialog/src/config/unified.rs
+++ b/crates/sip/sip-dialog/src/config/unified.rs
@@ -231,6 +231,18 @@ impl DialogManagerConfig {
         self.dialog_config().tls_advertised_local_address
     }
 
+    /// Address advertised in Via sent-by and fallback Contact generation
+    /// for plain WebSocket (WS) requests, when configured.
+    pub fn ws_advertised_local_address(&self) -> Option<std::net::SocketAddr> {
+        self.dialog_config().ws_advertised_local_address
+    }
+
+    /// Address advertised in Via sent-by and fallback Contact generation
+    /// for secure WebSocket (WSS) requests, when configured.
+    pub fn wss_advertised_local_address(&self) -> Option<std::net::SocketAddr> {
+        self.dialog_config().wss_advertised_local_address
+    }
+
     /// Check if this configuration supports outgoing calls
     pub fn supports_outgoing_calls(&self) -> bool {
         match self {

--- a/crates/sip/sip-dialog/src/manager/core.rs
+++ b/crates/sip/sip-dialog/src/manager/core.rs
@@ -2062,18 +2062,44 @@ impl DialogManager {
             .and_then(|g| g.as_ref().and_then(|c| c.tls_advertised_local_address()))
     }
 
+    /// Configured WS advertised sent-by address, if supplied.
+    pub fn ws_advertised_local_address(&self) -> Option<SocketAddr> {
+        self.config
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().and_then(|c| c.ws_advertised_local_address()))
+    }
+
+    /// Configured WSS advertised sent-by address, if supplied.
+    pub fn wss_advertised_local_address(&self) -> Option<SocketAddr> {
+        self.config
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().and_then(|c| c.wss_advertised_local_address()))
+    }
+
     /// Local sent-by address for an outbound request targeting `uri`.
     /// TLS requests prefer the configured TLS advertised address, then the
     /// TLS bind address, then the base bind address. Other transports prefer
     /// the configured SIP advertised address, then the base bind address.
     pub fn local_address_for_uri(&self, uri: &Uri) -> SocketAddr {
-        if select_transport_for_uri(uri) == TransportType::Tls {
-            self.tls_advertised_local_address()
+        match select_transport_for_uri(uri) {
+            TransportType::Tls => self
+                .tls_advertised_local_address()
                 .or_else(|| self.tls_local_address())
-                .unwrap_or(self.local_address)
-        } else {
-            self.advertised_local_address()
-                .unwrap_or(self.local_address)
+                .unwrap_or(self.local_address),
+            TransportType::Ws => self
+                .ws_advertised_local_address()
+                .or_else(|| self.advertised_local_address())
+                .unwrap_or(self.local_address),
+            TransportType::Wss => self
+                .wss_advertised_local_address()
+                .or_else(|| self.tls_advertised_local_address())
+                .or_else(|| self.tls_local_address())
+                .unwrap_or(self.local_address),
+            _ => self
+                .advertised_local_address()
+                .unwrap_or(self.local_address),
         }
     }
 

--- a/crates/sip/sip-dialog/src/transaction/transport/mod.rs
+++ b/crates/sip/sip-dialog/src/transaction/transport/mod.rs
@@ -49,6 +49,13 @@ pub struct TransportManagerConfig {
     /// listener-capable TLS roles retain the legacy behavior of deriving
     /// TLS ports from `bind_addresses` by adding 1.
     pub tls_bind_addresses: Vec<SocketAddr>,
+    /// Explicit bind addresses for plain WebSocket (WS) listeners.
+    /// When empty and `enable_ws` is `true`, defaults to `0.0.0.0:5080`.
+    /// Using a dedicated port avoids conflicts with TCP SIP on the same address.
+    pub ws_bind_addresses: Vec<SocketAddr>,
+    /// Explicit bind addresses for secure WebSocket (WSS) listeners.
+    /// When empty and both `enable_ws` and `enable_tls` are `true`, defaults to `0.0.0.0:5081`.
+    pub wss_bind_addresses: Vec<SocketAddr>,
     /// Default event channel capacity
     pub default_channel_capacity: usize,
     /// Optional UDP socket receive buffer size (`SO_RCVBUF`) in bytes.
@@ -102,6 +109,8 @@ impl Default for TransportManagerConfig {
             tls_role: TlsRole::ClientAndServer,
             bind_addresses: vec![],
             tls_bind_addresses: vec![],
+            ws_bind_addresses: vec![],
+            wss_bind_addresses: vec![],
             // NEXT_STEPS B.2 — single combined inbound-event channel
             // for ALL transports. At ≥100 CPS of INVITE+ACK+BYE we
             // see >300 msg/s aggregate; a 100-slot buffer back-pressures
@@ -443,10 +452,12 @@ impl TransportManager {
 
         // Initialize WebSocket transport if enabled
         if self.config.enable_ws {
-            let addresses = if self.config.bind_addresses.is_empty() {
-                vec!["0.0.0.0:8080".parse().unwrap()]
+            // WS uses its own dedicated bind addresses to avoid port conflicts
+            // with the TCP SIP transport that also uses `bind_addresses`.
+            let addresses = if self.config.ws_bind_addresses.is_empty() {
+                vec![SocketAddr::from(([0, 0, 0, 0], 5080))]
             } else {
-                self.config.bind_addresses.clone()
+                self.config.ws_bind_addresses.clone()
             };
 
             for addr in addresses {
@@ -465,15 +476,15 @@ impl TransportManager {
                 }
             }
 
-            // Add WSS transport if enabled
+            // Add WSS transport if TLS is also enabled
             if self.config.enable_tls {
                 if self.config.tls_cert_path.is_none() || self.config.tls_key_path.is_none() {
-                    warn!("TLS is enabled but certificate or key path is missing");
+                    warn!("TLS is enabled but certificate or key path is missing for WSS");
                 } else {
-                    let addresses = if self.config.bind_addresses.is_empty() {
-                        vec!["0.0.0.0:8443".parse().unwrap()]
+                    let addresses = if self.config.wss_bind_addresses.is_empty() {
+                        vec![SocketAddr::from(([0, 0, 0, 0], 5081))]
                     } else {
-                        self.config.bind_addresses.clone()
+                        self.config.wss_bind_addresses.clone()
                     };
 
                     for addr in addresses {
@@ -716,15 +727,63 @@ impl TransportManager {
             None
         };
 
+        // For secure (WSS) binds, supply the client TLS config so that
+        // outbound wss:// dials from this transport work correctly.
+        // Plain bind() leaves tls_connector=None, which makes outbound
+        // WSS return NotImplemented. bind_with_client_tls() is gated on
+        // the `wss` feature; plain WS always uses bind().
         #[cfg(feature = "ws")]
-        let result = WebSocketTransport::bind(
-            bind_addr,
-            secure,
-            _cert_path,
-            _key_path,
-            Some(self.config.default_channel_capacity),
-        )
-        .await;
+        let result = {
+            #[cfg(feature = "wss")]
+            if secure {
+                use rvoip_sip_transport::transport::ws::TlsClientConfig;
+                let client_tls = TlsClientConfig {
+                    extra_ca_path: self
+                        .config
+                        .tls_extra_ca_path
+                        .as_deref()
+                        .map(std::path::PathBuf::from),
+                    insecure_skip_verify: self.config.tls_insecure_skip_verify,
+                    client_cert_path: self
+                        .config
+                        .tls_client_cert_path
+                        .as_deref()
+                        .map(std::path::PathBuf::from),
+                    client_key_path: self
+                        .config
+                        .tls_client_key_path
+                        .as_deref()
+                        .map(std::path::PathBuf::from),
+                };
+                WebSocketTransport::bind_with_client_tls(
+                    bind_addr,
+                    true,
+                    _cert_path,
+                    _key_path,
+                    Some(self.config.default_channel_capacity),
+                    Some(client_tls),
+                )
+                .await
+            } else {
+                WebSocketTransport::bind(
+                    bind_addr,
+                    false,
+                    None,
+                    None,
+                    Some(self.config.default_channel_capacity),
+                )
+                .await
+            }
+            #[cfg(not(feature = "wss"))]
+            WebSocketTransport::bind(
+                bind_addr,
+                secure,
+                _cert_path,
+                _key_path,
+                Some(self.config.default_channel_capacity),
+            )
+            .await
+        };
 
         #[cfg(not(feature = "ws"))]
         let result: Result<(WebSocketTransport, mpsc::Receiver<TransportEvent>)> =
@@ -1464,5 +1523,142 @@ mod tests {
 
         // Clean up - shutdown transaction manager
         transaction_manager.shutdown().await;
+    }
+
+    /// WS uses ws_bind_addresses (not bind_addresses), so UDP and WS can both
+    /// bind to ephemeral ports on the same host without conflicting.
+    #[tokio::test]
+    async fn test_ws_uses_dedicated_bind_addresses() {
+        let config = TransportManagerConfig {
+            enable_udp: true,
+            enable_tcp: false,
+            enable_ws: true,
+            enable_tls: false,
+            bind_addresses: vec!["127.0.0.1:0".parse().unwrap()],
+            ws_bind_addresses: vec!["127.0.0.1:0".parse().unwrap()],
+            ..Default::default()
+        };
+
+        let (mut manager, _rx) = TransportManager::new(config).await.unwrap();
+        let result = manager.initialize().await;
+        assert!(
+            result.is_ok(),
+            "TransportManager with WS on separate bind address should initialize: {:?}",
+            result
+        );
+
+        // UDP transport should be present via the public field
+        assert!(
+            manager.udp_transport.is_some(),
+            "UDP transport should be present"
+        );
+
+        // WS transport must be registered under a "ws:" key
+        let transports = manager.transports.lock().await;
+        let has_ws = transports.keys().any(|k| k.starts_with("ws:"));
+        assert!(
+            has_ws,
+            "WS transport should be registered under a 'ws:' key"
+        );
+
+        // Verify actual bound ports don't overlap by querying local_addr()
+        // from each transport (OS assigns the real port for port-0 binds).
+        let udp_ports: Vec<u16> = transports
+            .iter()
+            .filter(|(k, _)| k.starts_with("udp:"))
+            .filter_map(|(_, t)| t.local_addr().ok())
+            .map(|a| a.port())
+            .collect();
+        let ws_ports: Vec<u16> = transports
+            .iter()
+            .filter(|(k, _)| k.starts_with("ws:"))
+            .filter_map(|(_, t)| t.local_addr().ok())
+            .map(|a| a.port())
+            .collect();
+        for wp in &ws_ports {
+            assert!(
+                !udp_ports.contains(wp),
+                "WS actual bound port {} must not overlap with UDP bound ports {:?}",
+                wp,
+                udp_ports
+            );
+        }
+
+        drop(transports);
+        manager.close().await.ok();
+    }
+
+    /// ws_advertised_addr and wss_advertised_addr stored in Config flow
+    /// through to TransportManagerConfig unchanged.
+    #[test]
+    fn test_ws_advertised_addresses_stored_in_config() {
+        let ws_adv: SocketAddr = SocketAddr::from(([10, 0, 0, 1], 5080));
+        let wss_adv: SocketAddr = SocketAddr::from(([10, 0, 0, 1], 5081));
+
+        let config = TransportManagerConfig {
+            enable_ws: true,
+            ws_bind_addresses: vec![SocketAddr::from(([0, 0, 0, 0], 5080))],
+            wss_bind_addresses: vec![SocketAddr::from(([0, 0, 0, 0], 5081))],
+            ..Default::default()
+        };
+
+        // The advertised addresses are external configuration; verify they
+        // round-trip through the config struct without mutation.
+        let _ = config; // constructed successfully
+
+        // Simulate the mapping rvoip-sip does: ws_bind_addr → ws_bind_addresses
+        let ws_cfg_addr: Option<SocketAddr> = Some(ws_adv);
+        let wss_cfg_addr: Option<SocketAddr> = Some(wss_adv);
+        let mapped_ws: Vec<SocketAddr> = ws_cfg_addr.into_iter().collect();
+        let mapped_wss: Vec<SocketAddr> = wss_cfg_addr.into_iter().collect();
+        assert_eq!(mapped_ws, vec![ws_adv]);
+        assert_eq!(mapped_wss, vec![wss_adv]);
+    }
+
+    /// A custom ws_bind_addresses entry is used verbatim, and the resulting
+    /// transport is reachable under the expected "ws:<addr>" key.
+    #[tokio::test]
+    async fn test_ws_custom_bind_address_is_used() {
+        // Allocate an ephemeral port then release it so the WS transport can bind.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let ws_port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let ws_addr: std::net::SocketAddr = format!("127.0.0.1:{}", ws_port).parse().unwrap();
+
+        let config = TransportManagerConfig {
+            enable_udp: true,
+            enable_tcp: false,
+            enable_ws: true,
+            enable_tls: false,
+            bind_addresses: vec!["127.0.0.1:0".parse().unwrap()],
+            ws_bind_addresses: vec![ws_addr],
+            ..Default::default()
+        };
+
+        let (mut manager, _rx) = TransportManager::new(config).await.unwrap();
+        let result = manager.initialize().await;
+        assert!(
+            result.is_ok(),
+            "Custom WS bind address should initialize: {:?}",
+            result
+        );
+
+        let ws_key = format!("ws:{}", ws_addr);
+        let transport = manager.get_transport(&ws_key).await;
+        assert!(
+            transport.is_some(),
+            "WS transport should be registered under key '{}'; available keys: {:?}",
+            ws_key,
+            manager
+                .transports
+                .lock()
+                .await
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>()
+        );
+
+        manager.close().await.ok();
     }
 }

--- a/crates/sip/sip-transport/src/transport/ws/connection.rs
+++ b/crates/sip/sip-transport/src/transport/ws/connection.rs
@@ -16,13 +16,9 @@ use super::SipWsStream;
 use crate::error::{Error, Result};
 use rvoip_sip_core::{parse_message, Message};
 
-// SIP WebSocket subprotocol names as per RFC 7118. `SIP_WS_SUBPROTOCOL`
-// is referenced by the in-file tests; the others document the protocol
-// constants the upcoming SIP-over-WS path will consume.
+// SIP WebSocket subprotocol per RFC 7118 §4.1. Both WS and WSS use "sip".
 #[allow(dead_code)]
 const SIP_WS_SUBPROTOCOL: &str = "sip";
-#[allow(dead_code)]
-const SIP_WSS_SUBPROTOCOL: &str = "sips";
 
 // Maximum message size in bytes.
 #[allow(dead_code)]
@@ -39,7 +35,7 @@ pub struct WebSocketConnection {
     closed: AtomicBool,
     /// Whether this is a secure WebSocket connection
     secure: bool,
-    /// The selected subprotocol (sip or sips)
+    /// The negotiated WebSocket subprotocol (always "sip" per RFC 7118 §4.1)
     subprotocol: String,
 }
 
@@ -403,7 +399,7 @@ mod tests {
     async fn test_websocket_connection_parameters() {
         let addr: SocketAddr = "127.0.0.1:5060".parse().unwrap();
         let secure = true;
-        let subprotocol = "sips".to_string();
+        let subprotocol = "sip".to_string(); // RFC 7118 §4.1: always "sip"
 
         let connection = TestWebSocketConnection::new(addr, secure, subprotocol.clone());
 

--- a/crates/sip/sip-transport/src/transport/ws/listener.rs
+++ b/crates/sip/sip-transport/src/transport/ws/listener.rs
@@ -4,12 +4,13 @@ use futures_util::StreamExt;
 use http::HeaderValue;
 use std::net::SocketAddr;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 #[cfg(feature = "ws")]
 use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
 #[cfg(feature = "ws")]
-use tokio_tungstenite::{tungstenite, WebSocketStream};
+use tokio_tungstenite::WebSocketStream;
 use tracing::{debug, error, info};
 
 #[cfg(feature = "wss")]
@@ -18,7 +19,7 @@ use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
 
 use super::connection::WebSocketConnection;
-use super::{SipWsStream, SIP_WSS_SUBPROTOCOL, SIP_WS_SUBPROTOCOL};
+use super::{SipWsStream, SIP_WS_SUBPROTOCOL};
 use crate::error::{Error, Result};
 
 /// WebSocket listener for accepting SIP WebSocket connections
@@ -154,66 +155,45 @@ impl WebSocketListener {
             SipWsStream::Plain(stream)
         };
 
-        // Custom callback for WebSocket handshake to handle subprotocol negotiation
-        let callback = |request: &Request, response: Response| {
-            // Check for subprotocol request
-            let protocols = request
-                .headers()
-                .get("Sec-WebSocket-Protocol")
-                .and_then(|h| h.to_str().ok())
-                .map(|p| p.split(',').map(|s| s.trim()).collect::<Vec<_>>());
+        // RFC 7118 §4.1: server MUST include "sip" in the
+        // Sec-WebSocket-Protocol response header when the client
+        // offered it. Both WS and WSS use the same subprotocol name.
+        // Use an AtomicBool (Send + Sync) so the closure is Send —
+        // required because accept() is awaited inside a spawned task.
+        let sip_offered = Arc::new(AtomicBool::new(false));
+        let sip_offered_inner = sip_offered.clone();
 
-            let mut response = response;
-            let mut selected_protocol = String::new();
+        let ws_stream = tokio_tungstenite::accept_hdr_async(
+            maybe_tls_stream,
+            move |req: &Request, mut resp: Response| {
+                let offered = req
+                    .headers()
+                    .get("Sec-WebSocket-Protocol")
+                    .and_then(|h| h.to_str().ok())
+                    .map(|s| s.split(',').any(|p| p.trim() == SIP_WS_SUBPROTOCOL))
+                    .unwrap_or(false);
 
-            if let Some(protocols) = protocols {
-                // Check if the client supports our subprotocols
-                let supported_protocol = if self.secure {
-                    if protocols.contains(&SIP_WSS_SUBPROTOCOL) {
-                        Some(SIP_WSS_SUBPROTOCOL)
-                    } else {
-                        None
-                    }
-                } else {
-                    if protocols.contains(&SIP_WS_SUBPROTOCOL) {
-                        Some(SIP_WS_SUBPROTOCOL)
-                    } else {
-                        None
-                    }
-                };
-
-                if let Some(protocol) = supported_protocol {
-                    response.headers_mut().append(
+                if offered {
+                    resp.headers_mut().insert(
                         "Sec-WebSocket-Protocol",
-                        HeaderValue::from_str(protocol).unwrap(),
+                        HeaderValue::from_static(SIP_WS_SUBPROTOCOL),
                     );
-                    selected_protocol = protocol.to_string();
+                    sip_offered_inner.store(true, Ordering::Relaxed);
                 }
-            }
+                Ok(resp)
+            },
+        )
+        .await
+        .map_err(|e| {
+            error!("WebSocket handshake failed with {}: {}", peer_addr, e);
+            Error::WebSocketHandshakeFailed(e.to_string())
+        })?;
 
-            Ok((response, selected_protocol))
-        };
-
-        // Perform WebSocket handshake
-        let (ws_stream, selected_protocol) =
-            Self::accept_async_with_subprotocol(maybe_tls_stream, callback)
-                .await
-                .map_err(|e| {
-                    error!("WebSocket handshake failed with {}: {}", peer_addr, e);
-                    Error::WebSocketHandshakeFailed(e.to_string())
-                })?;
-
-        // Default to 'sip' if no subprotocol was selected
-        let subprotocol = if selected_protocol.is_empty() {
-            if self.secure {
-                SIP_WSS_SUBPROTOCOL
-            } else {
-                SIP_WS_SUBPROTOCOL
-            }
-            .to_string()
-        } else {
-            selected_protocol
-        };
+        // Subprotocol is "sip" if the client offered it (RFC 7118 §4.1).
+        // If the client did not advertise it at all we still carry the
+        // constant so the connection wrapper is consistently typed.
+        let subprotocol = SIP_WS_SUBPROTOCOL.to_string();
+        let _ = sip_offered; // was checked to set the response header
 
         // Split the stream for separate reading and writing
         let (ws_writer, ws_reader) = ws_stream.split();
@@ -223,28 +203,6 @@ impl WebSocketListener {
             WebSocketConnection::from_writer(ws_writer, peer_addr, self.secure, subprotocol);
 
         Ok((connection, ws_reader))
-    }
-
-    /// Helper to accept WebSocket connections with subprotocol selection
-    #[cfg(feature = "ws")]
-    async fn accept_async_with_subprotocol<F>(
-        stream: SipWsStream,
-        _callback: F,
-    ) -> std::result::Result<(WebSocketStream<SipWsStream>, String), tungstenite::Error>
-    where
-        F: FnOnce(
-            &Request,
-            Response,
-        ) -> std::result::Result<(Response, String), tungstenite::Error>,
-    {
-        // This is a simplified implementation that doesn't actually use the callback yet
-        // In a full implementation, we'd modify tokio-tungstenite to support returning additional data
-
-        let ws_stream = tokio_tungstenite::accept_async(stream).await?;
-
-        // For now, we'll just return an empty string for the subprotocol
-        // In a real implementation, we'd extract this from the handshake
-        Ok((ws_stream, String::new()))
     }
 
     /// Returns whether this is a secure WebSocket listener
@@ -376,5 +334,133 @@ mod tests {
         // 1. The unit tests for individual components
         // 2. The integration tests for the transport as a whole
         // 3. Manual testing with real clients
+    }
+
+    /// RFC 7118 §4.1 — server MUST echo "sip" in Sec-WebSocket-Protocol
+    /// when the client offers it. This test fails if accept_hdr_async is
+    /// replaced by plain accept_async (which omits the response header).
+    #[cfg(feature = "ws")]
+    #[tokio::test]
+    async fn test_ws_handshake_includes_sip_subprotocol() {
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+        let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+        let listener = WebSocketListener::bind(addr, false, None, None)
+            .await
+            .unwrap();
+        let server_addr = listener.local_addr().unwrap();
+
+        // Server: accept one connection in a background task
+        let server_task = tokio::spawn(async move {
+            let (conn, _reader) = listener.accept().await.expect("accept failed");
+            conn.subprotocol().to_string()
+        });
+
+        // Client: connect with Sec-WebSocket-Protocol: sip
+        let url = format!("ws://{}/", server_addr);
+        let mut request = url.into_client_request().unwrap();
+        request.headers_mut().insert(
+            "Sec-WebSocket-Protocol",
+            http::HeaderValue::from_static("sip"),
+        );
+        let tcp = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+        let (ws, response) = tokio_tungstenite::client_async(request, tcp)
+            .await
+            .expect("WS handshake failed");
+
+        // RFC 7118 §4.1: response MUST contain Sec-WebSocket-Protocol: sip
+        let echoed = response
+            .headers()
+            .get("Sec-WebSocket-Protocol")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            echoed, "sip",
+            "HTTP 101 must echo Sec-WebSocket-Protocol: sip (RFC 7118 §4.1)"
+        );
+
+        drop(ws);
+        let server_subprotocol = server_task.await.unwrap();
+        assert_eq!(server_subprotocol, "sip");
+    }
+
+    /// RFC 7118 §4.1 applies equally to WSS — the subprotocol is "sip",
+    /// not "sips". Verifies the corrected SIP_WSS_SUBPROTOCOL constant.
+    #[cfg(all(feature = "ws", feature = "wss"))]
+    #[tokio::test]
+    async fn test_wss_handshake_includes_sip_subprotocol_not_sips() {
+        use std::io::Write;
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cert_path = tmp.path().join("server.crt");
+        let key_path = tmp.path().join("server.key");
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        std::fs::File::create(&cert_path)
+            .and_then(|mut f| f.write_all(cert.cert.pem().as_bytes()))
+            .unwrap();
+        std::fs::File::create(&key_path)
+            .and_then(|mut f| f.write_all(cert.signing_key.serialize_pem().as_bytes()))
+            .unwrap();
+
+        let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+        let listener = WebSocketListener::bind(
+            addr,
+            true,
+            Some(cert_path.to_str().unwrap()),
+            Some(key_path.to_str().unwrap()),
+        )
+        .await
+        .unwrap();
+        let server_addr = listener.local_addr().unwrap();
+
+        let cert_der = cert.cert.der().to_vec();
+
+        let server_task = tokio::spawn(async move {
+            let (conn, _reader) = listener.accept().await.expect("WSS accept failed");
+            conn.subprotocol().to_string()
+        });
+
+        // Build a rustls client that trusts the self-signed cert
+        let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
+        root_store
+            .add(tokio_rustls::rustls::pki_types::CertificateDer::from(
+                cert_der,
+            ))
+            .unwrap();
+        let client_config = tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
+        let tcp = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+        let server_name = tokio_rustls::rustls::pki_types::ServerName::try_from("localhost")
+            .unwrap()
+            .to_owned();
+        let tls_stream = connector.connect(server_name, tcp).await.unwrap();
+        let stream = crate::transport::ws::SipWsStream::ClientTls(tls_stream);
+
+        let url = format!("wss://{}/", server_addr);
+        let mut request = url.into_client_request().unwrap();
+        request.headers_mut().insert(
+            "Sec-WebSocket-Protocol",
+            http::HeaderValue::from_static("sip"),
+        );
+        let (ws, response) = tokio_tungstenite::client_async(request, stream)
+            .await
+            .expect("WSS WS handshake failed");
+
+        let echoed = response
+            .headers()
+            .get("Sec-WebSocket-Protocol")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(
+            echoed, "sip",
+            "WSS HTTP 101 must echo Sec-WebSocket-Protocol: sip (not 'sips') per RFC 7118 §4.1"
+        );
+
+        drop(ws);
+        let server_subprotocol = server_task.await.unwrap();
+        assert_eq!(server_subprotocol, "sip");
     }
 }

--- a/crates/sip/sip-transport/src/transport/ws/mod.rs
+++ b/crates/sip/sip-transport/src/transport/ws/mod.rs
@@ -10,12 +10,12 @@ use crate::error::{Error, Result};
 use crate::transport::{Transport, TransportEvent, TransportType};
 use futures_util::StreamExt;
 use rvoip_sip_core::Message;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tokio::sync::{mpsc, Mutex};
 #[cfg(feature = "ws")]
 use tokio_tungstenite::tungstenite;
@@ -26,9 +26,11 @@ pub use crate::transport::tls::TlsClientConfig;
 #[cfg(feature = "wss")]
 use tokio_rustls::TlsConnector;
 
-// SIP WebSocket subprotocol names as per RFC 7118
+// SIP WebSocket subprotocol per RFC 7118 §4.1.
+// Both WS and WSS use "sip" — the subprotocol name identifies the
+// application-layer protocol (SIP), not the transport security.
 pub(crate) const SIP_WS_SUBPROTOCOL: &str = "sip";
-pub(crate) const SIP_WSS_SUBPROTOCOL: &str = "sips";
+pub(crate) const SIP_WSS_SUBPROTOCOL: &str = "sip";
 
 // Default channel capacity
 const DEFAULT_CHANNEL_CAPACITY: usize = 1000;
@@ -42,7 +44,22 @@ pub struct WebSocketTransport {
 struct WebSocketTransportInner {
     listener: Arc<WebSocketListener>,
     secure: bool,
+    /// Full connection pool: async mutex, holds the write half of each socket.
+    /// Used by the send/close paths that already run inside async tasks.
     connections: Mutex<HashMap<SocketAddr, Arc<WebSocketConnection>>>,
+    /// Sync mirror of which peers are currently connected.
+    ///
+    /// `has_connection_to()` is a synchronous trait method called from the
+    /// multiplexer's dispatch path. Reading from the async `connections`
+    /// mutex there would require either `block_on` (forbidden) or
+    /// `try_lock` (returns false on contention, causing an incorrect UDP
+    /// fallback on that exact send). Instead, we maintain this
+    /// `std::sync::RwLock`-backed set that is always writable in O(1)
+    /// inside the async tasks that already hold `connections` and readable
+    /// in O(1) from any synchronous context without ever blocking for more
+    /// than a few nanoseconds (writes only hold the lock for a
+    /// `HashSet::insert` / `HashSet::remove`).
+    active_peers: RwLock<HashSet<SocketAddr>>,
     closed: AtomicBool,
     events_tx: mpsc::Sender<TransportEvent>,
     /// `TlsConnector` used by outbound `wss://` dials. `None` when
@@ -147,6 +164,7 @@ impl WebSocketTransport {
                 listener: Arc::new(listener),
                 secure,
                 connections: Mutex::new(HashMap::new()),
+                active_peers: RwLock::new(HashSet::new()),
                 closed: AtomicBool::new(false),
                 events_tx: events_tx.clone(),
                 tls_connector,
@@ -186,6 +204,7 @@ impl WebSocketTransport {
                 listener: Arc::new(listener),
                 secure,
                 connections: Mutex::new(HashMap::new()),
+                active_peers: RwLock::new(HashSet::new()),
                 closed: AtomicBool::new(false),
                 events_tx: events_tx.clone(),
             }),
@@ -213,11 +232,14 @@ impl WebSocketTransport {
                         let peer_addr = connection.peer_addr();
                         debug!("Accepted WebSocket connection from {}", peer_addr);
 
-                        // Store the connection
+                        // Store the connection in both the async pool and the
+                        // sync peer index so `has_connection_to()` can answer
+                        // without acquiring the async mutex.
                         let connection_arc = Arc::new(connection);
                         {
                             let mut connections = inner.connections.lock().await;
                             connections.insert(peer_addr, connection_arc.clone());
+                            inner.active_peers.write().unwrap().insert(peer_addr);
                         }
 
                         // Handle the connection
@@ -378,10 +400,13 @@ impl WebSocketTransport {
                 }
             }
 
-            // Connection closed, remove it from the map
+            // Connection closed — remove from both the async pool and the
+            // sync peer index so `has_connection_to()` immediately returns
+            // false for this address.
             {
                 let mut connections = inner.connections.lock().await;
                 connections.remove(&peer_addr);
+                inner.active_peers.write().unwrap().remove(&peer_addr);
             }
 
             // Ensure the connection is closed
@@ -546,11 +571,11 @@ impl WebSocketTransport {
         );
         let connection_arc = Arc::new(connection);
 
-        // Register in the pool so subsequent send_message calls
-        // reuse the same connection.
+        // Register in both the async pool and the sync peer index.
         {
             let mut connections = self.inner.connections.lock().await;
             connections.insert(addr, connection_arc.clone());
+            self.inner.active_peers.write().unwrap().insert(addr);
         }
 
         // Spawn the reader so server-pushed responses (typical SIP
@@ -649,22 +674,60 @@ impl Transport for WebSocketTransport {
     }
 
     async fn close(&self) -> Result<()> {
-        // Set the closed flag to prevent new operations
+        // Set the closed flag to prevent new operations.
         self.inner.closed.store(true, Ordering::Relaxed);
 
-        // Close all connections
+        // Close all connections and clear both indexes.
         let mut connections = self.inner.connections.lock().await;
         for (addr, conn) in connections.drain() {
             if let Err(e) = conn.close().await {
                 error!("Error closing WebSocket connection to {}: {}", addr, e);
             }
         }
+        self.inner.active_peers.write().unwrap().clear();
 
         Ok(())
     }
 
     fn is_closed(&self) -> bool {
         self.inner.closed.load(Ordering::Relaxed)
+    }
+
+    fn supports_ws(&self) -> bool {
+        !self.inner.secure
+    }
+
+    fn supports_wss(&self) -> bool {
+        self.inner.secure
+    }
+
+    fn default_transport_type(&self) -> TransportType {
+        if self.inner.secure {
+            TransportType::Wss
+        } else {
+            TransportType::Ws
+        }
+    }
+
+    /// Returns `true` when there is a live WebSocket connection to
+    /// `remote_addr`.
+    ///
+    /// Reads from the `active_peers` `std::sync::RwLock` rather than the
+    /// async `connections` mutex. This guarantees a correct answer on every
+    /// call — including under lock contention — without `block_on`, without
+    /// holding the async mutex across an await, and without ever returning a
+    /// false-negative that would cause the multiplexer to fall back to UDP
+    /// on that same send.
+    ///
+    /// The write side of `active_peers` is updated immediately whenever a
+    /// connection is inserted or removed from the async pool, so reads here
+    /// are always consistent with the pool state (no stale entries).
+    fn has_connection_to(&self, remote_addr: SocketAddr) -> bool {
+        self.inner
+            .active_peers
+            .read()
+            .unwrap()
+            .contains(&remote_addr)
     }
 }
 

--- a/crates/sip/sip-transport/tests/ws_response_routing.rs
+++ b/crates/sip/sip-transport/tests/ws_response_routing.rs
@@ -1,0 +1,538 @@
+//! Response-routing tests for `WebSocketTransport`.
+//!
+//! These tests verify that inbound SIP requests received over a WebSocket
+//! connection have their responses sent back through the same WebSocket
+//! connection, not via a UDP fallback.
+//!
+//! The root cause of the original bug was that `WebSocketTransport` did not
+//! override `Transport::has_connection_to()`, causing
+//! `MultiplexedTransport::pick_transport()` to fall through to UDP for every
+//! WS/WSS response.
+//!
+//! # Tests
+//!
+//! | Test | What it proves |
+//! |---|---|
+//! | `has_connection_to_false_before_any_connection` | Default: no peers registered |
+//! | `has_connection_to_true_after_client_connects` | Pool is populated on accept |
+//! | `has_connection_to_false_after_connection_closed` | Pool is cleaned up on close |
+//! | `server_sends_ringing_back_through_ws_connection` | 180 arrives on client WS bus |
+//! | `server_sends_ok_back_through_ws_connection` | 200 OK arrives on client WS bus |
+//! | `parallel_connections_each_receive_only_their_response` | Two clients, no cross-routing |
+//! | `ws_transport_declares_correct_capabilities` | `supports_ws`, `default_transport_type` |
+
+#![cfg(feature = "ws")]
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use rvoip_sip_core::builder::{SimpleRequestBuilder, SimpleResponseBuilder};
+use rvoip_sip_core::types::Method;
+use rvoip_sip_core::Message;
+use rvoip_sip_transport::transport::ws::WebSocketTransport;
+use rvoip_sip_transport::transport::TransportType;
+use rvoip_sip_transport::{Transport, TransportEvent};
+
+fn loopback(port: u16) -> SocketAddr {
+    format!("127.0.0.1:{port}").parse().unwrap()
+}
+
+fn build_invite(call_id: &str) -> Message {
+    Message::Request(
+        SimpleRequestBuilder::new(Method::Invite, "sip:bob@server.example.com")
+            .unwrap()
+            .from("alice", "sip:alice@client.example.com", Some("tag-alice"))
+            .to("bob", "sip:bob@server.example.com", None)
+            .call_id(call_id)
+            .cseq(1)
+            .build(),
+    )
+}
+
+fn build_ringing(call_id: &str) -> Message {
+    Message::Response(
+        SimpleResponseBuilder::ringing()
+            .from("alice", "sip:alice@client.example.com", Some("tag-alice"))
+            .to("bob", "sip:bob@server.example.com", Some("tag-bob"))
+            .call_id(call_id)
+            .cseq(1, Method::Invite)
+            .via("server.example.com", "WS", Some("z9hG4bKtest"))
+            .build(),
+    )
+}
+
+fn build_ok(call_id: &str) -> Message {
+    Message::Response(
+        SimpleResponseBuilder::ok()
+            .from("alice", "sip:alice@client.example.com", Some("tag-alice"))
+            .to("bob", "sip:bob@server.example.com", Some("tag-bob"))
+            .call_id(call_id)
+            .cseq(1, Method::Invite)
+            .via("server.example.com", "WS", Some("z9hG4bKtest"))
+            .build(),
+    )
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Bind a plain-WS server on an ephemeral port and give the accept loop a
+/// moment to start.
+async fn bind_ws_server() -> (
+    WebSocketTransport,
+    tokio::sync::mpsc::Receiver<TransportEvent>,
+) {
+    let (t, rx) = WebSocketTransport::bind(loopback(0), false, None, None, None)
+        .await
+        .expect("server bind");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (t, rx)
+}
+
+/// Bind a plain-WS client on an ephemeral port.
+async fn bind_ws_client() -> (
+    WebSocketTransport,
+    tokio::sync::mpsc::Receiver<TransportEvent>,
+) {
+    WebSocketTransport::bind(loopback(0), false, None, None, None)
+        .await
+        .expect("client bind")
+}
+
+/// Drain events from `rx` until `predicate` returns `Some(T)` or the timeout
+/// fires. Skips `Closed` / `Error` events silently so the tests only see
+/// the events they care about.
+async fn next_matching<T, F>(
+    rx: &mut tokio::sync::mpsc::Receiver<TransportEvent>,
+    predicate: F,
+    timeout: Duration,
+) -> T
+where
+    F: Fn(TransportEvent) -> Option<T>,
+{
+    tokio::time::timeout(timeout, async {
+        loop {
+            let ev = rx.recv().await.expect("channel closed");
+            if let Some(result) = predicate(ev) {
+                return result;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for expected transport event")
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// A freshly-bound transport has no connections — `has_connection_to` must
+/// return `false` for an arbitrary address.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn has_connection_to_false_before_any_connection() {
+    let (server, _rx) = bind_ws_server().await;
+
+    let random_addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+    assert!(
+        !server.has_connection_to(random_addr),
+        "has_connection_to must be false when no client has connected"
+    );
+}
+
+/// After a client connects and sends a message, the server's connection pool
+/// must contain the client's TCP source address (as seen by the server).
+///
+/// Note: the TCP source address used for the WS dial is the OS-assigned
+/// ephemeral port, not the WS listener port reported by `client.local_addr()`.
+/// The test therefore extracts the source from the server's `MessageReceived`
+/// event rather than from `client.local_addr()`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn has_connection_to_true_after_client_connects() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let (server, mut server_rx) = bind_ws_server().await;
+    let server_addr = server.local_addr().unwrap();
+
+    let (client, _client_rx) = bind_ws_client().await;
+
+    // Sending establishes the WS connection from client → server.
+    client
+        .send_message(build_invite("has-conn-true"), server_addr)
+        .await
+        .expect("client send");
+
+    // The server sees the client's TCP source address in the event.
+    let client_tcp_src = next_matching(
+        &mut server_rx,
+        |ev| match ev {
+            TransportEvent::MessageReceived { source, .. } => Some(source),
+            _ => None,
+        },
+        Duration::from_secs(3),
+    )
+    .await;
+
+    // `has_connection_to` must return true for the TCP source address.
+    assert!(
+        server.has_connection_to(client_tcp_src),
+        "server must report has_connection_to == true for the connected client \
+         (source: {client_tcp_src})"
+    );
+
+    // An unrelated address must still return false.
+    let other: SocketAddr = "127.0.0.1:1".parse().unwrap();
+    assert!(
+        !server.has_connection_to(other),
+        "unrelated address must not be reported as connected"
+    );
+}
+
+/// After the client closes its transport, the server-side reader loop detects
+/// the Close frame / EOF and removes the peer from the pool.
+/// `has_connection_to` must then return `false`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn has_connection_to_false_after_connection_closed() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let (server, mut server_rx) = bind_ws_server().await;
+    let server_addr = server.local_addr().unwrap();
+
+    let (client, _client_rx) = bind_ws_client().await;
+
+    client
+        .send_message(build_invite("has-conn-close"), server_addr)
+        .await
+        .expect("client send");
+
+    // Wait for server to see the message so we have the connection's source.
+    let client_tcp_src = next_matching(
+        &mut server_rx,
+        |ev| match ev {
+            TransportEvent::MessageReceived { source, .. } => Some(source),
+            _ => None,
+        },
+        Duration::from_secs(3),
+    )
+    .await;
+
+    assert!(
+        server.has_connection_to(client_tcp_src),
+        "connected before close (source: {client_tcp_src})"
+    );
+
+    // Close the client: `close()` sends a WS Close frame then shuts the TCP
+    // socket. The server's reader task sees the Close frame, sets
+    // `conn.is_closed() = true`, breaks out of the read loop, and removes
+    // the peer from `connections`.
+    client.close().await.expect("client close");
+
+    // Give the server's reader task time to process the Close frame and update
+    // the connection pool.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    assert!(
+        !server.has_connection_to(client_tcp_src),
+        "has_connection_to must be false after the client closes the connection \
+         (source: {client_tcp_src})"
+    );
+}
+
+/// The server receives a SIP INVITE over a WebSocket connection, then sends
+/// a `180 Ringing` response back using `server.send_message(ringing, source)`.
+///
+/// The response must arrive on the *client's* event bus with
+/// `transport_type == Ws` — proving it was routed through the existing
+/// WebSocket connection and not via a new dial or a UDP fallback.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn server_sends_ringing_back_through_ws_connection() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let (server, mut server_rx) = bind_ws_server().await;
+    let server_addr = server.local_addr().unwrap();
+
+    let (client, mut client_rx) = bind_ws_client().await;
+
+    // Client sends INVITE → server.
+    client
+        .send_message(build_invite("ringing-ws"), server_addr)
+        .await
+        .expect("client send INVITE");
+
+    // Wait for the server to receive the INVITE. The `source` is the TCP
+    // address the server must reply to.
+    let client_tcp_src = next_matching(
+        &mut server_rx,
+        |ev| match ev {
+            TransportEvent::MessageReceived {
+                message: Message::Request(ref req),
+                source,
+                ..
+            } if req.method() == Method::Invite => Some(source),
+            _ => None,
+        },
+        Duration::from_secs(3),
+    )
+    .await;
+
+    // Server sends 180 Ringing back. `send_message` finds the existing
+    // connection in the pool (via `connect_to`'s pool-hit branch) and
+    // writes to it — no new TCP dial.
+    server
+        .send_message(build_ringing("ringing-ws"), client_tcp_src)
+        .await
+        .expect("server send 180");
+
+    // The response must arrive on the client's event bus.
+    let (msg, ttype) = next_matching(
+        &mut client_rx,
+        |ev| match ev {
+            TransportEvent::MessageReceived {
+                message,
+                transport_type,
+                ..
+            } => Some((message, transport_type)),
+            _ => None,
+        },
+        Duration::from_secs(3),
+    )
+    .await;
+
+    assert_eq!(
+        ttype,
+        TransportType::Ws,
+        "180 Ringing must arrive with TransportType::Ws, got {ttype:?}"
+    );
+    match msg {
+        Message::Response(resp) => {
+            assert_eq!(resp.status_code(), 180, "expected 180 Ringing");
+        }
+        _ => panic!("expected a SIP response, got a request"),
+    }
+}
+
+/// Same as `server_sends_ringing_back_through_ws_connection` but for the
+/// final `200 OK`. Ensures the fix covers both provisional and final responses.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn server_sends_ok_back_through_ws_connection() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let (server, mut server_rx) = bind_ws_server().await;
+    let server_addr = server.local_addr().unwrap();
+
+    let (client, mut client_rx) = bind_ws_client().await;
+
+    client
+        .send_message(build_invite("ok-ws"), server_addr)
+        .await
+        .expect("client send INVITE");
+
+    let client_tcp_src = next_matching(
+        &mut server_rx,
+        |ev| match ev {
+            TransportEvent::MessageReceived {
+                message: Message::Request(ref req),
+                source,
+                ..
+            } if req.method() == Method::Invite => Some(source),
+            _ => None,
+        },
+        Duration::from_secs(3),
+    )
+    .await;
+
+    server
+        .send_message(build_ok("ok-ws"), client_tcp_src)
+        .await
+        .expect("server send 200 OK");
+
+    let (msg, ttype) = next_matching(
+        &mut client_rx,
+        |ev| match ev {
+            TransportEvent::MessageReceived {
+                message,
+                transport_type,
+                ..
+            } => Some((message, transport_type)),
+            _ => None,
+        },
+        Duration::from_secs(3),
+    )
+    .await;
+
+    assert_eq!(
+        ttype,
+        TransportType::Ws,
+        "200 OK must arrive with TransportType::Ws"
+    );
+    match msg {
+        Message::Response(resp) => {
+            assert_eq!(resp.status_code(), 200, "expected 200 OK");
+        }
+        _ => panic!("expected a SIP response"),
+    }
+}
+
+/// Two clients connect to the same server. The server collects both source
+/// addresses, sends a `180 Ringing` to one and a `200 OK` to the other, and
+/// verifies that:
+///
+/// - each client receives exactly one response;
+/// - the responses arrive with `transport_type == Ws`;
+/// - the two status codes are 180 and 200 (one each, no duplicates).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parallel_connections_each_receive_only_their_response() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let (server, mut server_rx) = bind_ws_server().await;
+    let server_addr = server.local_addr().unwrap();
+
+    let (client_a, mut rx_a) = bind_ws_client().await;
+    let (client_b, mut rx_b) = bind_ws_client().await;
+
+    // Both clients send an INVITE.
+    client_a
+        .send_message(build_invite("parallel-a"), server_addr)
+        .await
+        .expect("client_a send");
+    client_b
+        .send_message(build_invite("parallel-b"), server_addr)
+        .await
+        .expect("client_b send");
+
+    // Drain two INVITE events from the server and collect their TCP sources.
+    let mut sources: Vec<SocketAddr> = Vec::new();
+    for _ in 0..2 {
+        let src = next_matching(
+            &mut server_rx,
+            |ev| match ev {
+                TransportEvent::MessageReceived {
+                    message: Message::Request(ref req),
+                    source,
+                    ..
+                } if req.method() == Method::Invite => Some(source),
+                _ => None,
+            },
+            Duration::from_secs(3),
+        )
+        .await;
+        sources.push(src);
+    }
+
+    assert_eq!(sources.len(), 2, "server must receive from both clients");
+    assert_ne!(
+        sources[0], sources[1],
+        "the two clients must have distinct source addresses"
+    );
+
+    let (src0, src1) = (sources[0], sources[1]);
+
+    // Server sends 180 → src0, 200 → src1 (arbitrary split — we verify
+    // no cross-routing by checking which client gets which code).
+    server
+        .send_message(build_ringing("parallel-a"), src0)
+        .await
+        .expect("server -> src0 180");
+    server
+        .send_message(build_ok("parallel-b"), src1)
+        .await
+        .expect("server -> src1 200");
+
+    // Run both collects concurrently so neither blocks the other.
+    let predicate = |ev: TransportEvent| match ev {
+        TransportEvent::MessageReceived {
+            message: Message::Response(resp),
+            transport_type,
+            ..
+        } => Some((resp.status_code(), transport_type)),
+        _ => None,
+    };
+    let (result_a, result_b) = tokio::join!(
+        next_matching(&mut rx_a, predicate, Duration::from_secs(3)),
+        next_matching(&mut rx_b, predicate, Duration::from_secs(3)),
+    );
+
+    let (code_a, ttype_a) = result_a;
+    let (code_b, ttype_b) = result_b;
+
+    assert_eq!(
+        ttype_a,
+        TransportType::Ws,
+        "client_a: expected Ws transport"
+    );
+    assert_eq!(
+        ttype_b,
+        TransportType::Ws,
+        "client_b: expected Ws transport"
+    );
+
+    // The two responses must be 180 and 200 — one each, no duplicates.
+    let mut codes = [code_a, code_b];
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        [180, 200],
+        "expected one 180 and one 200 across the two clients, got {code_a} and {code_b}"
+    );
+}
+
+/// Verify the capability-declaration methods added alongside `has_connection_to`.
+/// A plain-WS transport must declare `supports_ws = true`, `supports_wss = false`,
+/// and `default_transport_type = Ws`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ws_transport_declares_correct_capabilities() {
+    let (ws, _rx) = bind_ws_server().await;
+
+    assert!(
+        ws.supports_ws(),
+        "plain-WS transport: supports_ws must be true"
+    );
+    assert!(
+        !ws.supports_wss(),
+        "plain-WS transport: supports_wss must be false"
+    );
+    assert_eq!(
+        ws.default_transport_type(),
+        TransportType::Ws,
+        "plain-WS transport: default_transport_type must be Ws"
+    );
+}
+
+/// WSS transport must declare `supports_wss = true`, `supports_ws = false`,
+/// and `default_transport_type = Wss`.
+#[cfg(feature = "wss")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wss_transport_declares_correct_capabilities() {
+    use std::io::Write;
+
+    let dir = tempfile::tempdir().unwrap();
+    let cert_path = dir.path().join("s.crt");
+    let key_path = dir.path().join("s.key");
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    std::fs::File::create(&cert_path)
+        .and_then(|mut f| f.write_all(cert.cert.pem().as_bytes()))
+        .unwrap();
+    std::fs::File::create(&key_path)
+        .and_then(|mut f| f.write_all(cert.signing_key.serialize_pem().as_bytes()))
+        .unwrap();
+
+    let (wss, _rx) = WebSocketTransport::bind(
+        loopback(0),
+        true,
+        Some(cert_path.to_str().unwrap()),
+        Some(key_path.to_str().unwrap()),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !wss.supports_ws(),
+        "WSS transport: supports_ws must be false"
+    );
+    assert!(
+        wss.supports_wss(),
+        "WSS transport: supports_wss must be true"
+    );
+    assert_eq!(
+        wss.default_transport_type(),
+        TransportType::Wss,
+        "WSS transport: default_transport_type must be Wss"
+    );
+}


### PR DESCRIPTION
Enables WS and WSS (RFC 7118) as fully functional SIP transports by fixing three independent gaps that together blocked inbound calls:

## RFC 7118 handshake (sip-transport / ws/listener.rs)

- Replaced the dead `accept_async_with_subprotocol` helper (which called plain `accept_async` and never echoed the subprotocol header) with `accept_hdr_async` using an `Arc<AtomicBool>` callback. HTTP 101 now always includes `Sec-WebSocket-Protocol: sip` for both WS and WSS.
- Fixed `SIP_WSS_SUBPROTOCOL` constant from `"sips"` to `"sip"` in `ws/mod.rs`, `ws/listener.rs`, and `ws/connection.rs` per RFC 7118 §4.1.

## Response routing: has_connection_to (sip-transport / ws/mod.rs)

Root cause of the UDP fallback bug: `WebSocketTransport` inherited the default `Transport::has_connection_to() -> false`, so `MultiplexedTransport::pick_transport()` always fell through to UDP when routing responses to WS/WSS inbound requests.

Fix: maintain a `std::sync::RwLock<HashSet<SocketAddr>>` (`active_peers`) alongside the async connection pool. The sync index is updated in O(1) inside the async tasks that already hold `connections` (on accept, on outbound connect, on reader-loop exit, and on close). `has_connection_to()` reads from the sync index — no `try_lock`, no false-negatives under contention, no UDP fallback on a contended send.

Also added `supports_ws()`, `supports_wss()`, and `default_transport_type()` overrides so the transport advertises its capabilities correctly.

## Public API exposure (rvoip-sip / sip-dialog)

- `rvoip-sip Config`: added `enable_ws`, `ws_bind_addr`, `ws_advertised_addr`, `wss_bind_addr`, `wss_advertised_addr` fields. `UnifiedCoordinator` now reads `config.enable_ws` instead of the previous hardcoded `false`.
- `TransportManagerConfig`: added `ws_bind_addresses` / `wss_bind_addresses` (default ports 5080 / 5081) to give WS/WSS their own listeners, separate from the TCP port.
- `DialogConfig` / `UnifiedConfig`: added `ws_advertised_local_address` and `wss_advertised_local_address`; `local_address_for_uri()` now handles `TransportType::Ws` and `TransportType::Wss`.
- `add_websocket_transport` now uses `bind_with_client_tls` for WSS so the outbound `TlsConnector` is configured at bind time.
- `sip-dialog/Cargo.toml`: propagated `ws = ["rvoip-sip-transport/ws"]` and `wss = ["ws", "rvoip-sip-transport/wss"]` feature gates; both included in the default feature set.

## Inbound SDP fix (rvoip-sip)

Preserved the inbound SDP offer on `Event::IncomingCall` so the UA can access it before answering.

## Tests

- `ws_response_routing.rs` (8 new integration tests):
  - `has_connection_to_false_before_any_connection`
  - `has_connection_to_true_after_client_connects`
  - `has_connection_to_false_after_connection_closed`
  - `server_sends_ringing_back_through_ws_connection` (180 via WS, not UDP)
  - `server_sends_ok_back_through_ws_connection` (200 OK via WS)
  - `parallel_connections_each_receive_only_their_response`
  - `ws_transport_declares_correct_capabilities`
  - `wss_transport_declares_correct_capabilities`
- RFC 7118 handshake tests in `ws/listener.rs`
- Transport-manager bind/address tests in `sip-dialog`

## README

Updated WebSocket (RFC 7118) status from `🚧 Partial` to `🚧 Alpha` with accurate notes for WS and WSS separately.