### PR TITLE
chore: align examples and references to 0.3.1

### DIFF
--- a/crates/foundation/rvoip-core-traits/README.md
+++ b/crates/foundation/rvoip-core-traits/README.md
@@ -29,7 +29,7 @@ implementing your own adapter and want only the trait surface:
 
 ```toml
 [dependencies]
-rvoip-core-traits = "0.3.0"
+rvoip-core-traits = "0.3.1"
 ```
 
 ## License

--- a/crates/foundation/rvoip-core/README.md
+++ b/crates/foundation/rvoip-core/README.md
@@ -39,7 +39,7 @@ along transitively.
 
 ```toml
 [dependencies]
-rvoip-core = "0.3.0"
+rvoip-core = "0.3.1"
 ```
 
 ## Examples

--- a/crates/identity/auth-core/README.md
+++ b/crates/identity/auth-core/README.md
@@ -24,7 +24,7 @@ restructure is planned.
 
 ```toml
 [dependencies]
-rvoip-auth-core = "0.3.0"
+rvoip-auth-core = "0.3.1"
 ```
 
 ## Where to start

--- a/crates/identity/users-core/tests/integration_test/Cargo.toml
+++ b/crates/identity/users-core/tests/integration_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-users-core-integration-tests"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/media/codec-core/README.md
+++ b/crates/media/codec-core/README.md
@@ -25,7 +25,7 @@ isolation:
 
 ```toml
 [dependencies]
-rvoip-codec-core = "0.3.0"
+rvoip-codec-core = "0.3.1"
 ```
 
 ## License

--- a/crates/rvoip/src/lib.rs
+++ b/crates/rvoip/src/lib.rs
@@ -8,9 +8,10 @@
 //!
 //! ## Maturity tiers
 //!
-//! Versions are plain numeric (no `-alpha`/`-beta` suffixes): **`0.1.x` = alpha,
-//! `0.2.x` = beta, `1.0` = stable**. The `sip` surface is beta; the other
-//! surfaces (`webrtc`, `uctp`, the `voip-3` extensions, `client`) are alpha.
+//! All published workspace crates are aligned at **`0.3.1`**. Maturity is
+//! product-specific rather than encoded in the version number: the `sip`
+//! surface is beta-qualified, while `webrtc`, `uctp`, the `voip-3`
+//! extensions, and `client` are available as developer previews.
 //!
 //! See `docs/PRD.md`, `INTERFACE_DESIGN.md`, and `CONVERSATION_PROTOCOL.md`
 //! for the architectural context.
@@ -40,12 +41,12 @@
 //! | Feature | Default | Pulls in |
 //! |---|:---:|---|
 //! | `sip` | ✅ | SIP interop adapter (`rvoip::sip`) — **beta** |
-//! | `webrtc` | | WebRTC interop adapter (`rvoip::webrtc`) — alpha |
-//! | `uctp` | | UCTP substrate adapters — QUIC / WebTransport / WebSocket (`rvoip::uctp`) — alpha |
-//! | `sip-stir-shaken` | | RFC 8224 caller-ID attestation; requires `sip` (`rvoip::stir_shaken`) — alpha |
-//! | `voip-3` | | The full experience: every transport **+** vCon / identity / AI-harness extensions — alpha |
-//! | `client` | | Cross-transport client SDK (`rvoip::client`) — alpha |
-//! | `app` | | High-level gateway builder (`rvoip::app`) — alpha |
+//! | `webrtc` | | WebRTC interop adapter (`rvoip::webrtc`) — developer preview |
+//! | `uctp` | | UCTP substrate adapters — QUIC / WebTransport / WebSocket (`rvoip::uctp`) — developer preview |
+//! | `sip-stir-shaken` | | RFC 8224 caller-ID attestation; requires `sip` (`rvoip::stir_shaken`) — developer preview |
+//! | `voip-3` | | The full experience: every transport **+** vCon / identity / AI-harness extensions — developer preview |
+//! | `client` | | Cross-transport client SDK (`rvoip::client`) — developer preview |
+//! | `app` | | High-level gateway builder (`rvoip::app`) — developer preview |
 //! | `full` | | `voip-3` + `sip-stir-shaken` + `client` + `app` |
 //!
 //! The `vcon`, `identity`, and `harness` conversation-model extensions are
@@ -94,7 +95,7 @@ pub mod stir_shaken {
 }
 
 // ---------------------------------------------------------------------------
-// WebRTC (alpha)
+// WebRTC (developer preview)
 // ---------------------------------------------------------------------------
 
 /// WebRTC interop adapter — bridges DTLS-SRTP / ICE peers into the voip-3
@@ -105,7 +106,7 @@ pub mod webrtc {
 }
 
 // ---------------------------------------------------------------------------
-// UCTP substrates (alpha)
+// UCTP substrates (developer preview)
 // ---------------------------------------------------------------------------
 
 /// UCTP substrate adapters and protocol primitives. Per
@@ -125,7 +126,7 @@ pub mod uctp {
 }
 
 // ---------------------------------------------------------------------------
-// voip-3 conversation-model extensions (alpha) — reachable only via `voip-3`
+// voip-3 conversation-model extensions (developer preview) — reachable only via `voip-3`
 // ---------------------------------------------------------------------------
 
 /// vCon (IETF Virtualized Conversations) container builder, signer, and store —
@@ -150,7 +151,7 @@ pub mod harness {
 }
 
 // ---------------------------------------------------------------------------
-// Client SDK (alpha)
+// Client SDK (developer preview)
 // ---------------------------------------------------------------------------
 
 /// Client-side API for mobile / web / desktop / embedded apps, wrapping the
@@ -161,7 +162,7 @@ pub mod client {
 }
 
 // ---------------------------------------------------------------------------
-// High-level app/gateway API (alpha)
+// High-level app/gateway API (developer preview)
 // ---------------------------------------------------------------------------
 
 /// High-level server/gateway API for building practical cross-transport VoIP

--- a/crates/sip/rvoip-sip/docs/BENCHMARKING.md
+++ b/crates/sip/rvoip-sip/docs/BENCHMARKING.md
@@ -491,7 +491,7 @@ load.
 
 **Citing a result** — pick the highest sweep point where ASR ≥ 0.99
 and setup-p99 stays inside your SLA budget, and report that as the
-sustained capacity. Example: "rvoip-sip 0.2.5 sustains 500 CPS at
+sustained capacity. Example: "rvoip-sip 0.3.1 sustains 500 CPS at
 98.7% ASR with setup p99 < 90 ms on Apple M3 Max." Always include the
 hardware spec block from §6.
 
@@ -518,7 +518,7 @@ extra keys is fine, removing a canonical one is a breaking change.
     "total_ram_gb": 64.0,
     "build_profile": "release",
     "global_allocator": "mimalloc",
-    "rvoip_sip_version": "0.2.5",
+    "rvoip_sip_version": "0.3.1",
     "git_rev": "a9a3383c",
     "git_commit": "a9a3383c...",
     "git_dirty": false,

--- a/crates/sip/sip-core/README.md
+++ b/crates/sip/sip-core/README.md
@@ -418,7 +418,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rvoip-sip-core = "0.3.0"
+rvoip-sip-core = "0.3.1"
 bytes = "1.4"  # For handling raw message data
 tokio = { version = "1.0", features = ["full"] }  # For async examples
 ```

--- a/crates/sip/sip-proxy/README.md
+++ b/crates/sip/sip-proxy/README.md
@@ -25,7 +25,7 @@ you want the raw transaction-layer primitives:
 
 ```toml
 [dependencies]
-rvoip-sip-proxy = "0.3.0"
+rvoip-sip-proxy = "0.3.1"
 ```
 
 ## License

--- a/crates/sip/sip-transport/README.md
+++ b/crates/sip/sip-transport/README.md
@@ -169,7 +169,7 @@ The 0.3 API removes the unsafe `WebSocketListener::accept` escape hatch in
 favor of `Arc<WebSocketListener>::serve_concurrent`, which retains ownership of
 handshake/session admission and shutdown. See the complete before/after example
 and release guidance in [MIGRATING-0.3.md](./MIGRATING-0.3.md). The transport
-crate now carries the required 0.3.0 package version.
+crate now carries the required 0.3.1 package version.
 
 SIPS never falls back to a plaintext transport: `sips:...;transport=tcp` means
 TLS-over-TCP, `transport=wss` means secure WebSocket, and explicit `udp` or

--- a/docs/PRODUCTION_HARDENING_ROADMAP.md
+++ b/docs/PRODUCTION_HARDENING_ROADMAP.md
@@ -1,7 +1,7 @@
 # rvoip Production-Hardening Roadmap
 
 **Status:** P0 + P1 implemented (2026-07-01); P2/P3 open. Target: open-internet / hostile-network exposure for `rtp-core`.
-**Scope:** `rvoip-sip` (beta-ready within its documented envelope) and `rtp-core` (media transport). Both beta-tier (0.2.x).
+**Scope:** `rvoip-sip` (beta-ready within its documented envelope) and `rtp-core` (media transport). Both ship at `0.3.1`; SIP is beta-qualified by product scope rather than by a version suffix.
 
 ## Implementation status (2026-07-01)
 

--- a/examples/01-quickstart-p2p/Cargo.toml
+++ b/examples/01-quickstart-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-quickstart-p2p"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
@@ -13,8 +13,8 @@ publish = false
 # version + path: builds against the LOCAL tree now (so the example always
 # reflects current code and breaks loudly on API drift) while recording the
 # crates.io version used at publish time. Copying this example into your own
-# project? Drop the `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# project? Drop the `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/02-softphone-audio/Cargo.toml
+++ b/examples/02-softphone-audio/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-softphone-audio"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/03-register-to-pbx/Cargo.toml
+++ b/examples/03-register-to-pbx/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-register-to-pbx"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/04-call-control/Cargo.toml
+++ b/examples/04-call-control/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-call-control"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/05-blind-transfer/Cargo.toml
+++ b/examples/05-blind-transfer/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-blind-transfer"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/06-attended-transfer/Cargo.toml
+++ b/examples/06-attended-transfer/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-attended-transfer"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/07-secure-call-srtp/Cargo.toml
+++ b/examples/07-secure-call-srtp/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-secure-call-srtp"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/08-tls-transport/Cargo.toml
+++ b/examples/08-tls-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-tls-transport"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
@@ -11,7 +11,7 @@ publish = false
 # run against a self-signed dev cert. PRODUCTION builds must omit this feature
 # so rustls always validates server certs.
 # Copying into your own project? Drop `path` and keep just the version+features.
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip", features = ["dev-insecure-tls"] }
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip", features = ["dev-insecure-tls"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/09-ivr-server/Cargo.toml
+++ b/examples/09-ivr-server/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-ivr-server"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/10-call-center-b2bua/Cargo.toml
+++ b/examples/10-call-center-b2bua/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rvoip-example-call-center-b2bua"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
 [workspace]
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.2.5"
-rvoip-sip = { version = "0.2.5", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.1"
+rvoip-sip = { version = "0.3.1", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/11-ai-harness-demo/Cargo.toml
+++ b/examples/11-ai-harness-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-ai-harness-demo"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 
@@ -10,7 +10,7 @@ publish = false
 async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-rvoip-core-traits = { version = "0.2.5", path = "../../crates/foundation/rvoip-core-traits" }
-rvoip-harness = { version = "0.1.0", path = "../../crates/extensions/rvoip-harness" }
-rvoip-vcon = { version = "0.1.0", path = "../../crates/extensions/rvoip-vcon" }
+rvoip-core-traits = { version = "0.3.1", path = "../../crates/foundation/rvoip-core-traits" }
+rvoip-harness = { version = "0.3.1", path = "../../crates/extensions/rvoip-harness" }
+rvoip-vcon = { version = "0.3.1", path = "../../crates/extensions/rvoip-vcon" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/12-customer-escalation-sip-webrtc/Cargo.toml
+++ b/examples/12-customer-escalation-sip-webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-customer-escalation-sip-webrtc"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 

--- a/examples/13-sip-to-amazon-connect/Cargo.toml
+++ b/examples/13-sip-to-amazon-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-sip-to-amazon-connect"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,17 +5,20 @@ rvoip — organized by *what you want to build*, not by which API you use. Each 
 a standalone Cargo project with its own README and (for multi-process demos) a
 `./run_demo.sh` that boots every process and checks the result.
 
-## Beta scope
+## Maturity scope
 
-Examples 01-10 target **`rvoip-sip`, the beta-candidate crate** — the only crate
-in the workspace under the beta contract. Examples 11-12 are explicitly
-experimental: 11 demonstrates the in-process AI harness path, and 12 proves a
-cross-transport customer escalation workflow using WebRTC plus SIP.
+Examples 01-10 target **`rvoip-sip`, the beta-qualified product** — the only
+workspace product covered by the SIP release gate. Examples 11-13 demonstrate
+available developer-preview products: the AI harness and vCon path,
+cross-transport WebRTC-to-SIP escalation, and Amazon Connect integration.
 
-Beta media defaults to **PCMU/PCMA**; **G.729A/G.729AB** is optional and not
-exercised by these examples. Transports are **UDP** (interop-tested) and
-**TCP/TLS** (supported); **SDES-SRTP** has limited-suite support. **Opus/G.722,
-DTLS-SRTP, ICE/TURN, and WebRTC are post-beta.** The source of truth is
+Beta media defaults to **PCMU/PCMA**; the fully integrated optional
+**G.729A/G.729AB** path is developer preview and is not exercised here.
+Transports are **UDP** (interop-tested) and **TCP/TLS** (supported), with
+**SDES-SRTP** in the qualified SIP media envelope. **Opus/G.722** are
+developer-preview additions. **DTLS-SRTP, ICE, external TURN configuration,
+and WebRTC are available as developer previews outside the SIP beta gate.**
+The source of truth is
 [`crates/sip/rvoip-sip/docs/COMPATIBILITY_MATRIX.md`](../crates/sip/rvoip-sip/docs/COMPATIBILITY_MATRIX.md).
 
 ## Recommended path
@@ -40,14 +43,14 @@ DTLS-SRTP, ICE/TURN, and WebRTC are post-beta.** The source of truth is
 | 10 | [call-center-b2bua](10-call-center-b2bua/) | B2BUA bridge + routing | `UnifiedCoordinator` + `server::b2bua` | `./run_demo.sh` |
 | 11 | [ai-harness-demo](11-ai-harness-demo/) | Fake ASR/TTS/dialog + vCon evidence | `rvoip-harness` | `cargo run` |
 | 12 | [customer-escalation-sip-webrtc](12-customer-escalation-sip-webrtc/) | Browser WebRTC chat escalates to Alice's SIP phone | `rvoip::app` gateway API | `cargo run -- --auto-proof` |
+| 13 | [sip-to-amazon-connect](13-sip-to-amazon-connect/) | SIP headers become Amazon Connect attributes with a live audio bridge | `rvoip-amazon-connect` | `cargo run` |
 
 ## Conventions
 
-- **Self-contained projects.** Each example is its own Cargo workspace and
-  depends on the local crate via `rvoip-sip = { version = "0.2.5", path =
-  "../../crates/sip/rvoip-sip" }`. That builds against the live tree today and
-  records the crates.io version for when you copy it into your own project
-  (drop the `path`, keep the `version`).
+- **Self-contained projects.** Each example is its own Cargo workspace and uses
+  local rvoip crates through `version = "0.3.1"` plus `path`. That builds
+  against the live tree today and records the crates.io version for when you
+  copy it into your own project (drop `path`, keep `version`).
 - **`./run_demo.sh`** builds release binaries, boots every process with port
   readiness checks, prints the combined logs, and exits non-zero on failure.
   Logs land in each example's `logs/`.


### PR DESCRIPTION
## What changed

- Align all 13 standalone example package versions to `0.3.1`.
- Replace stale `rvoip-*` dependency pins with `0.3.1`.
- Update current Cargo snippets, benchmarking guidance, facade docs, and maturity terminology.
- Add Amazon Connect to the examples catalog and distinguish SIP beta qualification from developer-preview products.

## Why

The unified workspace release contains 43 publishable crates at `0.3.1`, but standalone examples and several current documentation snippets still referenced earlier version trains. The stale `rvoip-sip = "0.2.5"` constraints prevented example CI from resolving the local `0.3.1` path package.

Historical beta reports, release evidence, changelogs, migration records, deprecation `since` values, and test fixtures remain unchanged so their provenance stays accurate.

## Validation

- All 13 standalone examples passed `cargo check`.
- `cargo test -p rvoip --doc --all-features` passed.
- All 43 publishable workspace crates resolve at `0.3.1`.
- Every local `rvoip-*` package in all 13 examples resolves at `0.3.1`.
- Active `Cargo.toml` audit found no `0.1.0`, `0.2.5`, or `0.3.0` package/dependency declarations.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Cargo version pins only; no production code paths modified.
> 
> **Overview**
> **Release alignment** — Standalone examples (01–13), integration-test package metadata, and install snippets across core crates now pin **`0.3.1`** instead of mixed `0.1.0` / `0.2.5` / `0.3.0`, so path-based example CI can resolve local workspace packages.
> 
> **Maturity messaging** — The `rvoip` facade crate docs and module comments drop version-suffix maturity (`0.1.x` alpha / `0.2.x` beta) in favor of **product scope**: SIP stays **beta-qualified**; WebRTC, UCTP, voip-3 extensions, client, and app are labeled **developer preview**. `examples/README.md` and `docs/PRODUCTION_HARDENING_ROADMAP.md` follow the same framing and add example **13** (Amazon Connect) to the catalog.
> 
> **Reference touch-ups** — Benchmarking citation strings and a few README install lines move to `0.3.1`; no library or API behavior changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622498926637204f78ee7cf50731231bca2ea94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->