### PR TITLE
test(infra): remove event-suite scheduling races

### DIFF
--- a/crates/foundation/infra-common/src/events/coordinator.rs
+++ b/crates/foundation/infra-common/src/events/coordinator.rs
@@ -1379,7 +1379,7 @@ mod tests {
     }
 
     async fn receive_test_id(receiver: &mut mpsc::Receiver<Arc<dyn CrossCrateEvent>>) -> u64 {
-        tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+        tokio::time::timeout(std::time::Duration::from_secs(5), receiver.recv())
             .await
             .expect("bus observation timed out")
             .expect("bus observation channel closed")
@@ -1599,15 +1599,8 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(receive_handler_id(&mut recording_rx).await, id);
+            assert_eq!(receive_test_id(&mut bus).await, id);
         }
-        assert_eq!(
-            vec![
-                receive_test_id(&mut bus).await,
-                receive_test_id(&mut bus).await,
-                receive_test_id(&mut bus).await,
-            ],
-            vec![2, 3, 4]
-        );
         let saturated = coordinator.event_bus_diagnostic_snapshot();
         assert_eq!(saturated["observational_handlers"]["dropped_full"], 1);
         assert_eq!(saturated["observational_handlers"]["in_flight_current"], 1);

--- a/crates/foundation/infra-common/src/events/static_path.rs
+++ b/crates/foundation/infra-common/src/events/static_path.rs
@@ -577,6 +577,11 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    /// These tests intentionally replace the process-global typed channel for
+    /// the same event type. Serialize that replacement so parallel test
+    /// execution cannot close another test's receiver mid-assertion.
+    static STATIC_FILTER_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     /// Test event for filtering tests
     #[derive(Clone, Debug, Serialize, Deserialize)]
     struct StaticFilterEvent {
@@ -613,6 +618,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_basic_filtering() {
+        let _test_guard = STATIC_FILTER_TEST_LOCK.lock().await;
         // Register our test event with the global registry
         register_static_filter_event();
 
@@ -683,6 +689,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_filtered_subscriber() {
+        let _test_guard = STATIC_FILTER_TEST_LOCK.lock().await;
         // Register our test event with the global registry
         register_static_filter_event();
 
@@ -799,6 +806,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_try_receive_filtering() {
+        let _test_guard = STATIC_FILTER_TEST_LOCK.lock().await;
         // Register our test event with the global registry
         register_static_filter_event();
 


### PR DESCRIPTION
## Summary

- serialize tests that intentionally replace the same process-global static event channel
- drain the observational bus at each publish boundary so the bounded queue test does not depend on task scheduling
- give the bus observation helper CI-safe scheduling headroom

## Evidence

This addresses the two failures in post-merge workflow run 30541477841.

- 20 consecutive focused repetitions of both failing areas
- 10 consecutive full `rvoip-infra-common --lib` runs (58/58 each)
- strict all-target/all-feature Clippy for `rvoip-infra-common`
- formatting and diff checks

Production behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test helpers and assertions in infra-common; production event coordinator and static fast-path code paths are untouched.
> 
> **Overview**
> Stabilizes **infra-common** event tests that were flaky under parallel CI by removing scheduling assumptions, without changing production event behavior.
> 
> In **coordinator** tests, the observational bus is **drained after each publish** (paired with handler assertions) instead of batching three bus reads at the end, and the bus observation helper timeout is raised from **1s to 5s** for slower runners.
> 
> In **static_path** filtering tests, a shared **`STATIC_FILTER_TEST_LOCK`** serializes cases that re-register the same process-global typed channel so parallel `cargo test` cannot tear down another test’s receiver mid-assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79bdd8e806fcd17b3a7b98356e84150dd3ee9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->