### PR TITLE
Correct RTP/RTCP parsing, statistics, and live wiring

### DIFF
--- a/crates/media/rtp-core/CORRECTNESS_MIGRATION_0.3.5.md
+++ b/crates/media/rtp-core/CORRECTNESS_MIGRATION_0.3.5.md
@@ -1,0 +1,19 @@
+# RTP/RTCP correctness migration for 0.3.5
+
+The 0.3.5 correctness repair preserves RTP padding as explicit packet
+metadata. This intentionally changes two public data shapes:
+
+- `RtpPacket` has a public `padding_size: u8` field. Downstream struct
+  literals must set it to `0` for an unpadded packet, or use `RtpPacket::new`
+  and `set_padding`.
+- `RtpEvent::MediaReceived` has a `padding_size: u8` field. Exact match
+  patterns must bind that field or include `..`.
+
+Parsed packet payloads continue to exclude padding bytes. A non-zero padding
+size means the RTP P bit is set, and serialization writes canonical padding
+whose final octet contains the count.
+
+`RtpStreamStats::jitter` is now reported in RTP timestamp units, as required
+for RTCP report blocks. Use `RtpSessionStats::jitter_ms` when milliseconds are
+needed. `RtpStreamStats::packets_out_of_order` exposes the reordered-packet
+counter that was previously internal.

--- a/crates/media/rtp-core/benches/srtp_protect_unprotect.rs
+++ b/crates/media/rtp-core/benches/srtp_protect_unprotect.rs
@@ -10,6 +10,9 @@
 //!
 //! Suite under test: AES-CM-128 + HMAC-SHA1-80 (the default in this
 //! stack and in WebRTC).
+//!
+//! SRTCP is intentionally omitted until the authenticated, stateful
+//! implementation lands. Its public entry points currently fail closed.
 
 use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -88,22 +91,5 @@ fn bench_unprotect(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_protect_rtcp(c: &mut Criterion) {
-    let mut group = c.benchmark_group("srtp_protect_rtcp");
-    // Typical compound RTCP report ~60–100 bytes.
-    let rtcp_data: Vec<u8> = (0..96).map(|i| (i & 0xff) as u8).collect();
-    group.throughput(Throughput::Bytes(rtcp_data.len() as u64));
-    group.bench_function("compound_96", |b| {
-        let mut ctx = make_context();
-        b.iter(|| {
-            let out = ctx
-                .protect_rtcp(black_box(&rtcp_data))
-                .expect("protect_rtcp");
-            black_box(out);
-        });
-    });
-    group.finish();
-}
-
-criterion_group!(benches, bench_protect, bench_unprotect, bench_protect_rtcp);
+criterion_group!(benches, bench_protect, bench_unprotect);
 criterion_main!(benches);

--- a/crates/media/rtp-core/src/api/server/transport/default.rs
+++ b/crates/media/rtp-core/src/api/server/transport/default.rs
@@ -397,6 +397,7 @@ impl MediaTransportServer for DefaultMediaTransportServer {
                         timestamp,
                         marker,
                         ssrc,
+                        padding_size: _,
                     } => {
                         // Debug output to help diagnose issues
                         debug!(

--- a/crates/media/rtp-core/src/lib.rs
+++ b/crates/media/rtp-core/src/lib.rs
@@ -121,8 +121,9 @@ pub use packet::extension::{
 };
 pub use packet::header::RtpHeader;
 pub use packet::rtcp::{
-    NtpTimestamp, RtcpApplicationDefined, RtcpCompoundPacket, RtcpExtendedReport, RtcpGoodbye,
-    RtcpPacket, RtcpReceiverReport, RtcpReportBlock, RtcpSenderReport, RtcpSourceDescription,
+    NtpTimestamp, RtcpApplicationDefined, RtcpCompoundMember, RtcpCompoundPacket,
+    RtcpExtendedReport, RtcpGoodbye, RtcpPacket, RtcpReceiverReport, RtcpReportBlock,
+    RtcpSenderReport, RtcpSourceDescription, RtcpTolerantCompoundPacket, RtcpUnknownPacket,
     RtcpXrBlock, VoipMetricsBlock,
 };
 pub use packet::rtp::RtpPacket;

--- a/crates/media/rtp-core/src/packet/extension/mod.rs
+++ b/crates/media/rtp-core/src/packet/extension/mod.rs
@@ -70,9 +70,9 @@ impl ExtensionElement {
                     )));
                 }
 
-                if self.data.len() > 16 {
+                if self.data.is_empty() || self.data.len() > 16 {
                     return Err(Error::InvalidParameter(format!(
-                        "Invalid extension length for one-byte format: {} (must be ≤ 16 bytes)",
+                        "Invalid extension length for one-byte format: {} (must be 1-16 bytes)",
                         self.data.len()
                     )));
                 }
@@ -273,9 +273,9 @@ impl RtpHeaderExtensions {
                     // Each extension starts with a byte where the 4 most significant bits
                     // are the ID and the 4 least significant bits are the length minus 1
                     let length = element.data.len();
-                    if length > 16 {
+                    if length == 0 || length > 16 {
                         return Err(Error::InvalidParameter(format!(
-                            "Extension data too long for one-byte header: {} (max is 16 bytes)",
+                            "Invalid one-byte extension data length: {} (must be 1-16 bytes)",
                             length
                         )));
                     }
@@ -287,9 +287,6 @@ impl RtpHeaderExtensions {
                     // Then the extension data
                     buf.put_slice(&element.data);
                 }
-
-                // End marker
-                buf.put_u8(0x00);
 
                 // Add padding to align to 32-bit boundary
                 while buf.len() % 4 != 0 {
@@ -326,9 +323,6 @@ impl RtpHeaderExtensions {
                     buf.put_slice(&element.data);
                 }
 
-                // End marker (ID = 0)
-                buf.put_u8(0x00);
-
                 // Add padding to align to 32-bit boundary
                 while buf.len() % 4 != 0 {
                     buf.put_u8(0x00);
@@ -359,18 +353,23 @@ impl RtpHeaderExtensions {
             let header_byte = data[i];
             i += 1;
 
-            // End of extensions is marked by a 0 byte
-            if header_byte == 0 {
-                break;
-            }
+            let id = header_byte >> 4;
 
-            // If the 0xF0 bits are all set, this is padding
-            if (header_byte & 0xF0) == 0xF0 {
+            // ID zero with a zero length nibble is a single padding byte. It
+            // can appear between elements as well as at the end.
+            if id == 0 {
+                // RFC 8285 requires processing to stop when ID zero carries a
+                // non-zero length nibble.
+                if header_byte & 0x0f != 0 {
+                    break;
+                }
                 continue;
             }
 
-            // Extract the ID (top 4 bits)
-            let id = (header_byte >> 4) & 0x0F;
+            // ID 15 is reserved and terminates one-byte extension parsing.
+            if id == 15 {
+                break;
+            }
 
             // Length is stored as L-1, so need to add 1 (bottom 4 bits)
             let length = ((header_byte & 0x0F) + 1) as usize;
@@ -403,9 +402,10 @@ impl RtpHeaderExtensions {
             let id = data[i];
             i += 1;
 
-            // End of extensions is marked by a 0 ID
+            // ID zero is a single padding byte. There is no artificial end
+            // marker in RFC 8285, so parsing continues with the next byte.
             if id == 0 {
-                break;
+                continue;
             }
 
             // Make sure we have enough data for the length
@@ -669,6 +669,9 @@ mod tests {
         let long_data: Vec<u8> = (0..20).collect(); // 20 bytes > 16
         assert!(one_byte.add_extension(1, long_data).is_err());
 
+        // One-byte format cannot encode an empty element.
+        assert!(one_byte.add_extension(1, Vec::<u8>::new()).is_err());
+
         // Test valid extensions
         assert!(one_byte.add_extension(1, vec![1, 2, 3]).is_ok());
         assert!(one_byte.add_extension(14, vec![4, 5, 6]).is_ok());
@@ -729,9 +732,10 @@ mod tests {
 
         let serialized = ext.serialize().unwrap();
 
-        // Should have: 1 byte header + 1 byte data + 1 byte end marker (0x00) + 1 byte padding = 4 bytes
+        // One-byte header + one byte of data + two padding bytes.
         assert_eq!(serialized.len(), 4);
         assert_eq!(serialized.len() % 4, 0);
+        assert_eq!(&serialized[..], &[0x10, 42, 0, 0]);
     }
 
     #[test]
@@ -743,8 +747,63 @@ mod tests {
 
         let serialized = ext.serialize().unwrap();
 
-        // Should have: 1 byte ID + 1 byte length + 1 byte data + 1 byte end marker (0x00) = 4 bytes
+        // ID + length + data + one padding byte.
         assert_eq!(serialized.len(), 4);
         assert_eq!(serialized.len() % 4, 0);
+        assert_eq!(&serialized[..], &[1, 1, 42, 0]);
+    }
+
+    #[test]
+    fn aligned_extensions_do_not_gain_an_artificial_end_word() {
+        let mut one_byte = RtpHeaderExtensions::new_one_byte();
+        one_byte.add_extension(1, vec![1, 2, 3]).unwrap();
+        assert_eq!(&one_byte.serialize().unwrap()[..], &[0x12, 1, 2, 3]);
+        assert_eq!(one_byte.size(), 4);
+
+        let mut two_byte = RtpHeaderExtensions::new_two_byte();
+        two_byte.add_extension(1, vec![1, 2]).unwrap();
+        assert_eq!(&two_byte.serialize().unwrap()[..], &[1, 2, 1, 2]);
+        assert_eq!(two_byte.size(), 4);
+    }
+
+    #[test]
+    fn test_one_byte_padding_between_elements_is_ignored() {
+        let data = [0x10, 0xaa, 0x00, 0x21, 0xbb, 0xcc, 0x00, 0x00];
+        let parsed =
+            RtpHeaderExtensions::from_extension_data(ONE_BYTE_EXTENSION_ID, &data).unwrap();
+
+        assert_eq!(parsed.elements.len(), 2);
+        assert_eq!(parsed.elements[0], ExtensionElement::new(1, vec![0xaa]));
+        assert_eq!(
+            parsed.elements[1],
+            ExtensionElement::new(2, vec![0xbb, 0xcc])
+        );
+    }
+
+    #[test]
+    fn test_one_byte_reserved_ids_terminate_parsing() {
+        let reserved_fifteen = [0x10, 0xaa, 0xf7, 0x20, 0xbb, 0xcc, 0x00, 0x00];
+        let parsed =
+            RtpHeaderExtensions::from_extension_data(ONE_BYTE_EXTENSION_ID, &reserved_fifteen)
+                .unwrap();
+        assert_eq!(parsed.elements, vec![ExtensionElement::new(1, vec![0xaa])]);
+
+        let invalid_zero_length = [0x10, 0xaa, 0x01, 0x20, 0xbb, 0xcc, 0x00, 0x00];
+        let parsed =
+            RtpHeaderExtensions::from_extension_data(ONE_BYTE_EXTENSION_ID, &invalid_zero_length)
+                .unwrap();
+        assert_eq!(parsed.elements, vec![ExtensionElement::new(1, vec![0xaa])]);
+    }
+
+    #[test]
+    fn test_two_byte_padding_and_zero_length_elements() {
+        let data = [0x00, 0x01, 0x00, 0x00];
+        let parsed =
+            RtpHeaderExtensions::from_extension_data(TWO_BYTE_EXTENSION_ID_BASE, &data).unwrap();
+        assert_eq!(parsed.elements, vec![ExtensionElement::new(1, Vec::new())]);
+
+        let mut extensions = RtpHeaderExtensions::new_two_byte();
+        extensions.add_extension(1, Vec::<u8>::new()).unwrap();
+        assert_eq!(&extensions.serialize().unwrap()[..], &[1, 0, 0, 0]);
     }
 }

--- a/crates/media/rtp-core/src/packet/rtcp/compound.rs
+++ b/crates/media/rtp-core/src/packet/rtcp/compound.rs
@@ -513,4 +513,29 @@ mod tests {
         non_final_padding.extend_from_slice(&[0x80, 206, 0, 0]);
         assert!(RtcpTolerantCompoundPacket::parse(&non_final_padding).is_err());
     }
+
+    #[test]
+    fn final_padded_unknown_packet_round_trips_exactly() {
+        let rr = RtcpReceiverReport {
+            ssrc: 0x12345678,
+            report_blocks: Vec::new(),
+        };
+        let unknown = RtcpUnknownPacket {
+            packet_type: 205,
+            count: 7,
+            payload: Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+            padding: Bytes::from_static(&[0, 0, 0, 4]),
+        };
+        let compound = RtcpTolerantCompoundPacket {
+            packets: vec![
+                RtcpCompoundMember::Known(RtcpPacket::ReceiverReport(rr)),
+                RtcpCompoundMember::Unknown(unknown.clone()),
+            ],
+        };
+
+        let wire = compound.serialize().unwrap();
+        let parsed = RtcpTolerantCompoundPacket::parse(&wire).unwrap();
+        assert_eq!(parsed.packets[1], RtcpCompoundMember::Unknown(unknown));
+        assert_eq!(parsed.serialize().unwrap(), wire);
+    }
 }

--- a/crates/media/rtp-core/src/packet/rtcp/compound.rs
+++ b/crates/media/rtp-core/src/packet/rtcp/compound.rs
@@ -9,7 +9,7 @@ use bytes::{Buf, Bytes, BytesMut};
 
 use super::{
     RtcpApplicationDefined, RtcpExtendedReport, RtcpGoodbye, RtcpPacket, RtcpReceiverReport,
-    RtcpSenderReport, RtcpSourceDescription,
+    RtcpSenderReport, RtcpSourceDescription, RtcpUnknownPacket,
 };
 use crate::error::Error;
 use crate::Result;
@@ -25,6 +25,140 @@ use crate::Result;
 pub struct RtcpCompoundPacket {
     /// Packets in the compound packet
     pub packets: Vec<RtcpPacket>,
+}
+
+/// A member of a tolerantly parsed compound RTCP packet.
+///
+/// Keeping unknown members in this new wrapper avoids adding a variant to
+/// [`RtcpPacket`], whose existing public variants can therefore still be
+/// exhaustively matched by downstream 0.3.x users.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RtcpCompoundMember {
+    /// A packet type implemented by this crate.
+    Known(RtcpPacket),
+    /// A well-formed packet type not implemented by this crate.
+    Unknown(RtcpUnknownPacket),
+}
+
+impl RtcpCompoundMember {
+    /// Return the numeric RTCP packet type carried on the wire.
+    pub fn packet_type_byte(&self) -> u8 {
+        match self {
+            Self::Known(packet) => packet.packet_type() as u8,
+            Self::Unknown(packet) => packet.packet_type,
+        }
+    }
+
+    fn has_padding(&self) -> bool {
+        matches!(self, Self::Unknown(packet) if packet.has_padding())
+    }
+
+    fn serialize(&self) -> Result<Bytes> {
+        match self {
+            Self::Known(packet) => packet.serialize(),
+            Self::Unknown(packet) => packet.serialize(),
+        }
+    }
+}
+
+/// A compound RTCP packet that preserves unimplemented but well-formed
+/// packet types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RtcpTolerantCompoundPacket {
+    /// Known and unknown members in their original wire order.
+    pub packets: Vec<RtcpCompoundMember>,
+}
+
+impl RtcpTolerantCompoundPacket {
+    /// Validate the compound-packet ordering and padding rules.
+    pub fn validate(&self) -> Result<()> {
+        match self.packets.first() {
+            Some(RtcpCompoundMember::Known(
+                RtcpPacket::SenderReport(_) | RtcpPacket::ReceiverReport(_),
+            )) => {}
+            Some(_) => {
+                return Err(Error::RtcpError(
+                    "First packet in compound packet must be SR or RR".to_string(),
+                ));
+            }
+            None => {
+                return Err(Error::RtcpError(
+                    "Compound packet must contain at least one packet".to_string(),
+                ));
+            }
+        }
+
+        if self
+            .packets
+            .iter()
+            .take(self.packets.len().saturating_sub(1))
+            .any(RtcpCompoundMember::has_padding)
+        {
+            return Err(Error::RtcpError(
+                "Only the final packet in a compound RTCP packet may be padded".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Serialize all known and preserved unknown members.
+    pub fn serialize(&self) -> Result<Bytes> {
+        self.validate()?;
+
+        let mut buf = BytesMut::new();
+        for packet in &self.packets {
+            buf.extend_from_slice(&packet.serialize()?);
+        }
+        Ok(buf.freeze())
+    }
+
+    /// Parse an entire compound RTCP packet while preserving unimplemented
+    /// but well-formed packet types.
+    pub fn parse(data: &[u8]) -> Result<Self> {
+        let mut buf = Bytes::copy_from_slice(data);
+        let mut packets = Vec::new();
+
+        while buf.has_remaining() {
+            if buf.remaining() < 4 {
+                return Err(Error::BufferTooSmall {
+                    required: 4,
+                    available: buf.remaining(),
+                });
+            }
+
+            let mut peek_buf = buf.clone();
+            let first_byte = peek_buf.get_u8();
+            let packet_type = peek_buf.get_u8();
+            let length = peek_buf.get_u16() as usize * 4;
+            let total_packet_size = 4 + length;
+
+            if buf.remaining() < total_packet_size {
+                return Err(Error::BufferTooSmall {
+                    required: total_packet_size,
+                    available: buf.remaining(),
+                });
+            }
+            if first_byte & 0x20 != 0 && total_packet_size != buf.remaining() {
+                return Err(Error::RtcpError(
+                    "Only the final packet in a compound RTCP packet may be padded".to_string(),
+                ));
+            }
+
+            let packet_data = &buf[..total_packet_size];
+            let packet = if super::RtcpPacketType::try_from(packet_type).is_ok() {
+                RtcpCompoundMember::Known(RtcpPacket::parse(packet_data)?)
+            } else {
+                RtcpCompoundMember::Unknown(RtcpUnknownPacket::parse(packet_data)?)
+            };
+            packets.push(packet);
+            buf.advance(total_packet_size);
+        }
+
+        let compound = Self { packets };
+        compound.validate()?;
+        Ok(compound)
+    }
 }
 
 impl RtcpCompoundPacket {
@@ -93,11 +227,13 @@ impl RtcpCompoundPacket {
 
         // Check if the first packet is SR or RR
         match self.packets[0] {
-            RtcpPacket::SenderReport(_) | RtcpPacket::ReceiverReport(_) => Ok(()),
+            RtcpPacket::SenderReport(_) | RtcpPacket::ReceiverReport(_) => {}
             _ => Err(Error::RtcpError(
                 "First packet in compound packet must be SR or RR".to_string(),
-            )),
+            ))?,
         }
+
+        Ok(())
     }
 
     /// Serialize the compound packet
@@ -121,16 +257,18 @@ impl RtcpCompoundPacket {
         let mut buf = Bytes::copy_from_slice(data);
         let mut packets = Vec::new();
 
-        // Parse packets until we run out of data
-        while buf.remaining() >= 4 {
-            // Check if we have enough data for a header
+        // Parse packets until we run out of data.
+        while buf.has_remaining() {
             if buf.remaining() < 4 {
-                break;
+                return Err(Error::BufferTooSmall {
+                    required: 4,
+                    available: buf.remaining(),
+                });
             }
 
             // Look ahead to see packet length without consuming
             let mut peek_buf = buf.clone();
-            let _first_byte = peek_buf.get_u8();
+            let first_byte = peek_buf.get_u8();
             let _packet_type_byte = peek_buf.get_u8();
             let length = peek_buf.get_u16() as usize * 4;
 
@@ -142,6 +280,13 @@ impl RtcpCompoundPacket {
                     required: total_packet_size,
                     available: buf.remaining(),
                 });
+            }
+
+            let has_padding = first_byte & 0x20 != 0;
+            if has_padding && total_packet_size != buf.remaining() {
+                return Err(Error::RtcpError(
+                    "Only the final packet in a compound RTCP packet may be padded".to_string(),
+                ));
             }
 
             // Slice the current packet
@@ -161,11 +306,17 @@ impl RtcpCompoundPacket {
 
         Ok(compound)
     }
+
+    /// Parse a compound packet while preserving well-formed packet types
+    /// this crate does not implement.
+    pub fn parse_tolerant(data: &[u8]) -> Result<RtcpTolerantCompoundPacket> {
+        RtcpTolerantCompoundPacket::parse(data)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::super::NtpTimestamp;
+    use super::super::{NtpTimestamp, RtcpSdesItem, RtcpSdesItemType};
     use super::*;
 
     #[test]
@@ -263,5 +414,103 @@ mod tests {
             }
             _ => panic!("Expected BYE packet"),
         }
+    }
+
+    #[test]
+    fn tolerant_parser_preserves_unknown_mixed_packets() {
+        let rr = RtcpReceiverReport {
+            ssrc: 0x12345678,
+            report_blocks: Vec::new(),
+        };
+        let unknown = RtcpUnknownPacket {
+            packet_type: 205,
+            count: 1,
+            payload: Bytes::from_static(&[0xaa, 0xbb, 0xcc, 0xdd]),
+            padding: Bytes::new(),
+        };
+        let bye = RtcpGoodbye::new_for_source(0x12345678);
+        let compound = RtcpTolerantCompoundPacket {
+            packets: vec![
+                RtcpCompoundMember::Known(RtcpPacket::ReceiverReport(rr)),
+                RtcpCompoundMember::Unknown(unknown.clone()),
+                RtcpCompoundMember::Known(RtcpPacket::Goodbye(bye)),
+            ],
+        };
+
+        let wire = compound.serialize().unwrap();
+        let parsed = RtcpCompoundPacket::parse_tolerant(&wire).unwrap();
+        assert_eq!(parsed.packets.len(), 3);
+        assert_eq!(parsed.packets[1], RtcpCompoundMember::Unknown(unknown));
+        assert!(matches!(
+            parsed.packets[2],
+            RtcpCompoundMember::Known(RtcpPacket::Goodbye(_))
+        ));
+        assert_eq!(parsed.serialize().unwrap(), wire);
+
+        // The compatibility-preserving strict parser still reports the
+        // unimplemented member rather than changing RtcpPacket's variants.
+        assert!(RtcpCompoundPacket::parse(&wire).is_err());
+    }
+
+    #[test]
+    fn tolerant_mixed_parser_decodes_sdes_and_preserves_unknown_member() {
+        let rr = RtcpReceiverReport {
+            ssrc: 0x12345678,
+            report_blocks: Vec::new(),
+        };
+        let mut sdes = RtcpSourceDescription::new();
+        let mut chunk = super::super::RtcpSdesChunk::new(0x12345678);
+        chunk.add_item(RtcpSdesItem::new(
+            RtcpSdesItemType::CName,
+            "alice@example.test".to_string(),
+        ));
+        sdes.add_chunk(chunk);
+        let unknown = RtcpUnknownPacket {
+            packet_type: 205,
+            count: 1,
+            payload: Bytes::from_static(&[0xaa, 0xbb, 0xcc, 0xdd]),
+            padding: Bytes::new(),
+        };
+        let compound = RtcpTolerantCompoundPacket {
+            packets: vec![
+                RtcpCompoundMember::Known(RtcpPacket::ReceiverReport(rr)),
+                RtcpCompoundMember::Known(RtcpPacket::SourceDescription(sdes)),
+                RtcpCompoundMember::Unknown(unknown),
+            ],
+        };
+
+        let parsed = RtcpTolerantCompoundPacket::parse(&compound.serialize().unwrap()).unwrap();
+        assert!(matches!(
+            &parsed.packets[1],
+            RtcpCompoundMember::Known(RtcpPacket::SourceDescription(description))
+                if description.find_cname(0x12345678) == Some("alice@example.test")
+        ));
+        assert!(matches!(
+            parsed.packets[2],
+            RtcpCompoundMember::Unknown(RtcpUnknownPacket {
+                packet_type: 205,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn malformed_compound_packets_remain_errors() {
+        let rr = [0x80, 201, 0, 1, 0x12, 0x34, 0x56, 0x78];
+
+        let mut bad_version = rr.to_vec();
+        bad_version.extend_from_slice(&[0x40, 205, 0, 0]);
+        assert!(RtcpTolerantCompoundPacket::parse(&bad_version).is_err());
+
+        let mut trailing_bytes = rr.to_vec();
+        trailing_bytes.extend_from_slice(&[0x80, 205, 0]);
+        assert!(RtcpTolerantCompoundPacket::parse(&trailing_bytes).is_err());
+
+        // A padded unknown packet followed by another packet is invalid even
+        // though both individual lengths are well formed.
+        let mut non_final_padding = rr.to_vec();
+        non_final_padding.extend_from_slice(&[0xa0, 205, 0, 1, 0, 0, 0, 4]);
+        non_final_padding.extend_from_slice(&[0x80, 206, 0, 0]);
+        assert!(RtcpTolerantCompoundPacket::parse(&non_final_padding).is_err());
     }
 }

--- a/crates/media/rtp-core/src/packet/rtcp/mod.rs
+++ b/crates/media/rtp-core/src/packet/rtcp/mod.rs
@@ -4,7 +4,7 @@
 //! It includes implementations for different RTCP packet types: SR, RR, SDES, BYE, APP.
 //! Extended Reports (XR) are defined in RFC 3611.
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::error::Error;
 use crate::Result;
@@ -68,7 +68,7 @@ mod xr;
 // Re-export all public types
 pub use app::RtcpApplicationDefined;
 pub use bye::RtcpGoodbye;
-pub use compound::RtcpCompoundPacket;
+pub use compound::{RtcpCompoundMember, RtcpCompoundPacket, RtcpTolerantCompoundPacket};
 pub use ntp::NtpTimestamp;
 pub use receiver_report::RtcpReceiverReport;
 pub use report_block::RtcpReportBlock;
@@ -77,6 +77,169 @@ pub use sender_report::RtcpSenderReport;
 pub use xr::{
     ReceiverReferenceTimeBlock, RtcpExtendedReport, RtcpXrBlock, RtcpXrBlockType, VoipMetricsBlock,
 };
+
+/// A well-formed RTCP packet whose packet type is not implemented.
+///
+/// Both the body and any RTCP padding are retained so tolerant compound
+/// parsing can round-trip packets such as RTPFB/PSFB without interpreting
+/// them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RtcpUnknownPacket {
+    /// Raw RTCP packet type byte.
+    pub packet_type: u8,
+    /// The five count/subtype bits from the common header.
+    pub count: u8,
+    /// Packet body, excluding the common header and RTCP padding.
+    pub payload: Bytes,
+    /// Exact RTCP padding bytes. Empty when the padding bit was clear.
+    pub padding: Bytes,
+}
+
+#[derive(Debug)]
+struct ParsedRtcpEnvelope {
+    packet_type: u8,
+    count: u8,
+    payload: Bytes,
+    padding: Bytes,
+}
+
+fn parse_rtcp_envelope(data: &[u8]) -> Result<ParsedRtcpEnvelope> {
+    if data.len() < 4 {
+        return Err(Error::BufferTooSmall {
+            required: 4,
+            available: data.len(),
+        });
+    }
+
+    let first_byte = data[0];
+    let version = (first_byte >> 6) & 0x03;
+    if version != RTCP_VERSION {
+        return Err(Error::RtcpError(format!(
+            "Invalid RTCP version: {}",
+            version
+        )));
+    }
+
+    let has_padding = first_byte & 0x20 != 0;
+    let count = first_byte & 0x1f;
+    let packet_type = data[1];
+    let length_words_minus_one = u16::from_be_bytes([data[2], data[3]]) as usize;
+    let packet_size = (length_words_minus_one + 1) * 4;
+    if data.len() < packet_size {
+        return Err(Error::BufferTooSmall {
+            required: packet_size,
+            available: data.len(),
+        });
+    }
+    if data.len() > packet_size {
+        return Err(Error::RtcpError(format!(
+            "RTCP packet length declares {} bytes but {} bytes were supplied",
+            packet_size,
+            data.len()
+        )));
+    }
+
+    let mut body_end = packet_size;
+    let padding = if has_padding {
+        if packet_size == 4 {
+            return Err(Error::RtcpError(
+                "RTCP padding flag is set on a packet with no body".to_string(),
+            ));
+        }
+
+        let padding_size = data[packet_size - 1] as usize;
+        let body_size = packet_size - 4;
+        if padding_size == 0 || padding_size > body_size {
+            return Err(Error::RtcpError(format!(
+                "Invalid RTCP padding length {} for {}-byte body",
+                padding_size, body_size
+            )));
+        }
+        body_end -= padding_size;
+        Bytes::copy_from_slice(&data[body_end..packet_size])
+    } else {
+        Bytes::new()
+    };
+
+    Ok(ParsedRtcpEnvelope {
+        packet_type,
+        count,
+        payload: Bytes::copy_from_slice(&data[4..body_end]),
+        padding,
+    })
+}
+
+impl RtcpUnknownPacket {
+    /// Parse and preserve a well-formed RTCP packet type not implemented by
+    /// this crate.
+    pub fn parse(data: &[u8]) -> Result<Self> {
+        let envelope = parse_rtcp_envelope(data)?;
+        if RtcpPacketType::try_from(envelope.packet_type).is_ok() {
+            return Err(Error::InvalidParameter(format!(
+                "RTCP packet type {} is implemented and is not unknown",
+                envelope.packet_type
+            )));
+        }
+
+        Ok(Self {
+            packet_type: envelope.packet_type,
+            count: envelope.count,
+            payload: envelope.payload,
+            padding: envelope.padding,
+        })
+    }
+
+    /// Serialize the preserved packet without interpreting its payload.
+    pub fn serialize(&self) -> Result<Bytes> {
+        if RtcpPacketType::try_from(self.packet_type).is_ok() {
+            return Err(Error::InvalidParameter(format!(
+                "RTCP packet type {} is implemented and cannot use RtcpUnknownPacket",
+                self.packet_type
+            )));
+        }
+        if self.count > 31 {
+            return Err(Error::InvalidParameter(format!(
+                "RTCP count/subtype {} exceeds five bits",
+                self.count
+            )));
+        }
+        if !self.padding.is_empty()
+            && (self.padding.len() > u8::MAX as usize
+                || self.padding[self.padding.len() - 1] as usize != self.padding.len())
+        {
+            return Err(Error::InvalidParameter(
+                "Unknown RTCP packet has malformed padding".to_string(),
+            ));
+        }
+
+        let packet_size = 4 + self.payload.len() + self.padding.len();
+        if packet_size % 4 != 0 {
+            return Err(Error::InvalidParameter(format!(
+                "Unknown RTCP packet size {} is not 32-bit aligned",
+                packet_size
+            )));
+        }
+        let words_minus_one = packet_size / 4 - 1;
+        if words_minus_one > u16::MAX as usize {
+            return Err(Error::InvalidParameter(
+                "Unknown RTCP packet is too large".to_string(),
+            ));
+        }
+
+        let mut buf = BytesMut::with_capacity(packet_size);
+        let padding_bit = u8::from(!self.padding.is_empty()) << 5;
+        buf.put_u8((RTCP_VERSION << 6) | padding_bit | self.count);
+        buf.put_u8(self.packet_type);
+        buf.put_u16(words_minus_one as u16);
+        buf.extend_from_slice(&self.payload);
+        buf.extend_from_slice(&self.padding);
+        Ok(buf.freeze())
+    }
+
+    fn has_padding(&self) -> bool {
+        !self.padding.is_empty()
+    }
+}
 
 /// RTCP packet variants
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,60 +266,45 @@ pub enum RtcpPacket {
 impl RtcpPacket {
     /// Parse an RTCP packet from bytes
     pub fn parse(data: &[u8]) -> Result<Self> {
-        let mut buf = Bytes::copy_from_slice(data);
-
-        // Parse common header (first 4 bytes)
-        if buf.remaining() < 4 {
-            return Err(Error::BufferTooSmall {
-                required: 4,
-                available: buf.remaining(),
-            });
-        }
-
-        let first_byte = buf.get_u8();
-        // Check version (2 bits)
-        let version = (first_byte >> 6) & 0x03;
-        if version != RTCP_VERSION {
-            return Err(Error::RtcpError(format!(
-                "Invalid RTCP version: {}",
-                version
-            )));
-        }
-
-        // Check padding flag (1 bit)
-        let _padding = ((first_byte >> 5) & 0x01) != 0;
-
-        // Get reception report count (5 bits)
-        let report_count = first_byte & 0x1F;
-
-        // Get packet type
-        let packet_type = RtcpPacketType::try_from(buf.get_u8())?;
-
-        // Get length in 32-bit words minus one (convert to bytes)
-        let length = buf.get_u16() as usize * 4;
-
-        if buf.remaining() < length {
-            return Err(Error::BufferTooSmall {
-                required: length,
-                available: buf.remaining(),
-            });
-        }
+        let envelope = parse_rtcp_envelope(data)?;
+        let report_count = envelope.count;
+        let packet_type = RtcpPacketType::try_from(envelope.packet_type)?;
+        let mut buf = envelope.payload;
 
         // Parse specific packet type
         match packet_type {
-            RtcpPacketType::SenderReport => Ok(RtcpPacket::SenderReport(
-                sender_report::parse_sender_report(&mut buf, report_count)?,
-            )),
-            RtcpPacketType::ReceiverReport => Ok(RtcpPacket::ReceiverReport(
-                receiver_report::parse_receiver_report(&mut buf, report_count)?,
-            )),
-            RtcpPacketType::SourceDescription => {
-                Ok(RtcpPacket::SourceDescription(RtcpSourceDescription {
-                    chunks: Vec::new(),
-                }))
+            RtcpPacketType::SenderReport => {
+                let report = sender_report::parse_sender_report(&mut buf, report_count)?;
+                if !buf.is_empty() {
+                    return Err(Error::RtcpError(format!(
+                        "Sender Report has {} unexpected trailing bytes",
+                        buf.len()
+                    )));
+                }
+                Ok(RtcpPacket::SenderReport(report))
             }
+            RtcpPacketType::ReceiverReport => {
+                let report = receiver_report::parse_receiver_report(&mut buf, report_count)?;
+                if !buf.is_empty() {
+                    return Err(Error::RtcpError(format!(
+                        "Receiver Report has {} unexpected trailing bytes",
+                        buf.len()
+                    )));
+                }
+                Ok(RtcpPacket::ReceiverReport(report))
+            }
+            RtcpPacketType::SourceDescription => Ok(RtcpPacket::SourceDescription(
+                sdes::parse_sdes(&buf, report_count)?,
+            )),
             RtcpPacketType::Goodbye => {
-                Ok(RtcpPacket::Goodbye(bye::parse_bye(&mut buf, report_count)?))
+                let goodbye = bye::parse_bye(&mut buf, report_count)?;
+                if !buf.is_empty() {
+                    return Err(Error::RtcpError(format!(
+                        "BYE packet has {} unexpected trailing bytes",
+                        buf.len()
+                    )));
+                }
+                Ok(RtcpPacket::Goodbye(goodbye))
             }
             RtcpPacketType::ApplicationDefined => {
                 Ok(RtcpPacket::ApplicationDefined(app::parse_app(&mut buf)?))
@@ -399,5 +547,48 @@ mod tests {
         );
 
         assert!(RtcpPacketType::try_from(100).is_err());
+    }
+
+    #[test]
+    fn unknown_packet_is_preserved() {
+        let bytes = [0x85, 205, 0, 2, 1, 2, 3, 4, 5, 6, 7, 8];
+        let parsed = RtcpUnknownPacket::parse(&bytes).unwrap();
+
+        assert_eq!(parsed.packet_type, 205);
+        assert_eq!(parsed.count, 5);
+        assert_eq!(&parsed.payload[..], &bytes[4..]);
+        assert!(parsed.padding.is_empty());
+        assert_eq!(&parsed.serialize().unwrap()[..], &bytes);
+
+        // The legacy single-packet parser remains strict, so adding tolerant
+        // compound parsing does not add a variant to the public RtcpPacket
+        // enum and break downstream exhaustive matches.
+        assert!(RtcpPacket::parse(&bytes).is_err());
+    }
+
+    #[test]
+    fn malformed_rtcp_padding_is_rejected() {
+        assert!(RtcpUnknownPacket::parse(&[0xa0, 205, 0, 1, 1, 2, 3, 0]).is_err());
+        assert!(RtcpUnknownPacket::parse(&[0xa0, 205, 0, 1, 1, 2, 3, 5]).is_err());
+        assert!(RtcpUnknownPacket::parse(&[0xa0, 205, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn declared_packet_length_must_match_input() {
+        let rr_with_trailing_packet = [0x80, 201, 0, 1, 0x12, 0x34, 0x56, 0x78, 0x80, 205, 0, 0];
+        assert!(RtcpPacket::parse(&rr_with_trailing_packet).is_err());
+
+        // RR declares a second body word that is not a report block.
+        let rr_with_internal_trailing_word = [0x80, 201, 0, 2, 0x12, 0x34, 0x56, 0x78, 0, 0, 0, 0];
+        assert!(RtcpPacket::parse(&rr_with_internal_trailing_word).is_err());
+    }
+
+    #[test]
+    fn malformed_known_sdes_member_is_rejected() {
+        // The header declares one SDES chunk, but the body contains no SSRC.
+        assert!(RtcpPacket::parse(&[0x81, 202, 0, 0]).is_err());
+
+        // The SSRC is present, but the mandatory END item is missing.
+        assert!(RtcpPacket::parse(&[0x81, 202, 0, 1, 0x12, 0x34, 0x56, 0x78,]).is_err());
     }
 }

--- a/crates/media/rtp-core/src/packet/rtcp/sdes.rs
+++ b/crates/media/rtp-core/src/packet/rtcp/sdes.rs
@@ -218,6 +218,123 @@ pub fn serialize_sdes(sdes: &RtcpSourceDescription) -> Result<BytesMut> {
     sdes.serialize()
 }
 
+/// Parse an SDES body using the source count from the RTCP common header.
+///
+/// Each declared chunk must contain an SSRC, a terminating END item, and
+/// zero-valued alignment octets. Trailing or truncated data is rejected so a
+/// malformed known member cannot be hidden inside an otherwise valid compound
+/// packet.
+pub fn parse_sdes(data: &[u8], source_count: u8) -> Result<RtcpSourceDescription> {
+    let mut offset = 0usize;
+    let mut description = RtcpSourceDescription::new();
+
+    for _ in 0..source_count {
+        if data.len().saturating_sub(offset) < 4 {
+            return Err(Error::RtcpError(
+                "SDES chunk is truncated before its SSRC".to_string(),
+            ));
+        }
+
+        let ssrc = u32::from_be_bytes(
+            data[offset..offset + 4]
+                .try_into()
+                .expect("the SDES SSRC length was checked"),
+        );
+        offset += 4;
+        let mut chunk = RtcpSdesChunk::new(ssrc);
+
+        loop {
+            let Some(&item_type) = data.get(offset) else {
+                return Err(Error::RtcpError(
+                    "SDES chunk is missing its END item".to_string(),
+                ));
+            };
+            offset += 1;
+
+            if item_type == RtcpSdesItemType::End as u8 {
+                break;
+            }
+
+            let Some(&item_length) = data.get(offset) else {
+                return Err(Error::RtcpError(
+                    "SDES item is truncated before its length".to_string(),
+                ));
+            };
+            offset += 1;
+            let item_length = usize::from(item_length);
+            if data.len().saturating_sub(offset) < item_length {
+                return Err(Error::RtcpError(
+                    "SDES item value is shorter than its declared length".to_string(),
+                ));
+            }
+
+            let value_bytes = &data[offset..offset + item_length];
+            offset += item_length;
+
+            // RFC 3550 deliberately leaves the SDES item registry open to
+            // later assignments. Keep parsing the chunk when this crate does
+            // not model a registered or future item type; otherwise valid
+            // types such as MID (15) would make the entire compound packet
+            // unusable. Modeled text items still receive UTF-8 validation.
+            if let Ok(item_type) = RtcpSdesItemType::try_from(item_type) {
+                if item_type == RtcpSdesItemType::Private {
+                    // PRIV starts with a binary prefix-length octet, followed
+                    // by separate UTF-8 prefix and value strings. The legacy
+                    // `RtcpSdesItem { value: String }` cannot preserve that
+                    // boundary, so validate and ignore it instead of either
+                    // rejecting valid prefix lengths or inventing a lossy
+                    // representation.
+                    let (&prefix_length, text) = value_bytes.split_first().ok_or_else(|| {
+                        Error::RtcpError("SDES PRIV item has no prefix length".to_string())
+                    })?;
+                    let prefix_length = usize::from(prefix_length);
+                    if prefix_length > text.len() {
+                        return Err(Error::RtcpError(
+                            "SDES PRIV prefix exceeds its item length".to_string(),
+                        ));
+                    }
+                    std::str::from_utf8(&text[..prefix_length]).map_err(|_| {
+                        Error::RtcpError("SDES PRIV prefix is not valid UTF-8".to_string())
+                    })?;
+                    std::str::from_utf8(&text[prefix_length..]).map_err(|_| {
+                        Error::RtcpError("SDES PRIV value is not valid UTF-8".to_string())
+                    })?;
+                } else {
+                    let value = std::str::from_utf8(value_bytes)
+                        .map_err(|_| Error::RtcpError("SDES item is not valid UTF-8".to_string()))?
+                        .to_string();
+                    chunk.add_item(RtcpSdesItem::new(item_type, value));
+                }
+            }
+        }
+
+        while offset % 4 != 0 {
+            let Some(&padding) = data.get(offset) else {
+                return Err(Error::RtcpError(
+                    "SDES chunk alignment padding is truncated".to_string(),
+                ));
+            };
+            if padding != 0 {
+                return Err(Error::RtcpError(
+                    "SDES chunk alignment padding must be zero".to_string(),
+                ));
+            }
+            offset += 1;
+        }
+
+        description.add_chunk(chunk);
+    }
+
+    if offset != data.len() {
+        return Err(Error::RtcpError(format!(
+            "SDES source count leaves {} unexpected body bytes",
+            data.len() - offset
+        )));
+    }
+
+    Ok(description)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,5 +409,62 @@ mod tests {
 
         let cname = sdes.find_cname(0x99999999);
         assert!(cname.is_none());
+    }
+
+    #[test]
+    fn serialized_sdes_round_trips_with_exact_source_count() {
+        let mut sdes = RtcpSourceDescription::new();
+        sdes.add_source(0x1234_5678, Some("alice@example.test".to_string()));
+        sdes.add_source(0x90ab_cdef, None);
+
+        let bytes = sdes.serialize().unwrap();
+        assert_eq!(parse_sdes(&bytes, 2).unwrap(), sdes);
+    }
+
+    #[test]
+    fn source_count_and_chunk_termination_are_enforced() {
+        // One declared chunk but no SSRC.
+        assert!(parse_sdes(&[], 1).is_err());
+        // SSRC without the mandatory END item.
+        assert!(parse_sdes(&[0x12, 0x34, 0x56, 0x78], 1).is_err());
+        // A second body word cannot be ignored when the source count is zero.
+        assert!(parse_sdes(&[0, 0, 0, 0], 0).is_err());
+        // Alignment bytes after END must be present and zero.
+        assert!(parse_sdes(&[0x12, 0x34, 0x56, 0x78, 0, 0, 1, 0], 1).is_err());
+    }
+
+    #[test]
+    fn registered_unmodeled_item_does_not_hide_following_known_items() {
+        let body = [
+            0x12, 0x34, 0x56, 0x78, // SSRC
+            15, 3, b'm', b'i', b'd', // IANA-assigned MID, not modeled here
+            1, 5, b'a', b'l', b'i', b'c', b'e', // CNAME
+            0, 0, 0, 0, // END and chunk alignment
+        ];
+
+        let parsed = parse_sdes(&body, 1).unwrap();
+        assert_eq!(parsed.chunks.len(), 1);
+        assert_eq!(parsed.chunks[0].items.len(), 1);
+        assert_eq!(parsed.find_cname(0x12345678), Some("alice"));
+    }
+
+    #[test]
+    fn private_item_uses_its_rfc_length_prefixed_shape() {
+        let body = [
+            0x12, 0x34, 0x56, 0x78, // SSRC
+            8, 4, 2, b'i', b'd', b'v', // PRIV: prefix "id", value "v"
+            1, 1, b'a', // CNAME
+            0, 0, 0, // END and chunk alignment
+        ];
+        let parsed = parse_sdes(&body, 1).unwrap();
+        assert_eq!(parsed.find_cname(0x12345678), Some("a"));
+        assert_eq!(parsed.chunks[0].items.len(), 1);
+
+        let malformed = [
+            0x12, 0x34, 0x56, 0x78, // SSRC
+            8, 2, 3, b'x', // prefix length exceeds item body
+            0,    // END; already aligned
+        ];
+        assert!(parse_sdes(&malformed, 1).is_err());
     }
 }

--- a/crates/media/rtp-core/src/packet/rtp.rs
+++ b/crates/media/rtp-core/src/packet/rtp.rs
@@ -15,12 +15,23 @@ pub struct RtpPacket {
 
     /// Payload data
     pub payload: Bytes,
+
+    /// Number of RTP padding octets on the wire.
+    ///
+    /// Padding is not included in [`Self::payload`]. A non-zero value must
+    /// agree with [`RtpHeader::padding`]; the final serialized padding octet
+    /// contains this value as required by RFC 3550.
+    pub padding_size: u8,
 }
 
 impl RtpPacket {
     /// Create a new RTP packet with the given header and payload
     pub fn new(header: RtpHeader, payload: Bytes) -> Self {
-        Self { header, payload }
+        Self {
+            header,
+            payload,
+            padding_size: 0,
+        }
     }
 
     /// Create a new RTP packet with the standard header fields and payload
@@ -32,12 +43,77 @@ impl RtpPacket {
         payload: Bytes,
     ) -> Self {
         let header = RtpHeader::new(payload_type, sequence_number, timestamp, ssrc);
-        Self { header, payload }
+        Self {
+            header,
+            payload,
+            padding_size: 0,
+        }
+    }
+
+    /// Configure the number of padding octets to write on the wire.
+    pub fn set_padding(&mut self, padding_size: u8) {
+        self.padding_size = padding_size;
+        self.header.padding = padding_size != 0;
+    }
+
+    /// Remove RTP padding from the packet.
+    pub fn clear_padding(&mut self) {
+        self.set_padding(0);
     }
 
     /// Get the total size of the packet in bytes
     pub fn size(&self) -> usize {
-        self.header.size() + self.payload.len()
+        self.header.size() + self.payload.len() + self.padding_size as usize
+    }
+
+    fn payload_bounds(data: &[u8], header_size: usize, has_padding: bool) -> Result<(usize, u8)> {
+        if !has_padding {
+            return Ok((data.len(), 0));
+        }
+
+        if data.len() <= header_size {
+            return Err(crate::Error::InvalidPacket(
+                "RTP padding flag is set but the packet has no padding octets".to_string(),
+            ));
+        }
+
+        let padding_size = data[data.len() - 1];
+        if padding_size == 0 {
+            return Err(crate::Error::InvalidPacket(
+                "RTP padding length must be non-zero".to_string(),
+            ));
+        }
+
+        let available = data.len() - header_size;
+        if padding_size as usize > available {
+            return Err(crate::Error::InvalidPacket(format!(
+                "RTP padding length {} exceeds {} available payload octets",
+                padding_size, available
+            )));
+        }
+
+        Ok((data.len() - padding_size as usize, padding_size))
+    }
+
+    fn validate_padding(&self) -> Result<()> {
+        if self.header.padding != (self.padding_size != 0) {
+            return Err(crate::Error::InvalidParameter(format!(
+                "RTP padding flag ({}) does not match padding length ({})",
+                self.header.padding, self.padding_size
+            )));
+        }
+        Ok(())
+    }
+
+    fn serialize_padding(&self, buf: &mut BytesMut) {
+        if self.padding_size == 0 {
+            return;
+        }
+
+        for _ in 1..self.padding_size {
+            buf.extend_from_slice(&[0]);
+        }
+        buf.extend_from_slice(&[self.padding_size]);
     }
 
     /// Parse an RTP packet from bytes.
@@ -50,15 +126,21 @@ impl RtpPacket {
         let (header, header_size) = RtpHeader::parse_without_consuming(data)?;
         debug!("Parsed header of size {}", header_size);
 
-        // Extract the payload
-        let payload = if data.len() > header_size {
-            Bytes::copy_from_slice(&data[header_size..])
+        let (payload_end, padding_size) = Self::payload_bounds(data, header_size, header.padding)?;
+
+        // Extract the payload without the RTP padding.
+        let payload = if payload_end > header_size {
+            Bytes::copy_from_slice(&data[header_size..payload_end])
         } else {
             Bytes::new()
         };
         debug!("Extracted payload of size {}", payload.len());
 
-        Ok(Self { header, payload })
+        Ok(Self {
+            header,
+            payload,
+            padding_size,
+        })
     }
 
     /// Parse an RTP packet from an owned `Bytes`, slicing the payload as a
@@ -69,16 +151,22 @@ impl RtpPacket {
         let (header, header_size) = RtpHeader::parse_without_consuming(&data)?;
         debug!("Parsed header of size {}", header_size);
 
+        let (payload_end, padding_size) = Self::payload_bounds(&data, header_size, header.padding)?;
+
         // Zero-copy slice: `Bytes::slice` only bumps the underlying
         // refcount, no allocation.
-        let payload = if data.len() > header_size {
-            data.slice(header_size..)
+        let payload = if payload_end > header_size {
+            data.slice(header_size..payload_end)
         } else {
             Bytes::new()
         };
         debug!("Sliced payload of size {}", payload.len());
 
-        Ok(Self { header, payload })
+        Ok(Self {
+            header,
+            payload,
+            padding_size,
+        })
     }
 
     /// Serialize the packet to bytes.
@@ -88,10 +176,12 @@ impl RtpPacket {
     /// [`Self::serialize_into`] with a per-task buffer to amortise the
     /// allocation across calls.
     pub fn serialize(&self) -> Result<Bytes> {
+        self.validate_padding()?;
         let total_size = self.size();
         let mut buf = BytesMut::with_capacity(total_size);
         self.header.serialize(&mut buf)?;
         buf.extend_from_slice(&self.payload);
+        self.serialize_padding(&mut buf);
         Ok(buf.freeze())
     }
 
@@ -111,6 +201,7 @@ impl RtpPacket {
     /// performs an internal reallocation that only pays off when the
     /// buffer is reused across repeated calls.
     pub fn serialize_into(&self, buf: &mut BytesMut) -> Result<Bytes> {
+        self.validate_padding()?;
         let total_size = self.size();
         buf.reserve(total_size);
 
@@ -119,6 +210,9 @@ impl RtpPacket {
 
         // Add the payload
         buf.extend_from_slice(&self.payload);
+
+        // Add RFC 3550 padding, with the count in the final octet.
+        self.serialize_padding(buf);
 
         // Split off exactly the bytes we wrote and freeze them into an
         // immutable Bytes view. `buf` retains any leftover capacity for
@@ -131,9 +225,10 @@ impl fmt::Debug for RtpPacket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "RtpPacket {{ header: {:?}, payload_len: {} }}",
+            "RtpPacket {{ header: {:?}, payload_len: {}, padding_size: {} }}",
             self.header,
-            self.payload.len()
+            self.payload.len(),
+            self.padding_size
         )
     }
 }
@@ -213,6 +308,51 @@ mod tests {
 
         assert_eq!(serialized.len(), RTP_MIN_HEADER_SIZE + payload.len());
         assert_eq!(&serialized[RTP_MIN_HEADER_SIZE..], payload.as_ref());
+    }
+
+    #[test]
+    fn test_padding_roundtrip_and_payload_stripping() {
+        let mut packet = RtpPacket::new_with_payload(
+            96,
+            1000,
+            12345,
+            0xabcdef01,
+            Bytes::from_static(b"payload"),
+        );
+        packet.set_padding(4);
+
+        let serialized = packet.serialize().unwrap();
+        assert_eq!(&serialized[serialized.len() - 4..], &[0, 0, 0, 4]);
+
+        let parsed = RtpPacket::parse(&serialized).unwrap();
+        assert!(parsed.header.padding);
+        assert_eq!(parsed.padding_size, 4);
+        assert_eq!(parsed.payload, Bytes::from_static(b"payload"));
+        assert_eq!(parsed, packet);
+    }
+
+    #[test]
+    fn test_parse_rejects_malformed_padding() {
+        let packet =
+            RtpPacket::new_with_payload(96, 1000, 12345, 0xabcdef01, Bytes::from_static(b"x"));
+        let mut serialized = packet.serialize().unwrap().to_vec();
+        serialized[0] |= 0x20;
+
+        serialized.push(0);
+        assert!(RtpPacket::parse(&serialized).is_err());
+
+        *serialized.last_mut().unwrap() = 3;
+        assert!(RtpPacket::parse(&serialized).is_err());
+
+        serialized.truncate(RTP_MIN_HEADER_SIZE);
+        assert!(RtpPacket::parse(&serialized).is_err());
+    }
+
+    #[test]
+    fn test_serialize_rejects_inconsistent_padding_state() {
+        let mut packet = RtpPacket::new_with_payload(96, 1000, 12345, 0xabcdef01, Bytes::new());
+        packet.header.padding = true;
+        assert!(packet.serialize().is_err());
     }
 
     #[test]

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -13,9 +13,9 @@ use bytes::{Bytes, BytesMut};
 use dashmap::DashMap;
 use rand::Rng;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::net::UdpSocket;
 use tokio::sync::{broadcast, mpsc, Mutex, Semaphore};
 use tokio::task::JoinHandle;
@@ -64,24 +64,20 @@ pub const RTP_SESSION_CHANNEL_CAPACITY: usize = 64;
 /// [`RtpSession::receive_packet`].
 pub const RTP_SESSION_RECEIVE_QUEUE_CAPACITY: usize = 32;
 
-/// Build the RTCP loss fields from the sequence-aware stream tracker.
-///
-/// `packets_received` includes duplicates and reordered arrivals, so deriving
-/// loss from that counter can hide a real sequence gap. The stream's bounded
-/// extended-sequence tracker is the source of truth for cumulative loss.
-fn rtcp_loss_fields(stats: &RtpStreamStats) -> (u8, u32) {
-    let expected = stats
-        .highest_seq
-        .saturating_sub(stats.first_seq)
-        .saturating_add(1);
-    if expected == 0 {
-        return (0, 0);
-    }
+fn take_rtcp_report_blocks(
+    streams: &DashMap<RtpSsrc, RtpStream>,
+) -> Vec<crate::packet::rtcp::RtcpReportBlock> {
+    streams
+        .iter_mut()
+        .take(31)
+        .map(|mut stream| stream.take_report_block())
+        .collect()
+}
 
-    let lost_in_range = stats.packets_lost.min(u64::from(expected));
-    let fraction = ((lost_in_range * 256) / u64::from(expected)).min(255) as u8;
-    let cumulative = stats.packets_lost.min(0x00ff_ffff) as u32;
-    (fraction, cumulative)
+#[derive(Debug, Clone, Copy)]
+struct ReceivedSenderReport {
+    lsr: u32,
+    received_at: Instant,
 }
 
 /// RTP session queue sizing.
@@ -216,6 +212,7 @@ struct RtpPacketSender {
     ssrc: RtpSsrc,
     sequence: Arc<AtomicU16>,
     stats: Arc<parking_lot::Mutex<RtpSessionStats>>,
+    sender_octets: Arc<AtomicU64>,
     event_tx: broadcast::Sender<RtpSessionEvent>,
     state: Mutex<RtpPacketSenderState>,
     slots: Arc<Semaphore>,
@@ -234,6 +231,7 @@ impl RtpPacketSender {
         ssrc: RtpSsrc,
         sequence: Arc<AtomicU16>,
         stats: Arc<parking_lot::Mutex<RtpSessionStats>>,
+        sender_octets: Arc<AtomicU64>,
         event_tx: broadcast::Sender<RtpSessionEvent>,
         capacity: usize,
     ) -> Self {
@@ -244,6 +242,7 @@ impl RtpPacketSender {
             ssrc,
             sequence,
             stats,
+            sender_octets,
             event_tx,
             state: Mutex::new(RtpPacketSenderState {
                 send_buffer: BytesMut::with_capacity(crate::DEFAULT_MAX_PACKET_SIZE),
@@ -313,6 +312,8 @@ impl RtpPacketSender {
                 let mut stats = self.stats.lock();
                 stats.packets_sent += 1;
                 stats.bytes_sent += packet.size() as u64;
+                self.sender_octets
+                    .fetch_add(packet.payload.len() as u64, Ordering::Relaxed);
                 Ok(())
             }
             Err(err) => {
@@ -504,6 +505,10 @@ pub struct RtpSession {
     /// `stream_count` readers don't block the demux task.
     streams: Arc<DashMap<RtpSsrc, RtpStream>>,
 
+    /// Sender Reports retained even when RTCP arrives before the source's
+    /// first RTP packet.
+    received_sender_reports: Arc<DashMap<RtpSsrc, ReceivedSenderReport>>,
+
     /// Packet scheduler for sending packets
     scheduler: Option<RtpScheduler>,
 
@@ -528,6 +533,9 @@ pub struct RtpSession {
     /// added avoidable lock-acquire overhead on the send/recv hot
     /// paths and forced everything to unwrap poison.
     stats: Arc<parking_lot::Mutex<RtpSessionStats>>,
+
+    /// RFC 3550 sender octet count (RTP payload bytes only).
+    sender_octets: Arc<AtomicU64>,
 
     /// Media synchronization context
     media_sync: Option<Arc<std::sync::RwLock<crate::sync::MediaSync>>>,
@@ -630,6 +638,7 @@ impl RtpSession {
             rand::thread_rng().gen::<u32>(), // Random starting timestamp
         ));
         let stats = Arc::new(parking_lot::Mutex::new(RtpSessionStats::default()));
+        let sender_octets = Arc::new(AtomicU64::new(0));
         let packet_sender = Arc::new(RtpPacketSender::new(
             transport.clone(),
             config.remote_addr,
@@ -639,6 +648,7 @@ impl RtpSession {
                 .expect("RTP session scheduler")
                 .sequence_handle(),
             stats.clone(),
+            sender_octets.clone(),
             event_tx.clone(),
             session_buffer_config.sender_channel_capacity,
         ));
@@ -658,6 +668,7 @@ impl RtpSession {
             ssrc,
             transport,
             streams: Arc::new(DashMap::new()),
+            received_sender_reports: Arc::new(DashMap::new()),
             scheduler,
             receiver: receiver_rx,
             packet_sender,
@@ -665,6 +676,7 @@ impl RtpSession {
             event_tx,
             recv_task: None,
             stats,
+            sender_octets,
             media_sync: None,
             active: false,
             rtcp_generator: Some(rtcp_generator),
@@ -713,6 +725,7 @@ impl RtpSession {
         let _payload_type = self.config.payload_type;
         let ssrc = self.ssrc;
         let streams_map = self.streams.clone();
+        let received_sender_reports = self.received_sender_reports.clone();
         let _jitter_buffer_enabled = self.config.enable_jitter_buffer;
         let _jitter_size = self.config.jitter_buffer_size.unwrap_or(50);
         let _max_age_ms = self.config.max_packet_age_ms.unwrap_or(200);
@@ -799,15 +812,22 @@ impl RtpSession {
                                                 report_ssrc
                                             );
 
-                                            // Update stream statistics if this stream exists
+                                            let sender_report = ReceivedSenderReport {
+                                                lsr: sr.ntp_timestamp.to_u32(),
+                                                received_at: Instant::now(),
+                                            };
+                                            received_sender_reports
+                                                .insert(report_ssrc, sender_report);
+
+                                            // Update stream statistics if RTP for this source
+                                            // has already created the stream. The retained map
+                                            // above covers the SR-before-RTP ordering.
                                             if let Some(mut stream) =
                                                 streams_map.get_mut(&report_ssrc)
                                             {
-                                                // Update the stream's RTCP SR info
-                                                // This will be used for calculating round-trip time
                                                 stream.update_last_sr_info(
-                                                    sr.ntp_timestamp.to_u32(),
-                                                    std::time::Instant::now(),
+                                                    sender_report.lsr,
+                                                    sender_report.received_at,
                                                 );
 
                                                 debug!(
@@ -858,21 +878,18 @@ impl RtpSession {
                                                 ssrc
                                             );
 
-                                                    // Update session stats with packet loss info
-                                                    {
-                                                        let mut stats = stats_recv.lock();
-                                                        stats.packets_lost =
-                                                            block.cumulative_lost as u64;
-
-                                                        // Calculate packet loss percentage
-                                                        let fraction_lost =
-                                                            block.fraction_lost as f64 / 256.0;
-                                                        debug!(
-                                                            "Packet loss: {}% (fraction={})",
-                                                            fraction_lost * 100.0,
-                                                            block.fraction_lost
-                                                        );
-                                                    }
+                                                    // This block describes loss of our outbound
+                                                    // stream. Keep the session's `packets_lost`
+                                                    // counter reserved for locally observed
+                                                    // inbound sequence gaps.
+                                                    let fraction_lost =
+                                                        block.fraction_lost as f64 / 256.0;
+                                                    debug!(
+                                                        "Remote-reported outbound packet loss: {}% (fraction={}, cumulative={})",
+                                                        fraction_lost * 100.0,
+                                                        block.fraction_lost,
+                                                        block.cumulative_lost
+                                                    );
                                                 }
                                             }
 
@@ -901,6 +918,7 @@ impl RtpSession {
                         sequence_number,
                         timestamp,
                         payload,
+                        padding_size,
                         source,
                         ssrc: ssrc_from_event,
                         marker,
@@ -912,14 +930,14 @@ impl RtpSession {
                         // Reconstruct minimal RTP header for processing
                         let header = RtpHeader {
                             version: 2,
-                            padding: false,
+                            padding: padding_size != 0,
                             extension: false,
                             cc: 0,
                             marker,
                             payload_type,
                             sequence_number,
                             timestamp,
-                            ssrc,
+                            ssrc: ssrc_from_event,
                             csrc: vec![],
                             extensions: None,
                         };
@@ -927,16 +945,8 @@ impl RtpSession {
                         let packet = RtpPacket {
                             header,
                             payload: payload.clone(),
-                            padding_size: 0,
+                            padding_size,
                         };
-
-                        // Update stats
-                        {
-                            let mut session_stats = stats_recv.lock();
-                            session_stats.packets_received += 1;
-                            session_stats.bytes_received += payload.len() as u64 + 12; // payload + header
-                            session_stats.remote_addr = Some(source);
-                        }
 
                         // Use the SSRC from the event
                         let packet_ssrc = ssrc_from_event;
@@ -950,14 +960,52 @@ impl RtpSession {
                         // before we forward the packet.
                         let (is_new_stream, output_packet) = {
                             let mut created = false;
+                            let mut entry = streams_map.entry(packet_ssrc).or_insert_with(|| {
+                                created = true;
+                                info!("New RTP stream detected with SSRC={:08x}", packet_ssrc);
+                                let mut stream = RtpStream::new(packet_ssrc, clock_rate);
+                                if let Some(sender_report) =
+                                    received_sender_reports.get(&packet_ssrc)
+                                {
+                                    stream.update_last_sr_info(
+                                        sender_report.lsr,
+                                        sender_report.received_at,
+                                    );
+                                }
+                                stream
+                            });
+
+                            let before = entry.get_stats();
+                            let output = entry.process_packet(packet);
+                            let after = entry.get_stats();
+                            let jitter_ms = entry.get_jitter_ms();
+                            drop(entry);
+
+                            // Session counters are aggregate stream deltas.
+                            // Every datagram, including duplicates and late
+                            // packets, remains deliverable with buffering off.
                             {
-                                let _entry = streams_map.entry(packet_ssrc).or_insert_with(|| {
-                                    created = true;
-                                    info!("New RTP stream detected with SSRC={:08x}", packet_ssrc);
-                                    RtpStream::new(packet_ssrc, clock_rate)
-                                });
+                                let mut session_stats = stats_recv.lock();
+                                session_stats.packets_received += 1;
+                                session_stats.bytes_received +=
+                                    payload.len() as u64 + 12 + u64::from(padding_size);
+                                session_stats.packets_lost = session_stats
+                                    .packets_lost
+                                    .saturating_sub(before.packets_lost)
+                                    .saturating_add(after.packets_lost);
+                                session_stats.packets_duplicated = session_stats
+                                    .packets_duplicated
+                                    .saturating_sub(before.duplicates)
+                                    .saturating_add(after.duplicates);
+                                session_stats.packets_out_of_order = session_stats
+                                    .packets_out_of_order
+                                    .saturating_sub(before.packets_out_of_order)
+                                    .saturating_add(after.packets_out_of_order);
+                                session_stats.jitter_ms = jitter_ms;
+                                session_stats.remote_addr = Some(source);
                             }
-                            (created, Some(packet.clone()))
+
+                            (created, output)
                         };
 
                         // If this is a new stream, emit the NewStreamDetected event
@@ -1029,6 +1077,8 @@ impl RtpSession {
             let ssrc = self.ssrc;
             let event_tx = self.event_tx.clone();
             let stats = self.stats.clone();
+            let sender_octets = self.sender_octets.clone();
+            let report_streams = self.streams.clone();
             let active_state = Arc::new(tokio::sync::Mutex::new(true));
             let _active_state_clone = active_state.clone();
             let bandwidth = self.bandwidth_bps;
@@ -1056,15 +1106,16 @@ impl RtpSession {
                     // Update RTP statistics before sending the report
                     {
                         let session_stats = stats.lock();
-                        rtcp_generator.update_sent_stats(
+                        rtcp_generator.set_sent_totals(
                             session_stats.packets_sent as u32,
-                            session_stats.bytes_sent as u32,
+                            sender_octets.load(Ordering::Relaxed) as u32,
                         );
 
                         // Log the current stats for debugging
                         debug!(
-                            "Current stats for RTCP report: packets={}, bytes={}",
-                            session_stats.packets_sent, session_stats.bytes_sent
+                            "Current stats for RTCP report: packets={}, payload_octets={}",
+                            session_stats.packets_sent,
+                            sender_octets.load(Ordering::Relaxed)
                         );
                     }
 
@@ -1078,7 +1129,8 @@ impl RtpSession {
                         .unwrap_or_default()
                         .as_millis() as u32;
 
-                    let sr = rtcp_generator.generate_sender_report(rtp_timestamp);
+                    let mut sr = rtcp_generator.generate_sender_report(rtp_timestamp);
+                    sr.report_blocks = take_rtcp_report_blocks(&report_streams);
                     let sdes = rtcp_generator.generate_sdes();
 
                     // Create compound packet
@@ -1421,7 +1473,7 @@ impl RtpSession {
 
         // Create the stream
         info!("Manually creating new RTP stream for SSRC={:08x}", ssrc);
-        let stream = if self.config.enable_jitter_buffer {
+        let mut stream = if self.config.enable_jitter_buffer {
             debug!("Creating stream with jitter buffer for SSRC={:08x}", ssrc);
             RtpStream::with_jitter_buffer(
                 ssrc,
@@ -1436,6 +1488,9 @@ impl RtpSession {
             );
             RtpStream::new(ssrc, self.config.clock_rate)
         };
+        if let Some(sender_report) = self.received_sender_reports.get(&ssrc) {
+            stream.update_last_sr_info(sender_report.lsr, sender_report.received_at);
+        }
 
         // The contains_key check above is racy w.r.t. the recv hot
         // path also inserting on first packet; `entry()` arbitrates.
@@ -1538,28 +1593,11 @@ impl RtpSession {
 
         // Set packet and octet count from session stats
         sr.sender_packet_count = session_stats.packets_sent as u32;
-        sr.sender_octet_count = session_stats.bytes_sent as u32;
+        sr.sender_octet_count = self.sender_octets.load(Ordering::Relaxed) as u32;
 
         // Add report blocks for active streams (remote SSRCs we're receiving from)
         // Up to 31 streams per RTCP packet.
-        for entry in self.streams.iter().take(31) {
-            let ssrc = *entry.key();
-            let stream_stats = entry.value().get_stats();
-
-            // Create a report block for this source
-            let mut block = crate::packet::rtcp::RtcpReportBlock::new(ssrc);
-
-            // Set statistics
-            let (fraction_lost, cumulative_lost) = rtcp_loss_fields(&stream_stats);
-
-            block.fraction_lost = fraction_lost;
-            block.cumulative_lost = cumulative_lost;
-            block.highest_seq = stream_stats.highest_seq;
-            block.jitter = stream_stats.jitter;
-
-            // TODO: Set last_sr and delay_since_last_sr when we process incoming SRs
-
-            // Add the block to the SR
+        for block in take_rtcp_report_blocks(&self.streams) {
             sr.add_report_block(block);
         }
 
@@ -1614,24 +1652,7 @@ impl RtpSession {
 
         // Add report blocks for active streams (remote SSRCs we're receiving from)
         // Up to 31 streams per RTCP packet.
-        for entry in self.streams.iter().take(31) {
-            let ssrc = *entry.key();
-            let stream_stats = entry.value().get_stats();
-
-            // Create a report block for this source
-            let mut block = crate::packet::rtcp::RtcpReportBlock::new(ssrc);
-
-            // Set statistics
-            let (fraction_lost, cumulative_lost) = rtcp_loss_fields(&stream_stats);
-
-            block.fraction_lost = fraction_lost;
-            block.cumulative_lost = cumulative_lost;
-            block.highest_seq = stream_stats.highest_seq;
-            block.jitter = stream_stats.jitter;
-
-            // TODO: Set last_sr and delay_since_last_sr when we process incoming SRs
-
-            // Add the block to the RR
+        for block in take_rtcp_report_blocks(&self.streams) {
             rr.add_report_block(block);
         }
 
@@ -1762,22 +1783,39 @@ impl RtpSessionSender {
 mod tests {
     use super::*;
 
-    #[test]
-    fn rtcp_loss_uses_sequence_tracker_not_duplicate_inclusive_receive_count() {
-        let stats = RtpStreamStats {
-            first_seq: 65_535,
-            highest_seq: 65_537,
-            packets_received: 3,
-            received: 3,
-            packets_lost: 1,
-            ..RtpStreamStats::default()
-        };
+    async fn next_packet_event(events: &mut broadcast::Receiver<RtpSessionEvent>) -> RtpPacket {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if let RtpSessionEvent::PacketReceived(packet) = events.recv().await.unwrap() {
+                    return packet;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for RTP packet event")
+    }
 
-        // The three receive calls include a duplicate, so comparing the raw
-        // receive count with the three expected sequence positions would
-        // incorrectly report no loss. The tracker still has one missing
-        // sequence across the wrap.
-        assert_eq!(rtcp_loss_fields(&stats), (85, 1));
+    async fn send_raw_rtp(
+        peer: &UdpSocket,
+        destination: SocketAddr,
+        sequence_number: u16,
+        timestamp: u32,
+        ssrc: u32,
+    ) {
+        let packet = RtpPacket::new(
+            RtpHeader::new(96, sequence_number, timestamp, ssrc),
+            Bytes::from_static(b"media"),
+        );
+        peer.send_to(&packet.serialize().unwrap(), destination)
+            .await
+            .unwrap();
+    }
+
+    fn parse_receiver_report(data: &[u8]) -> crate::packet::rtcp::RtcpReceiverReport {
+        match crate::packet::rtcp::RtcpPacket::parse(data).unwrap() {
+            crate::packet::rtcp::RtcpPacket::ReceiverReport(report) => report,
+            packet => panic!("expected receiver report, got {packet:?}"),
+        }
     }
 
     #[test]
@@ -1860,6 +1898,390 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(error, Error::SessionError(_)));
+    }
+
+    #[tokio::test]
+    async fn live_session_tracks_wrap_reordering_and_duplicates_without_buffering() {
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let local_ssrc = 0x0102_0304;
+        let remote_ssrc = 0xa1a2_a3a4;
+        let session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ssrc: Some(local_ssrc),
+            // The default requests a jitter buffer. Production receive
+            // tracking intentionally remains unbuffered in this repair.
+            enable_jitter_buffer: true,
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        let destination = session.local_addr().unwrap();
+        let mut events = session.subscribe();
+
+        for (sequence, timestamp) in [(65535, 0), (1, 320), (1, 320), (0, 160)] {
+            send_raw_rtp(&peer, destination, sequence, timestamp, remote_ssrc).await;
+        }
+
+        let mut received_sequences = Vec::new();
+        for _ in 0..4 {
+            let packet = next_packet_event(&mut events).await;
+            assert_eq!(packet.header.ssrc, remote_ssrc);
+            received_sequences.push(packet.header.sequence_number);
+        }
+        assert_eq!(received_sequences, vec![65535, 1, 1, 0]);
+
+        let stream = session.get_stream(remote_ssrc).await.unwrap();
+        assert_eq!(stream.highest_seq, 65_537);
+        assert_eq!(stream.packets_lost, 0);
+        assert_eq!(stream.duplicates, 1);
+        assert_eq!(stream.packets_out_of_order, 1);
+
+        let stats = session.get_stats();
+        assert_eq!(stats.packets_received, 4);
+        assert_eq!(stats.packets_lost, 0);
+        assert_eq!(stats.packets_duplicated, 1);
+        assert_eq!(stats.packets_out_of_order, 1);
+    }
+
+    #[tokio::test]
+    async fn plain_udp_session_preserves_rtp_padding_and_remote_ssrc() {
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ssrc: Some(0x1111_1111),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        let mut events = session.subscribe();
+
+        let mut header = RtpHeader::new(96, 7, 960, 0x2222_2222);
+        header.padding = true;
+        let packet = RtpPacket {
+            header,
+            payload: Bytes::from_static(b"padded payload"),
+            padding_size: 4,
+        };
+        let wire = packet.serialize().unwrap();
+        peer.send_to(&wire, session.local_addr().unwrap())
+            .await
+            .unwrap();
+
+        let received = next_packet_event(&mut events).await;
+        assert_eq!(received.header.ssrc, 0x2222_2222);
+        assert!(received.header.padding);
+        assert_eq!(received.padding_size, 4);
+        assert_eq!(received.payload, Bytes::from_static(b"padded payload"));
+        assert_eq!(received.serialize().unwrap(), wire);
+        assert_eq!(session.get_stats().bytes_received, wire.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn srtp_session_preserves_encrypted_rtp_padding() {
+        use crate::srtp::{SrtpContext, SrtpCryptoKey, SRTP_AES128_CM_SHA1_80};
+
+        fn context() -> SrtpContext {
+            SrtpContext::new(
+                SRTP_AES128_CM_SHA1_80,
+                SrtpCryptoKey::new(vec![0x11; 16], vec![0x22; 14]),
+            )
+            .unwrap()
+        }
+
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        let transport = session.transport();
+        let udp = transport
+            .as_any()
+            .downcast_ref::<UdpRtpTransport>()
+            .unwrap();
+        udp.set_srtp_contexts(context(), context()).await.unwrap();
+        let mut events = session.subscribe();
+
+        let mut header = RtpHeader::new(96, 19, 3_040, 0x3333_3333);
+        header.padding = true;
+        let packet = RtpPacket {
+            header,
+            payload: Bytes::from_static(b"secret padded payload"),
+            padding_size: 8,
+        };
+        let mut sender = context();
+        let protected = sender.protect(&packet).unwrap().serialize().unwrap();
+        peer.send_to(&protected, session.local_addr().unwrap())
+            .await
+            .unwrap();
+
+        let received = next_packet_event(&mut events).await;
+        assert_eq!(received.header.ssrc, 0x3333_3333);
+        assert!(received.header.padding);
+        assert_eq!(received.padding_size, 8);
+        assert_eq!(received.payload, packet.payload);
+        assert_eq!(received.serialize().unwrap(), packet.serialize().unwrap());
+    }
+
+    #[tokio::test]
+    async fn production_rtcp_ingress_processes_members_around_unknown_packet() {
+        use crate::packet::rtcp::{
+            RtcpCompoundMember, RtcpGoodbye, RtcpPacket, RtcpReceiverReport, RtcpReportBlock,
+            RtcpTolerantCompoundPacket, RtcpUnknownPacket,
+        };
+
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ssrc: Some(0x4444_4444),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        let mut events = session.subscribe();
+        let remote_ssrc = 0x5555_5555;
+        let mut receiver_report = RtcpReceiverReport::new(remote_ssrc);
+        let mut outbound_loss = RtcpReportBlock::new(0x4444_4444);
+        outbound_loss.cumulative_lost = 99;
+        receiver_report.add_report_block(outbound_loss);
+        let compound = RtcpTolerantCompoundPacket {
+            packets: vec![
+                RtcpCompoundMember::Known(RtcpPacket::ReceiverReport(receiver_report)),
+                RtcpCompoundMember::Unknown(RtcpUnknownPacket {
+                    packet_type: 205,
+                    count: 1,
+                    payload: Bytes::from_static(&[0xaa, 0xbb, 0xcc, 0xdd]),
+                    padding: Bytes::new(),
+                }),
+                RtcpCompoundMember::Known(RtcpPacket::Goodbye(RtcpGoodbye::new_for_source(
+                    remote_ssrc,
+                ))),
+            ],
+        };
+        peer.send_to(
+            &compound.serialize().unwrap(),
+            session.local_addr().unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let (mut saw_report, mut saw_bye) = (false, false);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !(saw_report && saw_bye) {
+                match events.recv().await.unwrap() {
+                    RtpSessionEvent::RtcpReceiverReport { ssrc, .. } => {
+                        assert_eq!(ssrc, remote_ssrc);
+                        saw_report = true;
+                    }
+                    RtpSessionEvent::Bye { ssrc, .. } => {
+                        assert_eq!(ssrc, remote_ssrc);
+                        saw_bye = true;
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("known RTCP members after an unknown member were not processed");
+        assert_eq!(session.get_stats().packets_lost, 0);
+    }
+
+    #[tokio::test]
+    async fn malformed_compound_rtcp_is_rejected_atomically_in_production() {
+        async fn assert_no_event(data: &[u8]) {
+            let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let session = RtpSession::new(RtpSessionConfig {
+                local_addr: "127.0.0.1:0".parse().unwrap(),
+                ..RtpSessionConfig::default()
+            })
+            .await
+            .unwrap();
+            let mut events = session.subscribe();
+            peer.send_to(data, session.local_addr().unwrap())
+                .await
+                .unwrap();
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), events.recv())
+                    .await
+                    .is_err()
+            );
+        }
+
+        let rr = [0x80, 201, 0, 1, 0x12, 0x34, 0x56, 0x78];
+
+        let mut bad_trailing_version = rr.to_vec();
+        bad_trailing_version.extend_from_slice(&[0x40, 205, 0, 1, 0, 0, 0, 0]);
+        assert_no_event(&bad_trailing_version).await;
+
+        let declared_overrun = [0x80, 201, 0, 10, 0x12, 0x34, 0x56, 0x78];
+        assert_no_event(&declared_overrun).await;
+
+        let mut non_final_padding = rr.to_vec();
+        non_final_padding.extend_from_slice(&[0xa0, 205, 0, 1, 0, 0, 0, 4]);
+        non_final_padding.extend_from_slice(&[0x80, 203, 0, 1, 0, 0, 0, 1]);
+        assert_no_event(&non_final_padding).await;
+    }
+
+    #[tokio::test]
+    async fn manual_reports_use_interval_loss_and_retain_cumulative_loss() {
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+        let mut session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        // Configure the destination after construction so this manual-report
+        // test has no periodic RTCP task racing its assertions.
+        session.set_remote_addr(peer_addr).await;
+        let destination = session.local_addr().unwrap();
+        let remote_ssrc = 0x6666_6666;
+        let mut events = session.subscribe();
+
+        for (sequence, timestamp) in [(10, 0), (12, 320)] {
+            send_raw_rtp(&peer, destination, sequence, timestamp, remote_ssrc).await;
+            next_packet_event(&mut events).await;
+        }
+        session.send_receiver_report().await.unwrap();
+        let mut buffer = [0u8; 2048];
+        let (size, _) = tokio::time::timeout(Duration::from_secs(1), peer.recv_from(&mut buffer))
+            .await
+            .unwrap()
+            .unwrap();
+        let first = parse_receiver_report(&buffer[..size]);
+        assert_eq!(first.report_blocks[0].fraction_lost, 85);
+        assert_eq!(first.report_blocks[0].cumulative_lost, 1);
+
+        for (offset, sequence) in (13..=20).enumerate() {
+            send_raw_rtp(
+                &peer,
+                destination,
+                sequence,
+                480 + offset as u32 * 160,
+                remote_ssrc,
+            )
+            .await;
+            next_packet_event(&mut events).await;
+        }
+        session.send_receiver_report().await.unwrap();
+        let (size, _) = tokio::time::timeout(Duration::from_secs(1), peer.recv_from(&mut buffer))
+            .await
+            .unwrap()
+            .unwrap();
+        let second = parse_receiver_report(&buffer[..size]);
+        assert_eq!(second.report_blocks[0].fraction_lost, 0);
+        assert_eq!(second.report_blocks[0].cumulative_lost, 1);
+    }
+
+    #[tokio::test]
+    async fn sr_before_rtp_populates_manual_and_periodic_lsr_dlsr() {
+        use crate::packet::rtcp::{
+            NtpTimestamp, RtcpCompoundMember, RtcpCompoundPacket, RtcpPacket, RtcpSenderReport,
+        };
+
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+        let session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            remote_addr: Some(peer_addr),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        let destination = session.local_addr().unwrap();
+        let remote_ssrc = 0x7777_7777;
+        let mut events = session.subscribe();
+
+        let mut sender_report = RtcpSenderReport::new(remote_ssrc);
+        sender_report.ntp_timestamp = NtpTimestamp {
+            seconds: 0xaaaa_1234,
+            fraction: 0x5678_bbbb,
+        };
+        let sender_report_wire = RtcpCompoundPacket::new_with_sr(sender_report)
+            .serialize()
+            .unwrap();
+        peer.send_to(&sender_report_wire, destination)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if matches!(
+                    events.recv().await.unwrap(),
+                    RtpSessionEvent::RtcpSenderReport { ssrc, .. } if ssrc == remote_ssrc
+                ) {
+                    break;
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        send_raw_rtp(&peer, destination, 1, 160, remote_ssrc).await;
+        next_packet_event(&mut events).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        session.send_receiver_report().await.unwrap();
+        let mut buffer = [0u8; 2048];
+        let (size, _) = tokio::time::timeout(Duration::from_secs(1), peer.recv_from(&mut buffer))
+            .await
+            .unwrap()
+            .unwrap();
+        let manual = parse_receiver_report(&buffer[..size]);
+        assert_eq!(manual.report_blocks[0].last_sr, 0x1234_5678);
+        assert!(manual.report_blocks[0].delay_since_last_sr > 0);
+
+        let (size, _) = tokio::time::timeout(Duration::from_secs(2), peer.recv_from(&mut buffer))
+            .await
+            .expect("periodic RTCP report was not sent")
+            .unwrap();
+        let periodic = RtcpCompoundPacket::parse_tolerant(&buffer[..size]).unwrap();
+        let periodic_sr = periodic
+            .packets
+            .iter()
+            .find_map(|member| match member {
+                RtcpCompoundMember::Known(RtcpPacket::SenderReport(report)) => Some(report),
+                _ => None,
+            })
+            .expect("periodic compound packet did not contain a sender report");
+        assert_eq!(periodic_sr.report_blocks[0].last_sr, 0x1234_5678);
+        assert!(periodic_sr.report_blocks[0].delay_since_last_sr > 0);
+    }
+
+    #[tokio::test]
+    async fn sender_report_octet_count_excludes_rtp_header() {
+        use crate::packet::rtcp::{RtcpPacket, RtcpSenderReport};
+
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        session.set_remote_addr(peer.local_addr().unwrap()).await;
+        session
+            .send_packet(160, Bytes::from_static(b"12345"), false)
+            .await
+            .unwrap();
+
+        let mut buffer = [0u8; 2048];
+        tokio::time::timeout(Duration::from_secs(1), peer.recv_from(&mut buffer))
+            .await
+            .unwrap()
+            .unwrap();
+        session.send_sender_report().await.unwrap();
+        let (size, _) = tokio::time::timeout(Duration::from_secs(1), peer.recv_from(&mut buffer))
+            .await
+            .unwrap()
+            .unwrap();
+        let report: RtcpSenderReport = match RtcpPacket::parse(&buffer[..size]).unwrap() {
+            RtcpPacket::SenderReport(report) => report,
+            packet => panic!("expected sender report, got {packet:?}"),
+        };
+        assert_eq!(report.sender_packet_count, 1);
+        assert_eq!(report.sender_octet_count, 5);
     }
 
     #[tokio::test]

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -64,6 +64,26 @@ pub const RTP_SESSION_CHANNEL_CAPACITY: usize = 64;
 /// [`RtpSession::receive_packet`].
 pub const RTP_SESSION_RECEIVE_QUEUE_CAPACITY: usize = 32;
 
+/// Build the RTCP loss fields from the sequence-aware stream tracker.
+///
+/// `packets_received` includes duplicates and reordered arrivals, so deriving
+/// loss from that counter can hide a real sequence gap. The stream's bounded
+/// extended-sequence tracker is the source of truth for cumulative loss.
+fn rtcp_loss_fields(stats: &RtpStreamStats) -> (u8, u32) {
+    let expected = stats
+        .highest_seq
+        .saturating_sub(stats.first_seq)
+        .saturating_add(1);
+    if expected == 0 {
+        return (0, 0);
+    }
+
+    let lost_in_range = stats.packets_lost.min(u64::from(expected));
+    let fraction = ((lost_in_range * 256) / u64::from(expected)).min(255) as u8;
+    let cumulative = stats.packets_lost.min(0x00ff_ffff) as u32;
+    (fraction, cumulative)
+}
+
 /// RTP session queue sizing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RtpSessionBufferConfig {
@@ -1530,12 +1550,10 @@ impl RtpSession {
             let mut block = crate::packet::rtcp::RtcpReportBlock::new(ssrc);
 
             // Set statistics
-            let expected_packets = stream_stats.highest_seq - stream_stats.first_seq + 1;
-            let (fraction_lost, cumulative_lost) =
-                block.calculate_packet_loss(expected_packets, stream_stats.received);
+            let (fraction_lost, cumulative_lost) = rtcp_loss_fields(&stream_stats);
 
             block.fraction_lost = fraction_lost;
-            block.cumulative_lost = cumulative_lost as u32;
+            block.cumulative_lost = cumulative_lost;
             block.highest_seq = stream_stats.highest_seq;
             block.jitter = stream_stats.jitter;
 
@@ -1604,12 +1622,10 @@ impl RtpSession {
             let mut block = crate::packet::rtcp::RtcpReportBlock::new(ssrc);
 
             // Set statistics
-            let expected_packets = stream_stats.highest_seq - stream_stats.first_seq + 1;
-            let (fraction_lost, cumulative_lost) =
-                block.calculate_packet_loss(expected_packets, stream_stats.received);
+            let (fraction_lost, cumulative_lost) = rtcp_loss_fields(&stream_stats);
 
             block.fraction_lost = fraction_lost;
-            block.cumulative_lost = cumulative_lost as u32;
+            block.cumulative_lost = cumulative_lost;
             block.highest_seq = stream_stats.highest_seq;
             block.jitter = stream_stats.jitter;
 
@@ -1745,6 +1761,24 @@ impl RtpSessionSender {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rtcp_loss_uses_sequence_tracker_not_duplicate_inclusive_receive_count() {
+        let stats = RtpStreamStats {
+            first_seq: 65_535,
+            highest_seq: 65_537,
+            packets_received: 3,
+            received: 3,
+            packets_lost: 1,
+            ..RtpStreamStats::default()
+        };
+
+        // The three receive calls include a duplicate, so comparing the raw
+        // receive count with the three expected sequence positions would
+        // incorrectly report no loss. The tracker still has one missing
+        // sequence across the wrap.
+        assert_eq!(rtcp_loss_fields(&stats), (85, 1));
+    }
 
     #[test]
     fn default_session_buffer_config_preserves_channel_capacities() {

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -74,6 +74,21 @@ fn take_rtcp_report_blocks(
         .collect()
 }
 
+fn sender_report_totals(
+    stats: &parking_lot::Mutex<RtpSessionStats>,
+    sender_octets: &AtomicU64,
+) -> (u32, u32) {
+    // Packet sends update both counters while holding this lock. Keep the
+    // guard while loading the atomic octet counter so an RTCP report cannot
+    // combine the packet total from one send with the octet total from the
+    // next one.
+    let stats = stats.lock();
+    (
+        stats.packets_sent as u32,
+        sender_octets.load(Ordering::Relaxed) as u32,
+    )
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ReceivedSenderReport {
     lsr: u32,
@@ -1104,20 +1119,15 @@ impl RtpSession {
                     }
 
                     // Update RTP statistics before sending the report
-                    {
-                        let session_stats = stats.lock();
-                        rtcp_generator.set_sent_totals(
-                            session_stats.packets_sent as u32,
-                            sender_octets.load(Ordering::Relaxed) as u32,
-                        );
+                    let (sender_packet_count, sender_octet_count) =
+                        sender_report_totals(&stats, &sender_octets);
+                    rtcp_generator.set_sent_totals(sender_packet_count, sender_octet_count);
 
-                        // Log the current stats for debugging
-                        debug!(
-                            "Current stats for RTCP report: packets={}, payload_octets={}",
-                            session_stats.packets_sent,
-                            sender_octets.load(Ordering::Relaxed)
-                        );
-                    }
+                    // Log the current stats for debugging
+                    debug!(
+                        "Current stats for RTCP report: packets={}, payload_octets={}",
+                        sender_packet_count, sender_octet_count
+                    );
 
                     // Send an RTCP report regardless of should_send_report logic for this example
                     // We'll send a compound packet with SR and SDES
@@ -1567,8 +1577,10 @@ impl RtpSession {
             }
         };
 
-        // Get session stats
-        let session_stats = self.stats.lock().clone();
+        // Snapshot both sender totals while holding the same lock used by the
+        // packet-send update so the report cannot mix two send generations.
+        let (sender_packet_count, sender_octet_count) =
+            sender_report_totals(&self.stats, &self.sender_octets);
 
         // Create a new SR packet
         let mut sr = crate::packet::rtcp::RtcpSenderReport::new(self.ssrc);
@@ -1580,8 +1592,8 @@ impl RtpSession {
         sr.rtp_timestamp = self.get_timestamp();
 
         // Set packet and octet count from session stats
-        sr.sender_packet_count = session_stats.packets_sent as u32;
-        sr.sender_octet_count = self.sender_octets.load(Ordering::Relaxed) as u32;
+        sr.sender_packet_count = sender_packet_count;
+        sr.sender_octet_count = sender_octet_count;
 
         // Add report blocks for active streams (remote SSRCs we're receiving from)
         // Up to 31 streams per RTCP packet.
@@ -1826,6 +1838,39 @@ mod tests {
             config.transport_buffer_config,
             RtpTransportBufferConfig::default()
         );
+    }
+
+    #[test]
+    fn sender_report_totals_wait_for_a_complete_concurrent_update() {
+        let stats = Arc::new(parking_lot::Mutex::new(RtpSessionStats::default()));
+        let sender_octets = Arc::new(AtomicU64::new(0));
+        let (packet_count_updated_tx, packet_count_updated_rx) = std::sync::mpsc::channel();
+        let (finish_update_tx, finish_update_rx) = std::sync::mpsc::channel();
+
+        let update_stats = stats.clone();
+        let update_octets = sender_octets.clone();
+        let updater = std::thread::spawn(move || {
+            let mut stats = update_stats.lock();
+            stats.packets_sent = 1;
+            packet_count_updated_tx.send(()).unwrap();
+            finish_update_rx.recv().unwrap();
+            update_octets.store(5, Ordering::Relaxed);
+        });
+
+        packet_count_updated_rx.recv().unwrap();
+        let (snapshot_started_tx, snapshot_started_rx) = std::sync::mpsc::channel();
+        let snapshot_stats = stats.clone();
+        let snapshot_octets = sender_octets.clone();
+        let snapshot = std::thread::spawn(move || {
+            snapshot_started_tx.send(()).unwrap();
+            sender_report_totals(&snapshot_stats, &snapshot_octets)
+        });
+
+        snapshot_started_rx.recv().unwrap();
+        finish_update_tx.send(()).unwrap();
+
+        updater.join().unwrap();
+        assert_eq!(snapshot.join().unwrap(), (1, 5));
     }
 
     #[tokio::test]

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -1471,6 +1471,14 @@ impl RtpSession {
     /// This is useful when we want to ensure a stream exists for an SSRC
     /// even if no packets have been received yet.
     pub async fn create_stream_for_ssrc(&mut self, ssrc: RtpSsrc) -> bool {
+        self.create_stream_for_ssrc_after(ssrc, std::future::ready(()))
+            .await
+    }
+
+    async fn create_stream_for_ssrc_after<F>(&mut self, ssrc: RtpSsrc, before_insert: F) -> bool
+    where
+        F: std::future::Future<Output = ()>,
+    {
         // Check if this SSRC already exists. The contains_key + insert
         // pair has a benign race (two callers may both decide "new" and
         // race the insert), but we only need a stable per-SSRC entry —
@@ -1485,10 +1493,12 @@ impl RtpSession {
         // first-packet path stays unbuffered makes precreated streams hold the
         // second sequential packet and can reverse later delivery.
         info!("Manually creating new RTP stream for SSRC={:08x}", ssrc);
-        let mut stream = RtpStream::new(ssrc, self.config.clock_rate);
-        if let Some(sender_report) = self.received_sender_reports.get(&ssrc) {
-            stream.update_last_sr_info(sender_report.lsr, sender_report.received_at);
-        }
+        let stream = RtpStream::new(ssrc, self.config.clock_rate);
+
+        // Production passes an immediately-ready future. Keeping the
+        // insertion boundary explicit lets the race regression deliver an SR
+        // after precreation has begun but before the stream becomes visible.
+        before_insert.await;
 
         // The contains_key check above is racy w.r.t. the recv hot
         // path also inserting on first packet; `entry()` arbitrates.
@@ -1503,6 +1513,19 @@ impl RtpSession {
         }
         if !closure_ran {
             return false;
+        }
+
+        // Reconcile retained SR state only after the stream is visible. This
+        // closes both sides of the handoff with the RTCP task, which stores
+        // the SR first and then looks up the stream: an SR arriving before
+        // insertion is found here, while one arriving after insertion is
+        // applied by the RTCP task. Lock the visible stream first so a newer
+        // RTCP update waits behind reconciliation and cannot be overwritten
+        // by an older retained snapshot.
+        if let Some(mut stream) = self.streams.get_mut(&ssrc) {
+            if let Some(sender_report) = self.received_sender_reports.get(&ssrc) {
+                stream.update_last_sr_info(sender_report.lsr, sender_report.received_at);
+            }
         }
 
         // Emit the new stream event
@@ -2004,6 +2027,71 @@ mod tests {
         let stream = session.get_stream(remote_ssrc).await.unwrap();
         assert_eq!(stream.packets_received, 2);
         assert_eq!(stream.highest_seq, 101);
+    }
+
+    #[tokio::test]
+    async fn precreated_stream_reconciles_sender_report_during_insert_handoff() {
+        use crate::packet::rtcp::{NtpTimestamp, RtcpCompoundPacket, RtcpSenderReport};
+
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        session.set_remote_addr(peer.local_addr().unwrap()).await;
+        let destination = session.local_addr().unwrap();
+        let remote_ssrc = 0xc1c2_c3c4;
+        let mut events = session.subscribe();
+
+        let mut sender_report = RtcpSenderReport::new(remote_ssrc);
+        sender_report.ntp_timestamp = NtpTimestamp {
+            seconds: 0xaaaa_1234,
+            fraction: 0x5678_bbbb,
+        };
+        let sender_report_wire = RtcpCompoundPacket::new_with_sr(sender_report)
+            .serialize()
+            .unwrap();
+
+        // Pause production precreation immediately before insertion. The
+        // receive task must retain the SR and observe that no stream exists;
+        // precreation then inserts the stream and reconciles that retained SR.
+        let report_during_handoff = async {
+            peer.send_to(&sender_report_wire, destination)
+                .await
+                .unwrap();
+            tokio::time::timeout(Duration::from_secs(1), async {
+                loop {
+                    if matches!(
+                        events.recv().await.unwrap(),
+                        RtpSessionEvent::RtcpSenderReport { ssrc, .. } if ssrc == remote_ssrc
+                    ) {
+                        break;
+                    }
+                }
+            })
+            .await
+            .expect("sender report was not processed during precreation");
+        };
+        assert!(
+            session
+                .create_stream_for_ssrc_after(remote_ssrc, report_during_handoff)
+                .await
+        );
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        session.send_receiver_report().await.unwrap();
+        let mut buffer = [0u8; 2048];
+        let (size, _) = tokio::time::timeout(Duration::from_secs(1), peer.recv_from(&mut buffer))
+            .await
+            .unwrap()
+            .unwrap();
+        let report = parse_receiver_report(&buffer[..size]);
+        assert_eq!(report.report_blocks.len(), 1);
+        assert_eq!(report.report_blocks[0].ssrc, remote_ssrc);
+        assert_eq!(report.report_blocks[0].last_sr, 0x1234_5678);
+        assert!(report.report_blocks[0].delay_since_last_sr > 0);
     }
 
     #[tokio::test]

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -732,117 +732,148 @@ impl RtpSession {
             loop {
                 match transport_events.recv().await {
                     Ok(crate::traits::RtpEvent::RtcpReceived { data, source: _ }) => {
-                        // Try to parse the RTCP packet
-                        if let Ok(rtcp_packet) = crate::packet::rtcp::RtcpPacket::parse(&data) {
-                            // Handle the RTCP packet based on its type
-                            match rtcp_packet {
-                                crate::packet::rtcp::RtcpPacket::Goodbye(bye) => {
-                                    // Extract the SSRC and reason
-                                    if !bye.sources.is_empty() {
-                                        let source_ssrc = bye.sources[0];
+                        // Parse the complete compound packet. Unknown but
+                        // well-formed members are retained by the tolerant
+                        // parser and ignored by the production handler.
+                        match crate::packet::rtcp::RtcpCompoundPacket::parse_tolerant(&data) {
+                            Ok(compound) => {
+                                for rtcp_member in compound.packets {
+                                    let rtcp_packet = match rtcp_member {
+                                        crate::packet::rtcp::RtcpCompoundMember::Known(packet) => {
+                                            packet
+                                        }
+                                        crate::packet::rtcp::RtcpCompoundMember::Unknown(
+                                            unknown,
+                                        ) => {
+                                            trace!(
+                                                "Ignoring unimplemented RTCP packet type {}",
+                                                unknown.packet_type
+                                            );
+                                            continue;
+                                        }
+                                    };
+                                    match rtcp_packet {
+                                        crate::packet::rtcp::RtcpPacket::Goodbye(bye) => {
+                                            // Extract the SSRC and reason
+                                            if !bye.sources.is_empty() {
+                                                let source_ssrc = bye.sources[0];
 
-                                        // Broadcast BYE event
-                                        let _ = event_tx_recv.send(RtpSessionEvent::Bye {
-                                            ssrc: source_ssrc,
-                                            reason: bye.reason,
-                                        });
+                                                // Broadcast BYE event
+                                                let _ = event_tx_recv.send(RtpSessionEvent::Bye {
+                                                    ssrc: source_ssrc,
+                                                    reason: bye.reason,
+                                                });
 
-                                        info!("Received RTCP BYE from SSRC={:08x}", source_ssrc);
-                                    }
-                                }
-                                crate::packet::rtcp::RtcpPacket::SenderReport(sr) => {
-                                    // Process sender report
-                                    let report_ssrc = sr.ssrc;
+                                                info!(
+                                                    "Received RTCP BYE from SSRC={:08x}",
+                                                    source_ssrc
+                                                );
+                                            }
+                                        }
+                                        crate::packet::rtcp::RtcpPacket::SenderReport(sr) => {
+                                            // Process sender report
+                                            let report_ssrc = sr.ssrc;
 
-                                    debug!("Received RTCP SR from SSRC={:08x}", report_ssrc);
+                                            debug!(
+                                                "Received RTCP SR from SSRC={:08x}",
+                                                report_ssrc
+                                            );
 
-                                    // Update stream statistics if this stream exists
-                                    if let Some(mut stream) = streams_map.get_mut(&report_ssrc) {
-                                        // Update the stream's RTCP SR info
-                                        // This will be used for calculating round-trip time
-                                        stream.update_last_sr_info(
-                                            sr.ntp_timestamp.to_u32(),
-                                            std::time::Instant::now(),
-                                        );
+                                            // Update stream statistics if this stream exists
+                                            if let Some(mut stream) =
+                                                streams_map.get_mut(&report_ssrc)
+                                            {
+                                                // Update the stream's RTCP SR info
+                                                // This will be used for calculating round-trip time
+                                                stream.update_last_sr_info(
+                                                    sr.ntp_timestamp.to_u32(),
+                                                    std::time::Instant::now(),
+                                                );
 
-                                        debug!(
-                                            "Updated RTCP SR info for stream SSRC={:08x}",
-                                            report_ssrc
-                                        );
-                                    }
+                                                debug!(
+                                                    "Updated RTCP SR info for stream SSRC={:08x}",
+                                                    report_ssrc
+                                                );
+                                            }
 
-                                    // If media sync is enabled, update it
-                                    if let Some(sync) = &media_sync {
-                                        if let Ok(mut media_sync) = sync.write() {
-                                            // Update synchronization data
-                                            media_sync.update_from_sr(
-                                                report_ssrc,
-                                                sr.ntp_timestamp,
-                                                sr.rtp_timestamp,
+                                            // If media sync is enabled, update it
+                                            if let Some(sync) = &media_sync {
+                                                if let Ok(mut media_sync) = sync.write() {
+                                                    // Update synchronization data
+                                                    media_sync.update_from_sr(
+                                                        report_ssrc,
+                                                        sr.ntp_timestamp,
+                                                        sr.rtp_timestamp,
+                                                    );
+                                                }
+                                            }
+
+                                            // Emit SR event for external processing
+                                            let _ = event_tx_recv.send(
+                                                RtpSessionEvent::RtcpSenderReport {
+                                                    ssrc: report_ssrc,
+                                                    ntp_timestamp: sr.ntp_timestamp,
+                                                    rtp_timestamp: sr.rtp_timestamp,
+                                                    packet_count: sr.sender_packet_count,
+                                                    octet_count: sr.sender_octet_count,
+                                                    report_blocks: sr.report_blocks,
+                                                },
                                             );
                                         }
-                                    }
+                                        crate::packet::rtcp::RtcpPacket::ReceiverReport(rr) => {
+                                            // Process receiver report
+                                            let report_ssrc = rr.ssrc;
 
-                                    // Emit SR event for external processing
-                                    let _ = event_tx_recv.send(RtpSessionEvent::RtcpSenderReport {
-                                        ssrc: report_ssrc,
-                                        ntp_timestamp: sr.ntp_timestamp,
-                                        rtp_timestamp: sr.rtp_timestamp,
-                                        packet_count: sr.sender_packet_count,
-                                        octet_count: sr.sender_octet_count,
-                                        report_blocks: sr.report_blocks,
-                                    });
-                                }
-                                crate::packet::rtcp::RtcpPacket::ReceiverReport(rr) => {
-                                    // Process receiver report
-                                    let report_ssrc = rr.ssrc;
-
-                                    debug!(
+                                            debug!(
                                         "Received RTCP RR from SSRC={:08x} with {} report blocks",
                                         report_ssrc,
                                         rr.report_blocks.len()
                                     );
 
-                                    // If there's a report block about our SSRC, process it
-                                    for block in &rr.report_blocks {
-                                        if block.ssrc == ssrc {
-                                            debug!(
+                                            // If there's a report block about our SSRC, process it
+                                            for block in &rr.report_blocks {
+                                                if block.ssrc == ssrc {
+                                                    debug!(
                                                 "Processing report block about our SSRC={:08x}",
                                                 ssrc
                                             );
 
-                                            // Update session stats with packet loss info
-                                            {
-                                                let mut stats = stats_recv.lock();
-                                                stats.packets_lost = block.cumulative_lost as u64;
+                                                    // Update session stats with packet loss info
+                                                    {
+                                                        let mut stats = stats_recv.lock();
+                                                        stats.packets_lost =
+                                                            block.cumulative_lost as u64;
 
-                                                // Calculate packet loss percentage
-                                                let fraction_lost =
-                                                    block.fraction_lost as f64 / 256.0;
-                                                debug!(
-                                                    "Packet loss: {}% (fraction={})",
-                                                    fraction_lost * 100.0,
-                                                    block.fraction_lost
-                                                );
+                                                        // Calculate packet loss percentage
+                                                        let fraction_lost =
+                                                            block.fraction_lost as f64 / 256.0;
+                                                        debug!(
+                                                            "Packet loss: {}% (fraction={})",
+                                                            fraction_lost * 100.0,
+                                                            block.fraction_lost
+                                                        );
+                                                    }
+                                                }
                                             }
+
+                                            // Emit RR event for external processing
+                                            let _ = event_tx_recv.send(
+                                                RtpSessionEvent::RtcpReceiverReport {
+                                                    ssrc: report_ssrc,
+                                                    report_blocks: rr.report_blocks,
+                                                },
+                                            );
+                                        }
+                                        // Handle other RTCP packet types as needed.
+                                        other => {
+                                            trace!("Received RTCP packet: {:?}", other);
                                         }
                                     }
-
-                                    // Emit RR event for external processing
-                                    let _ =
-                                        event_tx_recv.send(RtpSessionEvent::RtcpReceiverReport {
-                                            ssrc: report_ssrc,
-                                            report_blocks: rr.report_blocks,
-                                        });
-                                }
-                                // Handle other RTCP packet types as needed
-                                _ => {
-                                    // For now, we're just logging other packet types
-                                    trace!("Received RTCP packet: {:?}", rtcp_packet);
                                 }
                             }
-                        } else {
-                            warn!("Failed to parse RTCP packet");
+                            Err(error) => {
+                                warn!("Failed to parse compound RTCP packet: {}", error);
+                            }
                         }
                     }
                     Ok(crate::traits::RtpEvent::MediaReceived {
@@ -876,6 +907,7 @@ impl RtpSession {
                         let packet = RtpPacket {
                             header,
                             payload: payload.clone(),
+                            padding_size: 0,
                         };
 
                         // Update stats

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -1451,8 +1451,7 @@ impl RtpSession {
 
     /// Get a list of all SSRCs known to this session
     ///
-    /// This returns all SSRCs that have been seen, even if their streams
-    /// haven't released any packets from their jitter buffers yet.
+    /// This returns all SSRCs that have been seen or explicitly precreated.
     pub async fn get_all_ssrcs(&self) -> Vec<RtpSsrc> {
         self.streams.iter().map(|entry| *entry.key()).collect()
     }
@@ -1471,23 +1470,12 @@ impl RtpSession {
             return false;
         }
 
-        // Create the stream
+        // Session ingress remains deliberately unbuffered in this correctness
+        // repair. Enabling the legacy RtpStream jitter buffer here while the
+        // first-packet path stays unbuffered makes precreated streams hold the
+        // second sequential packet and can reverse later delivery.
         info!("Manually creating new RTP stream for SSRC={:08x}", ssrc);
-        let mut stream = if self.config.enable_jitter_buffer {
-            debug!("Creating stream with jitter buffer for SSRC={:08x}", ssrc);
-            RtpStream::with_jitter_buffer(
-                ssrc,
-                self.config.clock_rate,
-                self.config.jitter_buffer_size.unwrap_or(50),
-                self.config.max_packet_age_ms.unwrap_or(200) as u64,
-            )
-        } else {
-            debug!(
-                "Creating stream without jitter buffer for SSRC={:08x}",
-                ssrc
-            );
-            RtpStream::new(ssrc, self.config.clock_rate)
-        };
+        let mut stream = RtpStream::new(ssrc, self.config.clock_rate);
         if let Some(sender_report) = self.received_sender_reports.get(&ssrc) {
             stream.update_last_sr_info(sender_report.lsr, sender_report.received_at);
         }
@@ -1941,6 +1929,36 @@ mod tests {
         assert_eq!(stats.packets_lost, 0);
         assert_eq!(stats.packets_duplicated, 1);
         assert_eq!(stats.packets_out_of_order, 1);
+    }
+
+    #[tokio::test]
+    async fn precreated_stream_delivers_sequential_packets_promptly_and_in_order() {
+        let peer = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let remote_ssrc = 0xb1b2_b3b4;
+        let mut session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            // Exercise the configuration that previously gave manually
+            // precreated streams a broken legacy jitter buffer.
+            enable_jitter_buffer: true,
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        let destination = session.local_addr().unwrap();
+        let mut events = session.subscribe();
+
+        assert!(session.create_stream_for_ssrc(remote_ssrc).await);
+        send_raw_rtp(&peer, destination, 100, 16_000, remote_ssrc).await;
+        send_raw_rtp(&peer, destination, 101, 16_160, remote_ssrc).await;
+
+        let first = next_packet_event(&mut events).await;
+        let second = next_packet_event(&mut events).await;
+        assert_eq!(first.header.sequence_number, 100);
+        assert_eq!(second.header.sequence_number, 101);
+
+        let stream = session.get_stream(remote_ssrc).await.unwrap();
+        assert_eq!(stream.packets_received, 2);
+        assert_eq!(stream.highest_seq, 101);
     }
 
     #[tokio::test]

--- a/crates/media/rtp-core/src/session/stream.rs
+++ b/crates/media/rtp-core/src/session/stream.rs
@@ -4,7 +4,10 @@ use std::time::{Duration, Instant};
 use tracing::{debug, warn};
 
 use crate::packet::RtpPacket;
-use crate::{RtpSequenceNumber, RtpSsrc, RtpTimestamp};
+use crate::stats::{JitterEstimator, PacketLossResult, PacketLossTracker};
+#[cfg(test)]
+use crate::RtpTimestamp;
+use crate::{RtpSequenceNumber, RtpSsrc};
 
 /// Represents an RTP stream with sequence tracking and statistics
 pub struct RtpStream {
@@ -41,14 +44,11 @@ pub struct RtpStream {
     /// Interarrival jitter estimate (RFC 3550)
     jitter: f64,
 
-    /// Last arrival time used for jitter calculation
-    last_arrival: Option<Instant>,
+    /// Sequence-aware RFC 3550 jitter estimator.
+    jitter_estimator: JitterEstimator,
 
-    /// Last RTP timestamp used for jitter calculation
-    last_timestamp: Option<RtpTimestamp>,
-
-    /// Clock rate for timestamp calculations
-    clock_rate: u32,
+    /// Extended sequence and received-window tracker.
+    loss_tracker: PacketLossTracker,
 
     /// Jitter buffer for reordering packets (optional)
     jitter_buffer: Option<Arc<Mutex<VecDeque<RtpPacket>>>>,
@@ -87,9 +87,8 @@ impl RtpStream {
             packets_lost: 0,
             duplicates: 0,
             jitter: 0.0,
-            last_arrival: None,
-            last_timestamp: None,
-            clock_rate,
+            jitter_estimator: JitterEstimator::new(clock_rate),
+            loss_tracker: PacketLossTracker::new(),
             jitter_buffer: None,
             max_jitter_size: 50,                        // Default size
             max_packet_age: Duration::from_millis(200), // Default 200ms
@@ -142,31 +141,46 @@ impl RtpStream {
         self.packets_received += 1;
         self.bytes_received += packet.size() as u64;
 
-        // Initialize sequence tracking if this is the first packet
-        if !self.initialized {
-            self.init_sequence(seq);
-            self.last_timestamp = Some(timestamp);
-            self.last_arrival = Some(now);
-            self.initialized = true;
+        let loss_result = self.loss_tracker.process(seq);
+        let is_first_packet = matches!(loss_result, PacketLossResult::FirstPacket { .. });
+        match loss_result {
+            PacketLossResult::FirstPacket { seq } => self.init_sequence(seq),
+            PacketLossResult::Sequential { seq } => {
+                self.latest_seq = seq;
+                self.highest_seq = self.loss_tracker.highest_extended_sequence();
+            }
+            PacketLossResult::Gap {
+                seq,
+                expected,
+                lost,
+            } => {
+                debug!(
+                    "Detected sequence gap: expected={}, got={}, lost={}",
+                    expected, seq, lost
+                );
+                self.latest_seq = seq;
+                self.highest_seq = self.loss_tracker.highest_extended_sequence();
+            }
+            PacketLossResult::Duplicate { .. }
+            | PacketLossResult::Reordered { .. }
+            | PacketLossResult::Unknown => {}
+        }
+
+        let loss_stats = self.loss_tracker.get_stats();
+        self.highest_seq = self.loss_tracker.highest_extended_sequence();
+        self.seq_cycles = (self.highest_seq >> 16) as u16;
+        self.packets_lost = loss_stats.packets_lost;
+        self.duplicates = loss_stats.duplicates;
+        self.jitter = self
+            .jitter_estimator
+            .update_with_sequence(seq, timestamp, now);
+        self.initialized = true;
+
+        // Preserve the existing first-packet behavior even when a jitter
+        // buffer is enabled.
+        if is_first_packet {
             return Some(packet);
         }
-
-        // Update sequence tracking
-        self.update_sequence(seq);
-
-        // Update jitter estimate
-        if let (Some(last_arrival), Some(last_ts)) = (self.last_arrival, self.last_timestamp) {
-            let arrival_diff = now.duration_since(last_arrival).as_secs_f64();
-            let ts_diff =
-                ((timestamp as i32 - last_ts as i32).abs() as f64) / (self.clock_rate as f64);
-
-            // RFC 3550 jitter calculation
-            let d = arrival_diff - ts_diff;
-            self.jitter += (d.abs() - self.jitter) / 16.0;
-        }
-
-        self.last_arrival = Some(now);
-        self.last_timestamp = Some(timestamp);
 
         // If using jitter buffer, add to buffer and return ordered packets
         if let Some(buffer) = &self.jitter_buffer {
@@ -184,61 +198,6 @@ impl RtpStream {
         self.latest_seq = seq;
         self.highest_seq = seq as u32;
         debug!("Initialized RTP stream with seq={}", seq);
-    }
-
-    /// Update sequence tracking with a new sequence number
-    fn update_sequence(&mut self, seq: RtpSequenceNumber) {
-        // Detect sequence number cycle (wraparound from 65535 to 0)
-        if seq < 0x1000 && self.latest_seq > 0xf000 {
-            debug!(
-                "Detected sequence wraparound: {} -> {}",
-                self.latest_seq, seq
-            );
-            self.seq_cycles += 1;
-        }
-
-        // Check for duplicate
-        if seq == self.latest_seq {
-            self.duplicates += 1;
-            return;
-        }
-
-        // Calculate extended sequence (with cycle count)
-        let extended_seq = (self.seq_cycles as u32) << 16 | (seq as u32);
-
-        // Check if this is the highest sequence seen
-        if extended_seq > self.highest_seq {
-            // Calculate lost packets (gap in sequence)
-            let expected_seq = (self.latest_seq as u32 + 1) & 0xFFFF;
-            if seq != expected_seq as u16 {
-                // There's a gap - calculate how many packets were lost
-                let gap = if seq > expected_seq as u16 {
-                    seq - expected_seq as u16
-                } else {
-                    // Handle sequence number wraparound
-                    ((0xFFFF as u32 + 1) - expected_seq as u32) as u16 + seq
-                };
-
-                if gap > 0 {
-                    self.packets_lost += gap as u64;
-                    debug!(
-                        "Detected sequence gap: expected={}, got={}, lost={}",
-                        expected_seq, seq, gap
-                    );
-                }
-            }
-
-            self.highest_seq = extended_seq;
-        } else {
-            // Out of order packet (older than highest)
-            debug!(
-                "Out of order packet: seq={}, highest={}",
-                seq,
-                self.highest_seq & 0xFFFF
-            );
-        }
-
-        self.latest_seq = seq;
     }
 
     /// Add a packet to the jitter buffer
@@ -329,8 +288,8 @@ impl RtpStream {
             self.packets_lost = 0;
             self.duplicates = 0;
             self.jitter = 0.0;
-            self.last_arrival = None;
-            self.last_timestamp = None;
+            self.loss_tracker.reset();
+            self.jitter_estimator.reset();
 
             self.initialized = true;
             debug!("Initialized RTP stream with seq={}", seq);
@@ -450,7 +409,7 @@ mod tests {
         stream.process_packet(create_test_packet(1003, 80480));
         assert_eq!(stream.highest_seq, 1005); // Highest shouldn't change
         assert_eq!(stream.packets_received, 5);
-        assert_eq!(stream.packets_lost, 3); // Still 3 packets lost
+        assert_eq!(stream.packets_lost, 2); // Late packet fills one gap
     }
 
     #[test]
@@ -482,6 +441,20 @@ mod tests {
         stream.process_packet(create_test_packet(2, 81280));
         assert_eq!(stream.highest_seq, 65538); // 1 cycle + sequence 2
         assert_eq!(stream.seq_cycles, 1);
+    }
+
+    #[test]
+    fn test_reordered_packet_from_before_wrap_fills_gap() {
+        let mut stream = RtpStream::new(0x12345678, 8000);
+
+        stream.process_packet(create_test_packet(65534, 0));
+        stream.process_packet(create_test_packet(0, 320));
+        assert_eq!(stream.highest_seq, 0x1_0000);
+        assert_eq!(stream.packets_lost, 1);
+
+        stream.process_packet(create_test_packet(65535, 160));
+        assert_eq!(stream.highest_seq, 0x1_0000);
+        assert_eq!(stream.packets_lost, 0);
     }
 
     #[test]

--- a/crates/media/rtp-core/src/session/stream.rs
+++ b/crates/media/rtp-core/src/session/stream.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tracing::{debug, warn};
 
-use crate::packet::RtpPacket;
+use crate::packet::{rtcp::RtcpReportBlock, RtpPacket};
 use crate::stats::{JitterEstimator, PacketLossResult, PacketLossTracker};
 #[cfg(test)]
 use crate::RtpTimestamp;
@@ -41,11 +41,17 @@ pub struct RtpStream {
     /// Number of duplicate packets
     duplicates: u64,
 
+    /// Number of packets received behind the highest sequence number.
+    reordered: u64,
+
     /// Interarrival jitter estimate (RFC 3550)
     jitter: f64,
 
     /// Sequence-aware RFC 3550 jitter estimator.
     jitter_estimator: JitterEstimator,
+
+    /// RTP clock rate used to encode RTCP jitter in timestamp units.
+    clock_rate: u32,
 
     /// Extended sequence and received-window tracker.
     loss_tracker: PacketLossTracker,
@@ -86,8 +92,10 @@ impl RtpStream {
             bytes_received: 0,
             packets_lost: 0,
             duplicates: 0,
+            reordered: 0,
             jitter: 0.0,
             jitter_estimator: JitterEstimator::new(clock_rate),
+            clock_rate,
             loss_tracker: PacketLossTracker::new(),
             jitter_buffer: None,
             max_jitter_size: 50,                        // Default size
@@ -131,7 +139,10 @@ impl RtpStream {
     /// Returns the packet if it should be processed immediately,
     /// or None if it was placed in the jitter buffer
     pub fn process_packet(&mut self, packet: RtpPacket) -> Option<RtpPacket> {
-        let now = Instant::now();
+        self.process_packet_at(packet, Instant::now())
+    }
+
+    fn process_packet_at(&mut self, packet: RtpPacket, now: Instant) -> Option<RtpPacket> {
         self.last_packet_time = now;
 
         let seq = packet.header.sequence_number;
@@ -171,6 +182,7 @@ impl RtpStream {
         self.seq_cycles = (self.highest_seq >> 16) as u16;
         self.packets_lost = loss_stats.packets_lost;
         self.duplicates = loss_stats.duplicates;
+        self.reordered = loss_stats.reordered;
         self.jitter = self
             .jitter_estimator
             .update_with_sequence(seq, timestamp, now);
@@ -266,8 +278,9 @@ impl RtpStream {
             bytes_received: self.bytes_received,
             packets_lost: self.packets_lost,
             duplicates: self.duplicates,
+            packets_out_of_order: self.reordered,
             last_packet_time: Some(self.last_packet_time),
-            jitter: self.jitter as u32,
+            jitter: self.jitter_timestamp_units(),
             first_seq: self.base_seq as u32,
             highest_seq: self.highest_seq,
             received: self.packets_received as u32,
@@ -287,6 +300,7 @@ impl RtpStream {
             self.latest_seq = seq as RtpSequenceNumber;
             self.packets_lost = 0;
             self.duplicates = 0;
+            self.reordered = 0;
             self.jitter = 0.0;
             self.loss_tracker.reset();
             self.jitter_estimator.reset();
@@ -315,6 +329,35 @@ impl RtpStream {
             (delay_secs * 65536.0) as u32
         } else {
             0
+        }
+    }
+
+    /// Build and snapshot this source's RFC 3550 reception report block.
+    pub(crate) fn take_report_block(&mut self) -> RtcpReportBlock {
+        let (last_sr, delay_since_last_sr) = match self.last_sr_timestamp {
+            Some(timestamp) => (timestamp, self.calculate_delay_since_last_sr()),
+            None => (0, 0),
+        };
+
+        RtcpReportBlock {
+            ssrc: self.ssrc,
+            fraction_lost: self.loss_tracker.take_interval_fraction_lost(),
+            cumulative_lost: self.loss_tracker.get_cumulative_lost(),
+            highest_seq: self.loss_tracker.highest_extended_sequence(),
+            jitter: self.jitter_timestamp_units(),
+            last_sr,
+            delay_since_last_sr,
+        }
+    }
+
+    fn jitter_timestamp_units(&self) -> u32 {
+        let units = self.jitter * f64::from(self.clock_rate);
+        if !units.is_finite() || units <= 0.0 {
+            0
+        } else if units >= f64::from(u32::MAX) {
+            u32::MAX
+        } else {
+            units.round() as u32
         }
     }
 }
@@ -347,6 +390,9 @@ pub struct RtpStreamStats {
 
     /// Number of duplicate packets
     pub duplicates: u64,
+
+    /// Number of packets received behind the highest sequence number.
+    pub packets_out_of_order: u64,
 
     /// Last time a packet was received
     pub last_packet_time: Option<Instant>,
@@ -455,6 +501,36 @@ mod tests {
         stream.process_packet(create_test_packet(65535, 160));
         assert_eq!(stream.highest_seq, 0x1_0000);
         assert_eq!(stream.packets_lost, 0);
+    }
+
+    #[test]
+    fn report_blocks_use_interval_loss_and_timestamp_unit_jitter() {
+        let mut stream = RtpStream::new(0x12345678, 8000);
+        let start = Instant::now();
+
+        stream.process_packet_at(create_test_packet(10, 0), start);
+        // RTP advances by 20 ms while arrival advances by 40 ms. The first
+        // RFC 3550 jitter sample is 20 ms / 16 = 1.25 ms = 10 ticks at 8 kHz.
+        stream.process_packet_at(
+            create_test_packet(12, 160),
+            start + Duration::from_millis(40),
+        );
+
+        let first = stream.take_report_block();
+        assert_eq!(first.fraction_lost, 85);
+        assert_eq!(first.cumulative_lost, 1);
+        assert_eq!(first.jitter, 10);
+
+        for (offset, sequence) in (13..=20).enumerate() {
+            stream.process_packet_at(
+                create_test_packet(sequence, 320 + offset as u32 * 160),
+                start + Duration::from_millis(60 + offset as u64 * 20),
+            );
+        }
+
+        let second = stream.take_report_block();
+        assert_eq!(second.fraction_lost, 0);
+        assert_eq!(second.cumulative_lost, 1);
     }
 
     #[test]

--- a/crates/media/rtp-core/src/srtp/crypto.rs
+++ b/crates/media/rtp-core/src/srtp/crypto.rs
@@ -187,9 +187,12 @@ impl SrtpCrypto {
             .as_ref()
             .ok_or_else(|| Error::SrtpError("Session keys not derived".to_string()))?;
 
-        // Extract header and payload
+        // Serialize once to validate RTP padding and obtain the complete RTP
+        // payload region. RFC 3711 encrypts RTP padding together with the
+        // media payload; the padding count is therefore ciphertext on wire.
         let header = packet.header.clone();
-        let payload = packet.payload.clone();
+        let serialized = packet.serialize()?;
+        let header_size = packet.header.size();
 
         // Create an IV for encryption
         let ssrc = packet.header.ssrc;
@@ -209,8 +212,8 @@ impl SrtpCrypto {
             }
         };
 
-        // Create a mutable copy of the payload for encryption
-        let mut encrypted_payload = BytesMut::from(&payload[..]);
+        // Encrypt the media payload and any RFC 3550 padding as one region.
+        let mut encrypted_payload = BytesMut::from(&serialized[header_size..]);
 
         // Encrypt the payload
         match self.suite.encryption {
@@ -224,13 +227,24 @@ impl SrtpCrypto {
             }
         }
 
-        // Create a new packet with the encrypted payload
-        let encrypted_packet = RtpPacket::new(header, encrypted_payload.freeze());
+        // `padding_size == 0` marks that the protected payload already
+        // contains encrypted padding. The RTP P bit remains on wire, but its
+        // final padding-count octet cannot be interpreted until decryption.
+        let encrypted_packet = RtpPacket {
+            header,
+            payload: encrypted_payload.freeze(),
+            padding_size: 0,
+        };
 
         // Calculate authentication tag if authentication is enabled
         let auth_tag = if self.suite.authentication != SrtpAuthenticationAlgorithm::Null {
-            // Serialize the encrypted packet for authentication
-            let encrypted_serialized = encrypted_packet.serialize()?;
+            // Serialize the protected representation without asking the
+            // ordinary RTP serializer to interpret encrypted padding.
+            let mut encrypted_serialized = BytesMut::with_capacity(encrypted_packet.size());
+            encrypted_packet
+                .header
+                .serialize(&mut encrypted_serialized)?;
+            encrypted_serialized.extend_from_slice(&encrypted_packet.payload);
 
             // Calculate the authentication tag
             let auth_tag = self.calculate_auth_tag(&encrypted_serialized, roc)?;
@@ -323,17 +337,19 @@ impl SrtpCrypto {
             }
         }
 
-        // Parse the RTP header first (it's not encrypted)
-        let packet = RtpPacket::parse(packet_data)?;
-
         if self.suite.encryption == SrtpEncryptionAlgorithm::Null {
-            // If only authentication is enabled, return the parsed packet
-            return Ok(packet);
+            // If only authentication is enabled, RTP padding remains in the
+            // clear and the ordinary parser can validate and strip it.
+            return RtpPacket::parse(packet_data);
         }
 
+        // Parse only the clear RTP header. The encrypted payload's final byte
+        // cannot be interpreted as an RTP padding count until after decryption.
+        let (header, header_size) = crate::packet::RtpHeader::parse_without_consuming(packet_data)?;
+
         // Create an IV for decryption
-        let ssrc = packet.header.ssrc;
-        let sequence = packet.header.sequence_number as u64;
+        let ssrc = header.ssrc;
+        let sequence = header.sequence_number as u64;
         let roc: u32 = 0; // In a real implementation, this would be tracked
         let packet_index = (roc as u64) << 16 | sequence;
 
@@ -349,8 +365,9 @@ impl SrtpCrypto {
             }
         };
 
-        // Create a mutable copy of the payload for decryption
-        let mut decrypted_payload = BytesMut::from(&packet.payload[..]);
+        // Decrypt the complete RTP payload region, including encrypted RTP
+        // padding when the P bit is set.
+        let mut decrypted_payload = BytesMut::from(&packet_data[header_size..]);
 
         // Decrypt the payload
         match self.suite.encryption {
@@ -364,10 +381,30 @@ impl SrtpCrypto {
             }
         }
 
-        // Create a new packet with the decrypted payload
-        let decrypted_packet = RtpPacket::new(packet.header, decrypted_payload.freeze());
+        let decrypted_payload = decrypted_payload.freeze();
+        let padding_size = if header.padding {
+            let Some(&padding_size) = decrypted_payload.last() else {
+                return Err(Error::InvalidPacket(
+                    "decrypted RTP padding flag is set but no padding is present".to_string(),
+                ));
+            };
+            if padding_size == 0 || usize::from(padding_size) > decrypted_payload.len() {
+                return Err(Error::InvalidPacket(format!(
+                    "invalid decrypted RTP padding length {padding_size} for {} payload octets",
+                    decrypted_payload.len()
+                )));
+            }
+            padding_size
+        } else {
+            0
+        };
+        let payload_end = decrypted_payload.len() - usize::from(padding_size);
 
-        Ok(decrypted_packet)
+        Ok(RtpPacket {
+            header,
+            payload: decrypted_payload.slice(..payload_end),
+            padding_size,
+        })
     }
 
     /// Reject low-level SRTCP protection until per-SSRC indexes, replay state,

--- a/crates/media/rtp-core/src/srtp/mod.rs
+++ b/crates/media/rtp-core/src/srtp/mod.rs
@@ -244,18 +244,7 @@ pub struct ProtectedRtpPacket {
 impl ProtectedRtpPacket {
     /// Serialize the protected packet with its authentication tag
     pub fn serialize(&self) -> Result<bytes::Bytes, crate::Error> {
-        let packet_bytes = self.packet.serialize()?;
-
-        if let Some(tag) = &self.auth_tag {
-            // Combine packet and authentication tag
-            let mut buffer = bytes::BytesMut::with_capacity(packet_bytes.len() + tag.len());
-            buffer.extend_from_slice(&packet_bytes);
-            buffer.extend_from_slice(tag);
-            Ok(buffer.freeze())
-        } else {
-            // No authentication tag
-            Ok(packet_bytes)
-        }
+        self.serialize_into(&mut bytes::BytesMut::new())
     }
 
     /// Serialize the protected packet into a caller-owned scratch buffer.
@@ -268,6 +257,26 @@ impl ProtectedRtpPacket {
 
         self.packet.header.serialize(buffer)?;
         buffer.extend_from_slice(&self.packet.payload);
+        if !self.packet.header.padding && self.packet.padding_size != 0 {
+            return Err(crate::Error::InvalidParameter(format!(
+                "RTP padding flag ({}) does not match padding length ({})",
+                self.packet.header.padding, self.packet.padding_size
+            )));
+        }
+        if self.packet.header.padding
+            && self.packet.padding_size == 0
+            && self.packet.payload.is_empty()
+        {
+            return Err(crate::Error::InvalidParameter(
+                "protected RTP padding flag is set but the encrypted payload is empty".to_string(),
+            ));
+        }
+        if self.packet.padding_size != 0 {
+            for _ in 1..self.packet.padding_size {
+                buffer.extend_from_slice(&[0]);
+            }
+            buffer.extend_from_slice(&[self.packet.padding_size]);
+        }
         if let Some(tag) = &self.auth_tag {
             buffer.extend_from_slice(tag);
         }
@@ -417,6 +426,7 @@ impl SrtpContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn null_profiles_are_retained_identities_but_cannot_construct_contexts() {
@@ -529,6 +539,37 @@ mod tests {
                 .unwrap();
             assert_eq!(after_failure, from_fresh);
         }
+    }
+
+    #[test]
+    fn rtp_padding_is_encrypted_and_restored() {
+        let key = SrtpCryptoKey::new(vec![0x11; 16], vec![0x22; 14]);
+        let mut sender = SrtpContext::new(SRTP_AES128_CM_SHA1_80, key.clone()).unwrap();
+        let mut receiver = SrtpContext::new(SRTP_AES128_CM_SHA1_80, key).unwrap();
+        let mut original = crate::packet::RtpPacket::new_with_payload(
+            96,
+            42,
+            123_456,
+            0x4567_89ab,
+            Bytes::from_static(b"padded media"),
+        );
+        original.set_padding(4);
+
+        let plaintext = original.serialize().unwrap();
+        let header_size = original.header.size();
+        let protected = sender.protect(&original).unwrap();
+        let wire = protected.serialize().unwrap();
+        let ciphertext_end = wire.len() - SRTP_AES128_CM_SHA1_80.tag_length;
+
+        assert_ne!(
+            &wire[header_size..ciphertext_end],
+            &plaintext[header_size..],
+            "RTP padding must be encrypted together with the media payload"
+        );
+
+        let restored = receiver.unprotect(&wire).unwrap();
+        assert_eq!(restored, original);
+        assert_eq!(restored.serialize().unwrap(), plaintext);
     }
 }
 

--- a/crates/media/rtp-core/src/stats/jitter.rs
+++ b/crates/media/rtp-core/src/stats/jitter.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 use std::time::Instant;
 
-use crate::RtpTimestamp;
+use crate::{RtpSequenceNumber, RtpTimestamp};
 
 /// Jitter estimator implementing RFC 3550 jitter calculation algorithm
 #[derive(Debug, Clone)]
@@ -15,6 +15,9 @@ pub struct JitterEstimator {
 
     /// Last RTP timestamp
     last_timestamp: Option<RtpTimestamp>,
+
+    /// Highest extended sequence number used as a timing reference.
+    last_sequence: Option<u64>,
 
     /// Clock rate for timestamp conversion
     clock_rate: u32,
@@ -39,6 +42,7 @@ impl JitterEstimator {
             jitter: 0.0,
             last_arrival: None,
             last_timestamp: None,
+            last_sequence: None,
             clock_rate,
             max_jitter: 0.0,
             min_jitter: f64::MAX,
@@ -81,6 +85,32 @@ impl JitterEstimator {
         self.jitter
     }
 
+    /// Update the jitter estimate using an RTP sequence number.
+    ///
+    /// Duplicated, late, and reordered packets do not advance the timing
+    /// reference. This prevents their later arrival time from corrupting the
+    /// RFC 3550 transit-time calculation for the next in-order packet.
+    pub fn update_with_sequence(
+        &mut self,
+        sequence: RtpSequenceNumber,
+        timestamp: RtpTimestamp,
+        arrival: Instant,
+    ) -> f64 {
+        if let Some(last_sequence) = self.last_sequence {
+            let Some(extended_sequence) = extend_sequence_near(sequence, last_sequence) else {
+                return self.jitter;
+            };
+            if extended_sequence <= last_sequence {
+                return self.jitter;
+            }
+            self.last_sequence = Some(extended_sequence);
+        } else {
+            self.last_sequence = Some(sequence as u64);
+        }
+
+        self.update(timestamp, arrival)
+    }
+
     /// Get the current jitter estimate in seconds
     pub fn get_jitter(&self) -> f64 {
         self.jitter
@@ -111,10 +141,27 @@ impl JitterEstimator {
         self.jitter = 0.0;
         self.last_arrival = None;
         self.last_timestamp = None;
+        self.last_sequence = None;
         self.max_jitter = 0.0;
         self.min_jitter = f64::MAX;
         self.samples = 0;
         self.avg_jitter = 0.0;
+    }
+}
+
+fn extend_sequence_near(sequence: RtpSequenceNumber, reference: u64) -> Option<u64> {
+    let reference_low = (reference & 0xffff) as i32;
+    let difference = sequence as i32 - reference_low;
+    let cycle_base = reference & !0xffff;
+
+    if difference < -0x8000 {
+        Some(cycle_base + 0x1_0000 + sequence as u64)
+    } else if difference > 0x8000 {
+        cycle_base
+            .checked_sub(0x1_0000)
+            .map(|previous_cycle| previous_cycle + sequence as u64)
+    } else {
+        Some(cycle_base + sequence as u64)
     }
 }
 
@@ -195,5 +242,48 @@ mod tests {
         // Check stats
         assert!(estimator.get_max_jitter_ms() >= estimator.get_jitter_ms());
         assert!(estimator.get_min_jitter_ms() <= estimator.get_jitter_ms());
+    }
+
+    #[test]
+    fn reordered_and_duplicate_packets_do_not_change_jitter_reference() {
+        let mut estimator = JitterEstimator::new(8000);
+        let start = Instant::now();
+
+        estimator.update_with_sequence(10, 0, start);
+        estimator.update_with_sequence(12, 320, start + Duration::from_millis(40));
+        let before_late_packet = estimator.get_jitter();
+
+        // This missing packet arrives much later. Including it would create a
+        // multi-second jitter sample and poison the next calculation.
+        estimator.update_with_sequence(11, 160, start + Duration::from_secs(5));
+        estimator.update_with_sequence(12, 320, start + Duration::from_secs(6));
+        assert_eq!(estimator.get_jitter(), before_late_packet);
+
+        estimator.update_with_sequence(13, 480, start + Duration::from_millis(60));
+        assert!(estimator.get_jitter() < 0.000_001);
+    }
+
+    #[test]
+    fn sequence_aware_jitter_handles_wraparound() {
+        let mut estimator = JitterEstimator::new(8000);
+        let start = Instant::now();
+
+        estimator.update_with_sequence(65535, 0, start);
+        estimator.update_with_sequence(0, 160, start + Duration::from_millis(20));
+
+        assert!(estimator.get_jitter() < 0.000_001);
+        assert_eq!(estimator.last_sequence, Some(0x1_0000));
+    }
+
+    #[test]
+    fn late_packet_before_cycle_zero_does_not_change_jitter() {
+        let mut estimator = JitterEstimator::new(8000);
+        let start = Instant::now();
+        estimator.update_with_sequence(1, 160, start);
+
+        let before = estimator.get_jitter();
+        estimator.update_with_sequence(65535, 0, start + Duration::from_secs(5));
+        assert_eq!(estimator.get_jitter(), before);
+        assert_eq!(estimator.last_sequence, Some(1));
     }
 }

--- a/crates/media/rtp-core/src/stats/loss.rs
+++ b/crates/media/rtp-core/src/stats/loss.rs
@@ -1,4 +1,10 @@
+use std::collections::HashSet;
+
 use crate::RtpSequenceNumber;
+
+/// Number of recent extended sequence numbers retained for duplicate and
+/// reordering detection.
+const RECEIVED_WINDOW_SIZE: u64 = 2048;
 
 /// Packet loss tracker for RTP streams
 #[derive(Debug, Clone)]
@@ -6,17 +12,17 @@ pub struct PacketLossTracker {
     /// Base sequence number (first received)
     base_seq: Option<RtpSequenceNumber>,
 
-    /// Highest sequence number received
-    highest_seq: u32,
+    /// Extended sequence number of the first packet.
+    base_extended: Option<u64>,
 
-    /// Previous sequence number
-    prev_seq: Option<RtpSequenceNumber>,
-
-    /// Number of packets expected
-    expected: u64,
+    /// Highest extended sequence number received.
+    highest_seq: u64,
 
     /// Number of packets actually received
     received: u64,
+
+    /// Number of distinct packets received in the tracked sequence range.
+    unique_received: u64,
 
     /// Number of packets lost
     lost: u64,
@@ -27,8 +33,11 @@ pub struct PacketLossTracker {
     /// Number of reordered packets
     reordered: u64,
 
-    /// Sequence number cycle count
-    cycles: u16,
+    /// Sequence number cycle count of the highest packet.
+    cycles: u32,
+
+    /// Recently received extended sequence numbers.
+    received_window: HashSet<u64>,
 
     /// Recent loss history (1=received, 0=lost) for burst detection
     loss_history: Vec<bool>,
@@ -51,14 +60,15 @@ impl PacketLossTracker {
     pub fn new() -> Self {
         Self {
             base_seq: None,
+            base_extended: None,
             highest_seq: 0,
-            prev_seq: None,
-            expected: 0,
             received: 0,
+            unique_received: 0,
             lost: 0,
             duplicates: 0,
             reordered: 0,
             cycles: 0,
+            received_window: HashSet::with_capacity(RECEIVED_WINDOW_SIZE as usize),
             loss_history: Vec::with_capacity(64),
             history_size: 64,
             burst_count: 0,
@@ -74,43 +84,45 @@ impl PacketLossTracker {
         // Initialize if this is the first packet
         if self.base_seq.is_none() {
             self.base_seq = Some(seq);
-            self.highest_seq = seq as u32;
-            self.prev_seq = Some(seq);
+            self.base_extended = Some(seq as u64);
+            self.highest_seq = seq as u64;
+            self.unique_received = 1;
+            self.received_window.insert(seq as u64);
             self.loss_history.push(true); // First packet is received
             return PacketLossResult::FirstPacket { seq };
         }
 
-        // Check for sequence number wraparound
-        let prev_seq = self.prev_seq.unwrap();
-        if seq < 0x1000 && prev_seq > 0xf000 {
-            // Sequence number wrapped around from 65535 to 0
-            self.cycles += 1;
-        }
-
-        // Calculate extended sequence number (with cycle count)
-        let extended_seq = (self.cycles as u32) << 16 | (seq as u32);
-
-        // Check for duplicate packets - a duplicate is a previously seen sequence number
-        // This applies to all sequence numbers we've previously processed, not just the last one
-        // Only need to check if we already saw this sequence number within the valid window
-        // First check exact match with previous seq (most common case)
-        if seq == prev_seq {
+        let Some(extended_seq) = self.extend_sequence(seq) else {
+            // A high sequence received while still in cycle zero belongs to
+            // the conceptual cycle before the first observed packet. It is
+            // late, not a jump almost 65,536 packets into the future.
+            self.reordered += 1;
+            return PacketLossResult::Reordered {
+                seq,
+                expected: self.highest_seq as u16,
+            };
+        };
+        if self.received_window.contains(&extended_seq) {
             self.duplicates += 1;
             return PacketLossResult::Duplicate { seq };
         }
 
-        // For simplicity in this test implementation, we'll consider any reordered packet
-        // that arrives with a sequence number less than highest - but not equal to prev_seq -
-        // as a duplicate if it's already been seen
-
-        // Check if this is a reordered packet
         let highest_seq = self.highest_seq;
         if extended_seq < highest_seq {
-            // Count as reordered
             self.reordered += 1;
 
-            // Add to history
-            self.add_to_history(true); // Mark as received
+            // Sequence numbers older than the bounded window cannot safely be
+            // distinguished from duplicates. Count them as reordered, but do
+            // not change the established loss total.
+            let oldest_tracked = highest_seq.saturating_sub(RECEIVED_WINDOW_SIZE - 1);
+            if extended_seq >= oldest_tracked {
+                self.received_window.insert(extended_seq);
+                if extended_seq >= self.base_extended.expect("tracker is initialized") {
+                    self.unique_received += 1;
+                    self.lost = self.lost.saturating_sub(1);
+                }
+                self.add_to_history(true);
+            }
 
             return PacketLossResult::Reordered {
                 seq,
@@ -118,66 +130,52 @@ impl PacketLossTracker {
             };
         }
 
-        // Calculate expected packets vs. received
         if extended_seq > highest_seq {
             let gap = extended_seq - highest_seq;
+            self.unique_received += 1;
+            self.received_window.insert(extended_seq);
 
             if gap > 1 {
-                // There was at least one packet loss in the gap
                 let lost_packets = gap - 1;
-                self.lost += lost_packets as u64;
+                self.lost += lost_packets;
 
-                // Update burst statistics
                 self.update_burst_stats(lost_packets);
 
-                // Add lost packets to history
-                for _ in 0..lost_packets {
-                    self.add_to_history(false); // Mark as lost
+                // The history is bounded; avoid work proportional to a
+                // maliciously large sequence jump.
+                for _ in 0..lost_packets.min(self.history_size as u64) {
+                    self.add_to_history(false);
                 }
 
-                // Add this packet to history
-                self.add_to_history(true); // Mark as received
-
-                // Update highest sequence
-                self.highest_seq = extended_seq;
-                self.prev_seq = Some(seq);
+                self.add_to_history(true);
+                self.advance_highest(extended_seq);
 
                 return PacketLossResult::Gap {
                     seq,
                     expected: (highest_seq + 1) as u16,
-                    lost: lost_packets as u16,
+                    lost: lost_packets.min(u16::MAX as u64) as u16,
                 };
             } else {
-                // Normal case - next sequential packet
-                self.add_to_history(true); // Mark as received
-                self.highest_seq = extended_seq;
-                self.prev_seq = Some(seq);
+                self.add_to_history(true);
+                self.advance_highest(extended_seq);
 
                 return PacketLossResult::Sequential { seq };
             }
         }
 
-        // Should not reach here normally, but just in case
-        self.prev_seq = Some(seq);
+        // Equality is handled by the received window above.
         PacketLossResult::Unknown
+    }
+
+    /// Return the extended highest sequence number used in RTCP reports.
+    pub fn highest_extended_sequence(&self) -> u32 {
+        self.highest_seq.min(u32::MAX as u64) as u32
     }
 
     /// Calculate the total number of expected packets
     pub fn calculate_expected(&self) -> u64 {
-        if let Some(base_seq) = self.base_seq {
-            // For the base sequence, use the raw value with cycle count = 0
-            let base_ext = base_seq as u32;
-
-            // For highest, use the extended sequence with cycle count
-            let highest_ext = self.highest_seq;
-
-            // Handle wraparound case
-            if highest_ext >= base_ext {
-                (highest_ext - base_ext + 1) as u64
-            } else {
-                // In case of wraparound where highest is actually lower after accounting for cycles
-                ((u32::MAX as u64) - (base_ext as u64) + (highest_ext as u64) + 1) as u64
-            }
+        if let Some(base_extended) = self.base_extended {
+            self.highest_seq - base_extended + 1
         } else {
             0
         }
@@ -190,13 +188,7 @@ impl PacketLossTracker {
             return 0;
         }
 
-        // Handle cases where expected < received (e.g., in tests or with reordering)
-        let received_valid = self.received - self.duplicates;
-        let lost = if expected >= received_valid {
-            expected - received_valid
-        } else {
-            0 // No loss if we received more than expected (shouldn't happen normally)
-        };
+        let lost = expected.saturating_sub(self.unique_received);
 
         let fraction = (lost as f64 / expected as f64) * 256.0;
         fraction.min(255.0) as u8
@@ -205,14 +197,10 @@ impl PacketLossTracker {
     /// Calculate the cumulative number of packets lost
     pub fn get_cumulative_lost(&self) -> u32 {
         let expected = self.calculate_expected();
+        let calculated = expected.saturating_sub(self.unique_received);
+        debug_assert_eq!(self.lost, calculated);
 
-        // Make sure we handle the case where we receive more packets than expected
-        // (e.g., due to duplicates)
-        if expected >= self.received - self.duplicates {
-            (expected - (self.received - self.duplicates)) as u32
-        } else {
-            0
-        }
+        calculated.min(0x00ff_ffff) as u32
     }
 
     /// Get packet loss statistics
@@ -221,7 +209,7 @@ impl PacketLossTracker {
 
         PacketLossStats {
             packets_received: self.received,
-            packets_lost: self.lost,
+            packets_lost: self.get_cumulative_lost() as u64,
             packets_expected: expected,
             duplicates: self.duplicates,
             reordered: self.reordered,
@@ -234,14 +222,15 @@ impl PacketLossTracker {
     /// Reset the tracker
     pub fn reset(&mut self) {
         self.base_seq = None;
+        self.base_extended = None;
         self.highest_seq = 0;
-        self.prev_seq = None;
-        self.expected = 0;
         self.received = 0;
+        self.unique_received = 0;
         self.lost = 0;
         self.duplicates = 0;
         self.reordered = 0;
         self.cycles = 0;
+        self.received_window.clear();
         self.loss_history.clear();
         self.burst_count = 0;
         self.max_burst_length = 0;
@@ -249,6 +238,34 @@ impl PacketLossTracker {
     }
 
     // Internal helper methods
+
+    /// Map a 16-bit sequence number to the cycle nearest the current highest
+    /// sequence number. This permits late packets from the preceding cycle
+    /// without mistaking them for a new wrap.
+    fn extend_sequence(&self, seq: RtpSequenceNumber) -> Option<u64> {
+        let highest_low = (self.highest_seq & 0xffff) as i32;
+        let difference = seq as i32 - highest_low;
+        let cycle_base = self.highest_seq & !0xffff;
+
+        if difference < -0x8000 {
+            Some(cycle_base + 0x1_0000 + seq as u64)
+        } else if difference > 0x8000 {
+            cycle_base
+                .checked_sub(0x1_0000)
+                .map(|previous_cycle| previous_cycle + seq as u64)
+        } else {
+            Some(cycle_base + seq as u64)
+        }
+    }
+
+    fn advance_highest(&mut self, extended_seq: u64) {
+        self.highest_seq = extended_seq;
+        self.cycles = (extended_seq >> 16).min(u32::MAX as u64) as u32;
+
+        let oldest_tracked = extended_seq.saturating_sub(RECEIVED_WINDOW_SIZE - 1);
+        self.received_window
+            .retain(|received| *received >= oldest_tracked);
+    }
 
     /// Add a packet status to the loss history
     fn add_to_history(&mut self, received: bool) {
@@ -259,7 +276,7 @@ impl PacketLossTracker {
     }
 
     /// Update burst statistics when packets are lost
-    fn update_burst_stats(&mut self, lost_count: u32) {
+    fn update_burst_stats(&mut self, lost_count: u64) {
         if lost_count == 0 {
             // Reset current burst if any
             if self.current_burst_length > 0 {
@@ -268,9 +285,9 @@ impl PacketLossTracker {
             return;
         }
 
-        // Each gap counts as one burst
-        self.burst_count = 1; // We always count just 1 burst
-        self.current_burst_length = lost_count as u64;
+        // Each newly observed gap counts as one burst.
+        self.burst_count += 1;
+        self.current_burst_length = lost_count;
 
         // Update max burst length
         if self.current_burst_length > self.max_burst_length {
@@ -416,22 +433,16 @@ mod tests {
             PacketLossResult::Sequential { seq: 1001 }
         );
 
-        // When we send 1000 again, it should be detected as Reordered since it's less than
-        // the highest sequence number we've seen (1001), but not equal to the previous seq
-        // In our implementation, this is considered out of order, not a duplicate
+        // Every sequence number in the bounded received window is recognized
+        // as a duplicate, not only the most recently received one.
         let result1 = tracker.process(1000);
         assert_eq!(
             result1,
-            PacketLossResult::Reordered {
-                seq: 1000,
-                expected: 1001
-            },
-            "Expected Reordered but got {:?}",
+            PacketLossResult::Duplicate { seq: 1000 },
+            "Expected Duplicate but got {:?}",
             result1
         );
 
-        // When we send 1001 again, it should be detected as a Duplicate since it equals
-        // the previous sequence number
         let result2 = tracker.process(1001);
         assert_eq!(
             result2,
@@ -443,8 +454,8 @@ mod tests {
         // Check stats
         let stats = tracker.get_stats();
         assert_eq!(stats.packets_received, 4); // 2 unique + 2 more
-        assert_eq!(stats.duplicates, 1); // Only one true duplicate detected
-        assert_eq!(stats.reordered, 1); // One reordered packet
+        assert_eq!(stats.duplicates, 2);
+        assert_eq!(stats.reordered, 0);
         assert_eq!(stats.packets_expected, 2); // Only expect 2 unique packets
     }
 
@@ -477,7 +488,41 @@ mod tests {
         let stats = tracker.get_stats();
         assert_eq!(stats.packets_received, 3);
         assert_eq!(stats.reordered, 1);
-        assert_eq!(stats.packets_lost, 1); // This doesn't get decremented when we receive the reordered packet
+        assert_eq!(stats.packets_lost, 0);
+        assert_eq!(tracker.get_cumulative_lost(), 0);
+    }
+
+    #[test]
+    fn packet_before_base_does_not_hide_later_loss() {
+        let mut tracker = PacketLossTracker::new();
+
+        tracker.process(1000);
+        assert!(matches!(
+            tracker.process(999),
+            PacketLossResult::Reordered { .. }
+        ));
+        assert_eq!(
+            tracker.process(1002),
+            PacketLossResult::Gap {
+                seq: 1002,
+                expected: 1001,
+                lost: 1,
+            }
+        );
+        assert_eq!(tracker.get_cumulative_lost(), 1);
+    }
+
+    #[test]
+    fn high_late_packet_in_cycle_zero_is_not_a_future_jump() {
+        let mut tracker = PacketLossTracker::new();
+        tracker.process(1);
+
+        assert!(matches!(
+            tracker.process(65535),
+            PacketLossResult::Reordered { .. }
+        ));
+        assert_eq!(tracker.highest_extended_sequence(), 1);
+        assert_eq!(tracker.get_cumulative_lost(), 0);
     }
 
     #[test]
@@ -508,6 +553,39 @@ mod tests {
 
         // Check cycle count
         assert_eq!(tracker.cycles, 1);
+        assert_eq!(tracker.highest_extended_sequence(), 0x1_0001);
+    }
+
+    #[test]
+    fn test_reordering_around_sequence_wrap_fills_loss() {
+        let mut tracker = PacketLossTracker::new();
+
+        assert_eq!(
+            tracker.process(65534),
+            PacketLossResult::FirstPacket { seq: 65534 }
+        );
+        assert_eq!(
+            tracker.process(0),
+            PacketLossResult::Gap {
+                seq: 0,
+                expected: 65535,
+                lost: 1,
+            }
+        );
+        assert_eq!(tracker.get_cumulative_lost(), 1);
+
+        assert_eq!(
+            tracker.process(65535),
+            PacketLossResult::Reordered {
+                seq: 65535,
+                expected: 0,
+            }
+        );
+        assert_eq!(tracker.get_cumulative_lost(), 0);
+        assert_eq!(
+            tracker.process(65535),
+            PacketLossResult::Duplicate { seq: 65535 }
+        );
     }
 
     #[test]
@@ -527,8 +605,7 @@ mod tests {
 
         // Check stats
         let stats = tracker.get_stats();
-        // Our implementation counts only 1 burst
-        assert_eq!(stats.burst_count, 1);
+        assert_eq!(stats.burst_count, 2);
         // The max burst length is from the first gap (4 packets)
         assert_eq!(stats.max_burst_length, 4);
     }

--- a/crates/media/rtp-core/src/stats/loss.rs
+++ b/crates/media/rtp-core/src/stats/loss.rs
@@ -194,21 +194,18 @@ impl PacketLossTracker {
     }
 
     /// Return the packet-loss fraction for the interval since the preceding
-    /// RTCP report and advance the report snapshot.
+    /// RTCP report without advancing the report snapshot.
     ///
     /// RFC 3550 defines the fraction field over the reporting interval, not
     /// over the lifetime of the source. Late packets can make the interval's
     /// received delta exceed its expected delta; that recovery is encoded as
     /// zero rather than wrapping into a large loss fraction.
-    pub fn take_interval_fraction_lost(&mut self) -> u8 {
+    pub fn interval_fraction_lost(&self) -> u8 {
         let expected = self.calculate_expected();
         let expected_interval = expected.saturating_sub(self.expected_prior);
         let received_interval = self
             .unique_received
             .saturating_sub(self.unique_received_prior);
-
-        self.expected_prior = expected;
-        self.unique_received_prior = self.unique_received;
 
         if expected_interval == 0 || received_interval >= expected_interval {
             return 0;
@@ -216,6 +213,15 @@ impl PacketLossTracker {
 
         let lost_interval = expected_interval - received_interval;
         ((lost_interval * 256) / expected_interval).min(255) as u8
+    }
+
+    /// Return the current interval loss fraction and advance the report
+    /// snapshot so the following report covers only newly expected packets.
+    pub fn take_interval_fraction_lost(&mut self) -> u8 {
+        let fraction_lost = self.interval_fraction_lost();
+        self.expected_prior = self.calculate_expected();
+        self.unique_received_prior = self.unique_received;
+        fraction_lost
     }
 
     /// Calculate the cumulative number of packets lost

--- a/crates/media/rtp-core/src/stats/loss.rs
+++ b/crates/media/rtp-core/src/stats/loss.rs
@@ -4,7 +4,7 @@ use crate::RtpSequenceNumber;
 
 /// Number of recent extended sequence numbers retained for duplicate and
 /// reordering detection.
-const RECEIVED_WINDOW_SIZE: u64 = 2048;
+const RECEIVED_WINDOW_SIZE: i64 = 2048;
 
 /// Packet loss tracker for RTP streams
 #[derive(Debug, Clone)]
@@ -13,16 +13,22 @@ pub struct PacketLossTracker {
     base_seq: Option<RtpSequenceNumber>,
 
     /// Extended sequence number of the first packet.
-    base_extended: Option<u64>,
+    base_extended: Option<i64>,
 
     /// Highest extended sequence number received.
-    highest_seq: u64,
+    highest_seq: i64,
 
     /// Number of packets actually received
     received: u64,
 
     /// Number of distinct packets received in the tracked sequence range.
     unique_received: u64,
+
+    /// Expected-packet total captured when the preceding RTCP report was built.
+    expected_prior: u64,
+
+    /// Unique-received total captured when the preceding RTCP report was built.
+    unique_received_prior: u64,
 
     /// Number of packets lost
     lost: u64,
@@ -37,7 +43,7 @@ pub struct PacketLossTracker {
     cycles: u32,
 
     /// Recently received extended sequence numbers.
-    received_window: HashSet<u64>,
+    received_window: HashSet<i64>,
 
     /// Recent loss history (1=received, 0=lost) for burst detection
     loss_history: Vec<bool>,
@@ -64,6 +70,8 @@ impl PacketLossTracker {
             highest_seq: 0,
             received: 0,
             unique_received: 0,
+            expected_prior: 0,
+            unique_received_prior: 0,
             lost: 0,
             duplicates: 0,
             reordered: 0,
@@ -84,24 +92,15 @@ impl PacketLossTracker {
         // Initialize if this is the first packet
         if self.base_seq.is_none() {
             self.base_seq = Some(seq);
-            self.base_extended = Some(seq as u64);
-            self.highest_seq = seq as u64;
+            self.base_extended = Some(seq as i64);
+            self.highest_seq = seq as i64;
             self.unique_received = 1;
-            self.received_window.insert(seq as u64);
+            self.received_window.insert(seq as i64);
             self.loss_history.push(true); // First packet is received
             return PacketLossResult::FirstPacket { seq };
         }
 
-        let Some(extended_seq) = self.extend_sequence(seq) else {
-            // A high sequence received while still in cycle zero belongs to
-            // the conceptual cycle before the first observed packet. It is
-            // late, not a jump almost 65,536 packets into the future.
-            self.reordered += 1;
-            return PacketLossResult::Reordered {
-                seq,
-                expected: self.highest_seq as u16,
-            };
-        };
+        let extended_seq = self.extend_sequence(seq);
         if self.received_window.contains(&extended_seq) {
             self.duplicates += 1;
             return PacketLossResult::Duplicate { seq };
@@ -114,7 +113,7 @@ impl PacketLossTracker {
             // Sequence numbers older than the bounded window cannot safely be
             // distinguished from duplicates. Count them as reordered, but do
             // not change the established loss total.
-            let oldest_tracked = highest_seq.saturating_sub(RECEIVED_WINDOW_SIZE - 1);
+            let oldest_tracked = highest_seq - (RECEIVED_WINDOW_SIZE - 1);
             if extended_seq >= oldest_tracked {
                 self.received_window.insert(extended_seq);
                 if extended_seq >= self.base_extended.expect("tracker is initialized") {
@@ -131,7 +130,7 @@ impl PacketLossTracker {
         }
 
         if extended_seq > highest_seq {
-            let gap = extended_seq - highest_seq;
+            let gap = (extended_seq - highest_seq) as u64;
             self.unique_received += 1;
             self.received_window.insert(extended_seq);
 
@@ -169,13 +168,13 @@ impl PacketLossTracker {
 
     /// Return the extended highest sequence number used in RTCP reports.
     pub fn highest_extended_sequence(&self) -> u32 {
-        self.highest_seq.min(u32::MAX as u64) as u32
+        self.highest_seq.clamp(0, u32::MAX as i64) as u32
     }
 
     /// Calculate the total number of expected packets
     pub fn calculate_expected(&self) -> u64 {
         if let Some(base_extended) = self.base_extended {
-            self.highest_seq - base_extended + 1
+            (self.highest_seq - base_extended + 1).max(0) as u64
         } else {
             0
         }
@@ -192,6 +191,31 @@ impl PacketLossTracker {
 
         let fraction = (lost as f64 / expected as f64) * 256.0;
         fraction.min(255.0) as u8
+    }
+
+    /// Return the packet-loss fraction for the interval since the preceding
+    /// RTCP report and advance the report snapshot.
+    ///
+    /// RFC 3550 defines the fraction field over the reporting interval, not
+    /// over the lifetime of the source. Late packets can make the interval's
+    /// received delta exceed its expected delta; that recovery is encoded as
+    /// zero rather than wrapping into a large loss fraction.
+    pub fn take_interval_fraction_lost(&mut self) -> u8 {
+        let expected = self.calculate_expected();
+        let expected_interval = expected.saturating_sub(self.expected_prior);
+        let received_interval = self
+            .unique_received
+            .saturating_sub(self.unique_received_prior);
+
+        self.expected_prior = expected;
+        self.unique_received_prior = self.unique_received;
+
+        if expected_interval == 0 || received_interval >= expected_interval {
+            return 0;
+        }
+
+        let lost_interval = expected_interval - received_interval;
+        ((lost_interval * 256) / expected_interval).min(255) as u8
     }
 
     /// Calculate the cumulative number of packets lost
@@ -226,6 +250,8 @@ impl PacketLossTracker {
         self.highest_seq = 0;
         self.received = 0;
         self.unique_received = 0;
+        self.expected_prior = 0;
+        self.unique_received_prior = 0;
         self.lost = 0;
         self.duplicates = 0;
         self.reordered = 0;
@@ -242,27 +268,25 @@ impl PacketLossTracker {
     /// Map a 16-bit sequence number to the cycle nearest the current highest
     /// sequence number. This permits late packets from the preceding cycle
     /// without mistaking them for a new wrap.
-    fn extend_sequence(&self, seq: RtpSequenceNumber) -> Option<u64> {
+    fn extend_sequence(&self, seq: RtpSequenceNumber) -> i64 {
         let highest_low = (self.highest_seq & 0xffff) as i32;
         let difference = seq as i32 - highest_low;
         let cycle_base = self.highest_seq & !0xffff;
 
         if difference < -0x8000 {
-            Some(cycle_base + 0x1_0000 + seq as u64)
+            cycle_base + 0x1_0000 + seq as i64
         } else if difference > 0x8000 {
-            cycle_base
-                .checked_sub(0x1_0000)
-                .map(|previous_cycle| previous_cycle + seq as u64)
+            cycle_base - 0x1_0000 + seq as i64
         } else {
-            Some(cycle_base + seq as u64)
+            cycle_base + seq as i64
         }
     }
 
-    fn advance_highest(&mut self, extended_seq: u64) {
+    fn advance_highest(&mut self, extended_seq: i64) {
         self.highest_seq = extended_seq;
-        self.cycles = (extended_seq >> 16).min(u32::MAX as u64) as u32;
+        self.cycles = (extended_seq >> 16).clamp(0, u32::MAX as i64) as u32;
 
-        let oldest_tracked = extended_seq.saturating_sub(RECEIVED_WINDOW_SIZE - 1);
+        let oldest_tracked = extended_seq - (RECEIVED_WINDOW_SIZE - 1);
         self.received_window
             .retain(|received| *received >= oldest_tracked);
     }
@@ -523,6 +547,43 @@ mod tests {
         ));
         assert_eq!(tracker.highest_extended_sequence(), 1);
         assert_eq!(tracker.get_cumulative_lost(), 0);
+    }
+
+    #[test]
+    fn late_packet_before_sequence_zero_is_then_a_duplicate() {
+        let mut tracker = PacketLossTracker::new();
+        tracker.process(0);
+
+        assert_eq!(
+            tracker.process(65535),
+            PacketLossResult::Reordered {
+                seq: 65535,
+                expected: 0,
+            }
+        );
+        assert_eq!(
+            tracker.process(65535),
+            PacketLossResult::Duplicate { seq: 65535 }
+        );
+        assert_eq!(tracker.highest_extended_sequence(), 0);
+        assert_eq!(tracker.get_stats().duplicates, 1);
+    }
+
+    #[test]
+    fn rtcp_fraction_lost_is_scoped_to_each_report_interval() {
+        let mut tracker = PacketLossTracker::new();
+        tracker.process(10);
+        tracker.process(12);
+
+        assert_eq!(tracker.take_interval_fraction_lost(), 85);
+        assert_eq!(tracker.get_cumulative_lost(), 1);
+
+        for sequence in 13..=20 {
+            tracker.process(sequence);
+        }
+
+        assert_eq!(tracker.take_interval_fraction_lost(), 0);
+        assert_eq!(tracker.get_cumulative_lost(), 1);
     }
 
     #[test]

--- a/crates/media/rtp-core/src/stats/mod.rs
+++ b/crates/media/rtp-core/src/stats/mod.rs
@@ -90,7 +90,6 @@ pub struct RtpStatsManager {
     start_time: Instant,
 
     /// Clock rate for timestamp conversions
-    #[allow(dead_code)] // retained (liveness/Drop hold or reserved); not read
     clock_rate: u32,
 }
 
@@ -118,6 +117,20 @@ impl RtpStatsManager {
     /// Get a copy of the current statistics
     pub fn get_stats(&self) -> RtpStats {
         self.stats.lock().unwrap().clone()
+    }
+
+    /// Take a statistics snapshot for an RTCP reporting interval.
+    ///
+    /// The returned `fraction_lost` covers packets expected since the prior
+    /// call, while cumulative counters such as `packets_lost` retain their
+    /// lifetime values. The cached live snapshot starts a clean interval.
+    pub fn take_interval_stats(&mut self) -> RtpStats {
+        let fraction_lost = self.loss_tracker.take_interval_fraction_lost();
+        let mut stats = self.stats.lock().unwrap();
+        stats.fraction_lost = fraction_lost;
+        let snapshot = stats.clone();
+        stats.fraction_lost = 0;
+        snapshot
     }
 
     /// Reset all statistics
@@ -148,6 +161,20 @@ impl RtpStatsManager {
 
     /// Update statistics for a received packet
     pub fn update_received(
+        &mut self,
+        seq: RtpSequenceNumber,
+        timestamp: u32,
+        bytes: usize,
+        arrival_time: Instant,
+    ) {
+        self.update_received_at(seq, timestamp, bytes, arrival_time);
+    }
+
+    /// Update receive statistics using an explicitly controlled arrival time.
+    ///
+    /// This is useful for packet captures, deterministic simulations, and
+    /// tests that must reproduce an exact RFC 3550 jitter sample.
+    pub fn update_received_at(
         &mut self,
         seq: RtpSequenceNumber,
         timestamp: u32,
@@ -191,16 +218,16 @@ impl RtpStatsManager {
         }
 
         // Update jitter calculation
-        let jitter = self
-            .jitter_estimator
-            .update_with_sequence(seq, timestamp, arrival_time);
-        stats.jitter = jitter;
+        let jitter_seconds =
+            self.jitter_estimator
+                .update_with_sequence(seq, timestamp, arrival_time);
+        stats.jitter = jitter_seconds * f64::from(self.clock_rate);
 
         // Recompute loss from the unique received-packet window so a late
         // packet that fills a gap reduces the cumulative total.
         let loss_stats = self.loss_tracker.get_stats();
         stats.packets_lost = loss_stats.packets_lost;
-        stats.fraction_lost = loss_stats.fraction_lost;
+        stats.fraction_lost = self.loss_tracker.interval_fraction_lost();
         stats.highest_seq = self.loss_tracker.highest_extended_sequence();
 
         // Update RTCP generator if available
@@ -289,5 +316,36 @@ mod tests {
         assert_eq!(stats.packets_out_of_order, 1);
         assert_eq!(stats.jitter, jitter_before_reorder);
         assert_eq!(stats.highest_seq, 0x1_0001);
+    }
+
+    #[test]
+    fn controlled_arrivals_use_timestamp_unit_jitter_and_interval_loss() {
+        let mut manager = RtpStatsManager::new(8000);
+        let start = Instant::now();
+
+        manager.update_received_at(10, 0, 100, start);
+        // RTP advances by 20 ms while arrival advances by 40 ms. RFC 3550
+        // therefore produces 20 ms / 16 = 1.25 ms of jitter, or 10 ticks at
+        // an 8 kHz RTP clock rate.
+        manager.update_received_at(12, 160, 100, start + Duration::from_millis(40));
+
+        let first = manager.take_interval_stats();
+        assert_eq!(first.fraction_lost, 85);
+        assert_eq!(first.packets_lost, 1);
+        assert!((first.jitter - 10.0).abs() < 0.000_001);
+        assert_eq!(manager.get_stats().fraction_lost, 0);
+
+        for (offset, sequence) in (13..=20).enumerate() {
+            manager.update_received_at(
+                sequence,
+                320 + offset as u32 * 160,
+                100,
+                start + Duration::from_millis(60 + offset as u64 * 20),
+            );
+        }
+
+        let second = manager.take_interval_stats();
+        assert_eq!(second.fraction_lost, 0);
+        assert_eq!(second.packets_lost, 1);
     }
 }

--- a/crates/media/rtp-core/src/stats/mod.rs
+++ b/crates/media/rtp-core/src/stats/mod.rs
@@ -171,16 +171,13 @@ impl RtpStatsManager {
                 stats.last_seq = Some(seq);
             }
             PacketLossResult::Sequential { seq } => {
-                stats.highest_seq = seq as u32;
                 stats.last_seq = Some(seq);
             }
             PacketLossResult::Gap {
                 seq,
                 expected: _,
-                lost,
+                lost: _,
             } => {
-                stats.packets_lost += lost as u64;
-                stats.highest_seq = seq as u32;
                 stats.last_seq = Some(seq);
             }
             PacketLossResult::Duplicate { seq: _ } => {
@@ -194,12 +191,17 @@ impl RtpStatsManager {
         }
 
         // Update jitter calculation
-        let jitter = self.jitter_estimator.update(timestamp, arrival_time);
+        let jitter = self
+            .jitter_estimator
+            .update_with_sequence(seq, timestamp, arrival_time);
         stats.jitter = jitter;
 
-        // Update fraction lost from loss tracker
+        // Recompute loss from the unique received-packet window so a late
+        // packet that fills a gap reduces the cumulative total.
         let loss_stats = self.loss_tracker.get_stats();
+        stats.packets_lost = loss_stats.packets_lost;
         stats.fraction_lost = loss_stats.fraction_lost;
+        stats.highest_seq = self.loss_tracker.highest_extended_sequence();
 
         // Update RTCP generator if available
         if let Some(generator) = &mut self.rtcp_generator {
@@ -269,5 +271,23 @@ mod tests {
         let stats = manager.get_stats();
         assert_eq!(stats.packets_sent, 1);
         assert_eq!(stats.bytes_sent, 100);
+    }
+
+    #[test]
+    fn reordered_packet_fills_loss_without_corrupting_jitter() {
+        let mut manager = RtpStatsManager::new(8000);
+        let start = Instant::now();
+
+        manager.update_received(65535, 0, 100, start);
+        manager.update_received(1, 320, 100, start + Duration::from_millis(40));
+        assert_eq!(manager.get_stats().packets_lost, 1);
+
+        let jitter_before_reorder = manager.get_stats().jitter;
+        manager.update_received(0, 160, 100, start + Duration::from_secs(5));
+        let stats = manager.get_stats();
+        assert_eq!(stats.packets_lost, 0);
+        assert_eq!(stats.packets_out_of_order, 1);
+        assert_eq!(stats.jitter, jitter_before_reorder);
+        assert_eq!(stats.highest_seq, 0x1_0001);
     }
 }

--- a/crates/media/rtp-core/src/stats/reports.rs
+++ b/crates/media/rtp-core/src/stats/reports.rs
@@ -23,7 +23,7 @@ pub struct RtcpReportGenerator {
     cname: String,
 
     /// Packet loss statistics by SSRC
-    loss_stats: HashMap<RtpSsrc, PacketLossTracker>,
+    loss_stats: HashMap<RtpSsrc, parking_lot::Mutex<PacketLossTracker>>,
 
     /// Time of last SR sent
     last_sr_time: Option<Instant>,
@@ -101,8 +101,27 @@ impl RtcpReportGenerator {
         let tracker = self
             .loss_stats
             .entry(ssrc)
-            .or_insert_with(|| PacketLossTracker::new());
-        tracker.process(seq);
+            .or_insert_with(|| parking_lot::Mutex::new(PacketLossTracker::new()));
+        tracker.get_mut().process(seq);
+    }
+
+    fn take_report_blocks(&self) -> Vec<RtcpReportBlock> {
+        self.loss_stats
+            .iter()
+            .take(31)
+            .map(|(ssrc, tracker)| {
+                let mut tracker = tracker.lock();
+                RtcpReportBlock {
+                    ssrc: *ssrc,
+                    fraction_lost: tracker.take_interval_fraction_lost(),
+                    cumulative_lost: tracker.get_cumulative_lost(),
+                    highest_seq: tracker.highest_extended_sequence(),
+                    jitter: 0,              // Jitter would be calculated separately
+                    last_sr: 0,             // Would be from received SRs
+                    delay_since_last_sr: 0, // Would be from received SRs
+                }
+            })
+            .collect()
     }
 
     /// Calculate RTCP interval based on session parameters
@@ -142,29 +161,10 @@ impl RtcpReportGenerator {
         self.last_sr_time = Some(Instant::now());
         self.last_rtp_timestamp = Some(rtp_timestamp);
 
-        // Create report blocks for each source we're receiving from
-        let mut report_blocks = Vec::new();
-
-        for (ssrc, tracker) in &self.loss_stats {
-            let stats = tracker.get_stats();
-
-            let report_block = RtcpReportBlock {
-                ssrc: *ssrc,
-                fraction_lost: stats.fraction_lost,
-                cumulative_lost: tracker.get_cumulative_lost(),
-                highest_seq: tracker.highest_extended_sequence(),
-                jitter: 0,              // Jitter would be calculated separately
-                last_sr: 0,             // Would be from received SRs
-                delay_since_last_sr: 0, // Would be from received SRs
-            };
-
-            report_blocks.push(report_block);
-
-            // Only include up to 31 report blocks (5-bit field in RTCP header)
-            if report_blocks.len() >= 31 {
-                break;
-            }
-        }
+        // RFC 3550 fraction loss covers the interval since the preceding
+        // report, while cumulative loss and highest sequence remain lifetime
+        // values.
+        let report_blocks = self.take_report_blocks();
 
         // Create SR
         RtcpSenderReport {
@@ -179,29 +179,7 @@ impl RtcpReportGenerator {
 
     /// Generate a Receiver Report (RR)
     pub fn generate_receiver_report(&self) -> RtcpReceiverReport {
-        // Create report blocks for each source we're receiving from
-        let mut report_blocks = Vec::new();
-
-        for (ssrc, tracker) in &self.loss_stats {
-            let stats = tracker.get_stats();
-
-            let report_block = RtcpReportBlock {
-                ssrc: *ssrc,
-                fraction_lost: stats.fraction_lost,
-                cumulative_lost: tracker.get_cumulative_lost(),
-                highest_seq: tracker.highest_extended_sequence(),
-                jitter: 0,              // Jitter would be calculated separately
-                last_sr: 0,             // Would be from received SRs
-                delay_since_last_sr: 0, // Would be from received SRs
-            };
-
-            report_blocks.push(report_block);
-
-            // Only include up to 31 report blocks (5-bit field in RTCP header)
-            if report_blocks.len() >= 31 {
-                break;
-            }
-        }
+        let report_blocks = self.take_report_blocks();
 
         // Create RR
         RtcpReceiverReport {
@@ -303,6 +281,41 @@ mod tests {
         assert_eq!(sr.report_blocks.len(), 1);
         assert_eq!(sr.report_blocks[0].ssrc, remote_ssrc);
         assert_eq!(sr.report_blocks[0].fraction_lost, 0); // No loss in our test
+    }
+
+    #[test]
+    fn sender_and_receiver_reports_use_interval_fraction_loss() {
+        let remote_ssrc = 0xabcdef01;
+
+        let mut sender_generator =
+            RtcpReportGenerator::new(0x12345678, "sender@example.com".to_string());
+        sender_generator.process_received_packet(remote_ssrc, 10);
+        sender_generator.process_received_packet(remote_ssrc, 12);
+        let first_sender = sender_generator.generate_sender_report(160);
+        assert_eq!(first_sender.report_blocks[0].fraction_lost, 85);
+        assert_eq!(first_sender.report_blocks[0].cumulative_lost, 1);
+
+        for sequence in 13..=20 {
+            sender_generator.process_received_packet(remote_ssrc, sequence);
+        }
+        let second_sender = sender_generator.generate_sender_report(320);
+        assert_eq!(second_sender.report_blocks[0].fraction_lost, 0);
+        assert_eq!(second_sender.report_blocks[0].cumulative_lost, 1);
+
+        let mut receiver_generator =
+            RtcpReportGenerator::new(0x87654321, "receiver@example.com".to_string());
+        receiver_generator.process_received_packet(remote_ssrc, 10);
+        receiver_generator.process_received_packet(remote_ssrc, 12);
+        let first_receiver = receiver_generator.generate_receiver_report();
+        assert_eq!(first_receiver.report_blocks[0].fraction_lost, 85);
+        assert_eq!(first_receiver.report_blocks[0].cumulative_lost, 1);
+
+        for sequence in 13..=20 {
+            receiver_generator.process_received_packet(remote_ssrc, sequence);
+        }
+        let second_receiver = receiver_generator.generate_receiver_report();
+        assert_eq!(second_receiver.report_blocks[0].fraction_lost, 0);
+        assert_eq!(second_receiver.report_blocks[0].cumulative_lost, 1);
     }
 
     #[test]

--- a/crates/media/rtp-core/src/stats/reports.rs
+++ b/crates/media/rtp-core/src/stats/reports.rs
@@ -143,7 +143,7 @@ impl RtcpReportGenerator {
                 ssrc: *ssrc,
                 fraction_lost: stats.fraction_lost,
                 cumulative_lost: tracker.get_cumulative_lost(),
-                highest_seq: stats.packets_expected as u32,
+                highest_seq: tracker.highest_extended_sequence(),
                 jitter: 0,              // Jitter would be calculated separately
                 last_sr: 0,             // Would be from received SRs
                 delay_since_last_sr: 0, // Would be from received SRs
@@ -180,7 +180,7 @@ impl RtcpReportGenerator {
                 ssrc: *ssrc,
                 fraction_lost: stats.fraction_lost,
                 cumulative_lost: tracker.get_cumulative_lost(),
-                highest_seq: stats.packets_expected as u32,
+                highest_seq: tracker.highest_extended_sequence(),
                 jitter: 0,              // Jitter would be calculated separately
                 last_sr: 0,             // Would be from received SRs
                 delay_since_last_sr: 0, // Would be from received SRs

--- a/crates/media/rtp-core/src/stats/reports.rs
+++ b/crates/media/rtp-core/src/stats/reports.rs
@@ -87,6 +87,15 @@ impl RtcpReportGenerator {
         self.octets_sent += octets;
     }
 
+    /// Replace the cumulative RTP sender totals used by the next report.
+    ///
+    /// Session statistics are already cumulative. Using the additive update
+    /// API on every periodic tick would count the same packets repeatedly.
+    pub fn set_sent_totals(&mut self, packets: u32, octets: u32) {
+        self.packets_sent = packets;
+        self.octets_sent = octets;
+    }
+
     /// Process a received RTP packet
     pub fn process_received_packet(&mut self, ssrc: RtpSsrc, seq: u16) {
         let tracker = self
@@ -294,6 +303,21 @@ mod tests {
         assert_eq!(sr.report_blocks.len(), 1);
         assert_eq!(sr.report_blocks[0].ssrc, remote_ssrc);
         assert_eq!(sr.report_blocks[0].fraction_lost, 0); // No loss in our test
+    }
+
+    #[test]
+    fn setting_cumulative_sender_totals_does_not_double_count() {
+        let mut generator = RtcpReportGenerator::new(0x12345678, "test".to_string());
+
+        generator.set_sent_totals(3, 30);
+        let first = generator.generate_sender_report(100);
+        generator.set_sent_totals(3, 30);
+        let second = generator.generate_sender_report(200);
+
+        assert_eq!(first.sender_packet_count, 3);
+        assert_eq!(first.sender_octet_count, 30);
+        assert_eq!(second.sender_packet_count, 3);
+        assert_eq!(second.sender_octet_count, 30);
     }
 
     #[test]

--- a/crates/media/rtp-core/src/stats/rtt.rs
+++ b/crates/media/rtp-core/src/stats/rtt.rs
@@ -78,13 +78,13 @@ impl RttEstimator {
             return None;
         }
 
-        // Find the corresponding SR record
-        // We need to match the NTP timestamp from our sent SRs with the one in the receiver report
-        // The last_sr in the receiver report contains the middle 16 bits of the NTP timestamp seconds
+        // The LSR field is the complete middle 32 bits of the 64-bit NTP
+        // timestamp: low 16 bits of seconds followed by high 16 bits of the
+        // fractional part (RFC 3550 section 6.4.1).
         let sr_record = self
             .sr_timestamps
             .iter()
-            .find(|(s, ntp, _)| *s == ssrc && ((ntp.seconds >> 16) as u32) == last_sr);
+            .find(|(s, ntp, _)| *s == ssrc && ntp.to_u32() == last_sr);
 
         if let Some((_, _, sent_time)) = sr_record {
             // Calculate RTT
@@ -222,12 +222,12 @@ mod tests {
         let mut estimator = RttEstimator::new();
 
         // Record an SR sent with NTP timestamp
-        // The NTP timestamp has seconds in the upper 32 bits, which we'll set to 0xabcd0000
-        // In the receiver report, last_sr would be the middle 16 bits, which is 0xabcd
+        // LSR contains the low 16 bits of seconds and the high 16 bits of the
+        // fractional part.
         let ssrc = 0x12345678;
         let ntp = NtpTimestamp {
-            seconds: 0xabcd0000,
-            fraction: 0x12345678,
+            seconds: 0xabcd1234,
+            fraction: 0x5678ef01,
         };
         estimator.record_sr_sent(ssrc, ntp);
 
@@ -235,8 +235,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
 
         // Process a receiver report
-        // The last_sr field in a receiver report is the middle 16 bits of NTP timestamp seconds
-        let last_sr = 0xabcd;
+        let last_sr = 0x12345678;
         let delay = (0.01 * 65536.0) as u32; // 10ms delay, in Q16 format
 
         let rtt = estimator.process_receiver_report(ssrc, last_sr, delay);
@@ -257,16 +256,35 @@ mod tests {
     }
 
     #[test]
+    fn test_lsr_requires_all_middle_ntp_bits() {
+        let mut estimator = RttEstimator::new();
+        let ssrc = 0x12345678;
+        estimator.record_sr_sent(
+            ssrc,
+            NtpTimestamp {
+                seconds: 0xaaaa1234,
+                fraction: 0x5678bbbb,
+            },
+        );
+
+        assert!(estimator
+            .process_receiver_report(ssrc, 0x12345678, 0)
+            .is_some());
+        assert!(estimator
+            .process_receiver_report(ssrc, 0x12340000, 0)
+            .is_none());
+    }
+
+    #[test]
     fn test_rtt_tracking() {
         let mut estimator = RttEstimator::new();
 
         // Simulate several measurements
         for i in 0..5 {
             let ssrc = 0x12345678;
-            // Create an NTP timestamp where the middle 16 bits of the seconds will be 0xabcd + i
             let ntp = NtpTimestamp {
-                seconds: ((0xabcd + i) << 16),
-                fraction: 0x12345678,
+                seconds: 0xabcd1200 | i,
+                fraction: ((0x3400 | i) << 16) | 0x5678,
             };
             estimator.record_sr_sent(ssrc, ntp);
 
@@ -274,8 +292,7 @@ mod tests {
             let delay_ms = 50 + (i * 10); // 50, 60, 70, 80, 90 ms
             std::thread::sleep(Duration::from_millis(delay_ms.into()));
 
-            // The last_sr field in a receiver report is the middle 16 bits of NTP timestamp seconds
-            let last_sr = (0xabcd + i) as u32;
+            let last_sr = ntp.to_u32();
             let delay = (0.01 * 65536.0) as u32; // 10ms delay
 
             let rtt = estimator.process_receiver_report(ssrc, last_sr, delay);

--- a/crates/media/rtp-core/src/traits/mod.rs
+++ b/crates/media/rtp-core/src/traits/mod.rs
@@ -55,6 +55,10 @@ pub enum RtpEvent {
         /// Payload data
         payload: Bytes,
 
+        /// RFC 3550 padding octets stripped from `payload` while parsing.
+        /// Zero means the RTP padding bit was clear.
+        padding_size: u8,
+
         /// Source address
         source: SocketAddr,
 

--- a/crates/media/rtp-core/src/transport/security_transport.rs
+++ b/crates/media/rtp-core/src/transport/security_transport.rs
@@ -114,6 +114,7 @@ impl SecurityRtpTransport {
                                             timestamp: decrypted_packet.header.timestamp,
                                             marker: decrypted_packet.header.marker,
                                             payload: decrypted_packet.payload.clone(),
+                                            padding_size: decrypted_packet.padding_size,
                                             source: addr,
                                             ssrc: decrypted_packet.header.ssrc,
                                         };
@@ -148,6 +149,7 @@ impl SecurityRtpTransport {
                                     timestamp: rtp_packet.header.timestamp,
                                     marker: rtp_packet.header.marker,
                                     payload: rtp_packet.payload.clone(),
+                                    padding_size: rtp_packet.padding_size,
                                     source: addr,
                                     ssrc: rtp_packet.header.ssrc,
                                 };

--- a/crates/media/rtp-core/src/transport/udp.rs
+++ b/crates/media/rtp-core/src/transport/udp.rs
@@ -1176,9 +1176,8 @@ impl UdpRtpTransport {
             ))
         } else {
             buffer.clear();
-            packet.header.serialize(buffer)?;
-            buffer.extend_from_slice(&packet.payload);
-            self.send_rtp_wire_bytes_unchecked(buffer, dest).await
+            let data = packet.serialize_into(buffer)?;
+            self.send_rtp_wire_bytes_unchecked(&data, dest).await
         }
     }
 }
@@ -1783,7 +1782,8 @@ mod tests {
         // Create a test packet
         let header = RtpHeader::new(96, 1000, 12345, 0xabcdef01);
         let payload = Bytes::from_static(b"test payload");
-        let packet = RtpPacket::new(header, payload.clone());
+        let mut packet = RtpPacket::new(header, payload.clone());
+        packet.set_padding(4);
 
         // Send from transport1 to transport2
         let addr2 = transport2.local_rtp_addr().unwrap();

--- a/crates/media/rtp-core/src/transport/udp.rs
+++ b/crates/media/rtp-core/src/transport/udp.rs
@@ -872,6 +872,7 @@ impl UdpRtpTransport {
                                             timestamp: packet.header.timestamp,
                                             marker: packet.header.marker,
                                             payload: packet.payload.clone(), // Use the parsed payload
+                                            padding_size: packet.padding_size,
                                             source: addr,
                                             ssrc: packet.header.ssrc, // Include the SSRC from the parsed packet
                                         };

--- a/crates/media/rtp-core/tests/rtp_correctness_regression_first.rs
+++ b/crates/media/rtp-core/tests/rtp_correctness_regression_first.rs
@@ -1,0 +1,13 @@
+use rvoip_rtp_core::packet::extension::RtpHeaderExtensions;
+
+#[test]
+fn aligned_rfc8285_one_byte_extensions_have_no_synthetic_end_marker() {
+    let mut extensions = RtpHeaderExtensions::new_one_byte();
+    extensions.add_extension(1, vec![1, 2, 3]).unwrap();
+
+    assert_eq!(
+        extensions.serialize().unwrap().as_ref(),
+        &[0x12, 1, 2, 3],
+        "an already aligned RFC 8285 extension block must not grow an extra word"
+    );
+}


### PR DESCRIPTION
## What changed

- add explicit RTP padding length with strict parse/serialize validation and end-to-end plain/SRTP preservation
- implement RFC 8285 one-byte and two-byte extension padding, reserved-ID, empty-element, and alignment rules
- track extended RTP sequence numbers, bounded receive history, duplicates, reordering, wraparound, interval loss, and sequence-aware jitter
- calculate LSR from the complete middle 32 NTP bits and preserve SR state across stream creation races
- preserve unknown well-formed RTCP members in tolerant compound parsing while rejecting malformed length, version, and padding
- wire the corrected parser and statistics into production UDP/session paths, including coherent Sender Report snapshots

## Regression-first evidence

The first commit adds an RFC 8285 regression that fails on merged `main`: an already aligned one-byte extension block receives an artificial extra zero word. It passes after the implementation commits.

## Validation

- `cargo test -p rvoip-rtp-core`: 359 unit tests plus malformed-input, regression-first, 24 fail-closed security, security regression, STUN, and doc tests passed
- `cargo test -p rvoip-rtp-core --all-features`: same matrix passed
- `cargo test -p rvoip-rtp-core --all-features --all-targets`: all tests, benches, and examples passed
- `cargo clippy -p rvoip-rtp-core --all-targets --all-features -- -D warnings`
- `cargo check -p rvoip-media-core --all-features`
- formatting and diff checks passed

## Compatibility and scope

`RtpPacket` and `RtpEvent::MediaReceived` now carry explicit padding metadata; migration guidance is included. SRTCP remains fail-closed until the dedicated state-management PR. The raw workspace `--all-features` command still hits the pre-existing mutually exclusive Tokio/Smol WebRTC runtime collision; this PR does not modify the standalone WebRTC stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core RTP/RTCP parsing, public structs/events, SRTP wire format, and live session statistics—any mistake affects interoperability and downstream pattern matches on `MediaReceived`.
> 
> **Overview**
> **0.3.5 correctness repair** for `rvoip-rtp-core`: RTP padding is first-class metadata, header extensions and RTCP parsing follow RFC rules more strictly, receive/RTCP statistics match RFC 3550 semantics, and the live session path uses the new behavior. `CORRECTNESS_MIGRATION_0.3.5.md` documents breaking API touches.
> 
> **RTP padding** — `RtpPacket` and `RtpEvent::MediaReceived` gain `padding_size`; payloads stay unpadded on parse, with strict serialize validation. SRTP encrypts/decrypts padding with the media region and restores it on unprotect.
> 
> **RFC 8285 extensions** — One/two-byte extension serialization and parsing no longer use artificial end markers; padding between elements, reserved IDs, empty one-byte elements, and alignment are handled per spec.
> 
> **Statistics** — Extended sequence tracking, bounded receive windows, interval vs cumulative loss, sequence-aware jitter (timestamp units in `RtpStreamStats`; use session `jitter_ms` for ms), and `packets_out_of_order`. RTCP report blocks and sender octet counts use payload-only octets; SR-before-RTP and precreated-stream races are reconciled. Default ingress stays unbuffered (jitter buffer no longer enabled on manual stream creation).
> 
> **RTCP** — Shared envelope parsing with padding validation; real SDES body parsing; `RtcpUnknownPacket` plus `RtcpTolerantCompoundPacket` / `parse_tolerant` preserve unknown types in compounds while strict `RtcpPacket` stays unchanged. Session RTCP ingress uses tolerant parsing and skips unimplemented types.
> 
> **Misc** — SRTCP protect bench removed (SRTCP still fail-closed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75835284f503347d1ce287862923511a5c499cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->