### PR TITLE
Make media performance gates scheduler-independent

### DIFF
--- a/.github/workflows/workspace-test-clippy.yml
+++ b/.github/workflows/workspace-test-clippy.yml
@@ -32,7 +32,9 @@ jobs:
   test:
     name: cargo test (core)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The post-RTP-correctness suite takes about 28 minutes on hosted runners,
+    # and the remaining 0.3.5 security/signaling regressions add coverage.
+    timeout-minutes: 60
     env:
       # The default-member test graph links several large SIP integration
       # binaries. Full debug info plus incremental artifacts exhausts the

--- a/crates/media/media-core/benches/audio_frame_pipeline.rs
+++ b/crates/media/media-core/benches/audio_frame_pipeline.rs
@@ -22,6 +22,10 @@
 
 use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rvoip_media_core::performance::{
+    pool::{AudioFramePool, PoolConfig},
+    zero_copy::ZeroCopyAudioFrame,
+};
 use rvoip_media_core::relay::controller::MediaSessionController;
 use rvoip_rtp_core::{RtpHeader, RtpPacket};
 use std::sync::Arc;
@@ -31,6 +35,7 @@ use tokio::runtime::Builder;
 const PAYLOAD_SIZE: usize = 160; // G.711 µ-law, 20 ms @ 8 kHz
 const OPS_PER_TASK: u64 = 200;
 const CONCURRENT_TASK_COUNTS: [usize; 4] = [1, 4, 8, 16];
+const FRAME_SAMPLES: usize = 160;
 
 fn make_packet(seq: u16) -> RtpPacket {
     let header = RtpHeader::new(0 /* µ-law PT */, seq, (seq as u32) * 160, 0xdead_beef);
@@ -128,5 +133,43 @@ fn bench_concurrent(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_single, bench_concurrent);
+/// Compare fresh frame allocation with a prewarmed pool. This used to be a
+/// single wall-clock ratio assertion in `cargo test`, where scheduler noise
+/// could reverse the result. Criterion supplies warmup, repeated sampling, and
+/// outlier analysis while the ordinary tests retain deterministic pool checks.
+fn bench_frame_acquisition(c: &mut Criterion) {
+    let pool = AudioFramePool::new(PoolConfig {
+        initial_size: 32,
+        max_size: 128,
+        sample_rate: 8_000,
+        channels: 1,
+        samples_per_frame: FRAME_SAMPLES,
+    });
+    pool.prewarm(32);
+
+    let mut group = c.benchmark_group("audio_frame_acquisition");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("fresh_allocation", |b| {
+        b.iter(|| {
+            let samples = vec![black_box(100i16); FRAME_SAMPLES];
+            black_box(ZeroCopyAudioFrame::new(samples, 8_000, 1, 0));
+        });
+    });
+
+    group.bench_function("prewarmed_pool", |b| {
+        b.iter(|| {
+            black_box(pool.get_frame());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_single,
+    bench_concurrent,
+    bench_frame_acquisition
+);
 criterion_main!(benches);

--- a/crates/media/media-core/src/performance/metrics.rs
+++ b/crates/media/media-core/src/performance/metrics.rs
@@ -647,18 +647,43 @@ mod tests {
             iterations: 10, // Small for test speed
             ..Default::default()
         };
+        let expected_iterations = config.iterations as u64;
+        let expected_frame_bytes = config.frame_size as u64
+            * u64::from(config.channels)
+            * std::mem::size_of::<i16>() as u64;
 
         let benchmark = AudioFrameBenchmark::new(config);
         let results = benchmark.run_comprehensive_benchmark();
 
-        // All metrics should have been populated
-        assert!(results.traditional_metrics.operation_count > 0);
-        assert!(results.zero_copy_metrics.operation_count > 0);
-        assert!(results.pooled_metrics.operation_count > 0);
-
-        // Zero-copy should typically be faster (though test data might be small)
-        let summary = results.calculate_improvements();
-        assert!(summary.zero_copy_speedup >= 0.5); // At least not much slower
-        assert!(summary.pooled_speedup >= 0.5);
+        // Gate deterministic work/allocation properties here. Comparative
+        // wall-clock timing is measured by the media-core Criterion benches;
+        // a ten-iteration timing ratio is not stable under hosted-CI load.
+        assert_eq!(
+            results.traditional_metrics.operation_count,
+            expected_iterations
+        );
+        assert_eq!(
+            results.zero_copy_metrics.operation_count,
+            expected_iterations
+        );
+        assert_eq!(results.pooled_metrics.operation_count, expected_iterations);
+        assert_eq!(
+            results.traditional_metrics.allocation_count,
+            expected_iterations
+        );
+        assert_eq!(
+            results.zero_copy_metrics.allocation_count,
+            expected_iterations
+        );
+        assert_eq!(results.pooled_metrics.allocation_count, 0);
+        assert_eq!(
+            results.traditional_metrics.memory_allocated,
+            expected_iterations * expected_frame_bytes * 3
+        );
+        assert_eq!(
+            results.zero_copy_metrics.memory_allocated,
+            expected_iterations * expected_frame_bytes
+        );
+        assert_eq!(results.pooled_metrics.memory_allocated, 0);
     }
 }

--- a/crates/media/media-core/tests/g711_performance_benchmark.rs
+++ b/crates/media/media-core/tests/g711_performance_benchmark.rs
@@ -1,7 +1,9 @@
 //! G.711 Codec Performance Benchmark
 //!
-//! This test verifies that our optimized G.711 codec provides significant performance
-//! improvements over naive implementations.
+//! These tests verify G.711 output and buffer-reuse behavior while printing timing
+//! for local diagnostics. Comparative timing is intentionally not a `cargo test`
+//! pass/fail condition; release performance is measured by the Criterion and beta
+//! qualification lanes, where scheduler noise can be sampled properly.
 
 use codec_core::codecs::g711::{alaw_compress, alaw_expand, ulaw_compress, ulaw_expand};
 use rvoip_media_core::codec::audio::common::AudioCodec;
@@ -239,10 +241,14 @@ async fn test_g711_codec_api_performance() {
     let mut decode_buffer = vec![0i16; frame_size];
 
     // Benchmark traditional API (with allocations)
+    let mut traditional_encoded = Vec::new();
+    let mut traditional_decoded = None;
     let start = Instant::now();
     for _ in 0..iterations {
         let encoded = codec.encode(&test_frame).unwrap();
-        let _decoded = codec.decode(&encoded).unwrap();
+        let decoded = codec.decode(&encoded).unwrap();
+        traditional_encoded = encoded;
+        traditional_decoded = Some(decoded);
     }
     let traditional_time = start.elapsed();
 
@@ -264,11 +270,11 @@ async fn test_g711_codec_api_performance() {
     println!("Zero-allocation API: {:?}", zero_alloc_time);
     println!("Zero-alloc speedup:  {:.2}x", speedup);
 
-    // Zero-allocation should be at least competitive (allow for small variance)
-    // Note: Performance is similar between APIs
-    println!("(Performance ratio is expected)");
+    let traditional_decoded = traditional_decoded.expect("traditional decode produced a frame");
+    assert_eq!(encode_buffer, traditional_encoded);
+    assert_eq!(decode_buffer, traditional_decoded.samples);
 
-    println!("✅ Zero-allocation API provides competitive performance");
+    println!("✅ Allocating and buffer-reuse APIs produce identical output");
 }
 
 #[tokio::test]
@@ -362,19 +368,12 @@ async fn test_g711_realtime_performance() {
         realtime_factor
     );
 
-    // Should use much less than 1% of CPU time for real-time processing
-    assert!(
-        cpu_usage_percent < 1.0,
-        "Should use <1% CPU time, got {:.3}%",
-        cpu_usage_percent
-    );
-    assert!(
-        realtime_factor > 100.0,
-        "Should be 100x faster than real-time, got {:.1}x",
-        realtime_factor
-    );
+    let expected_encoded: Vec<u8> = test_samples.iter().copied().map(ulaw_compress).collect();
+    let expected_decoded: Vec<i16> = expected_encoded.iter().copied().map(ulaw_expand).collect();
+    assert_eq!(encoded, expected_encoded);
+    assert_eq!(decoded, expected_decoded);
 
-    println!("✅ G.711 codec meets real-time performance requirements");
+    println!("✅ G.711 encode/decode correctness verified");
 }
 
 #[tokio::test]
@@ -414,13 +413,17 @@ async fn test_g711_memory_efficiency() {
     println!("Average per encode/decode cycle: {:?}", avg_time_per_cycle);
     println!("Memory allocations: 0 (buffers reused)");
 
-    // Verify consistent performance (no allocation overhead)
-    assert!(
-        avg_time_per_cycle < std::time::Duration::from_micros(50),
-        "Average cycle should be <50μs with buffer reuse"
-    );
+    let expected_encoded: Vec<u8> = test_frame
+        .samples
+        .iter()
+        .copied()
+        .map(ulaw_compress)
+        .collect();
+    let expected_decoded: Vec<i16> = expected_encoded.iter().copied().map(ulaw_expand).collect();
+    assert_eq!(encode_buffer, expected_encoded);
+    assert_eq!(decode_buffer, expected_decoded);
 
-    println!("✅ Zero-allocation G.711 processing achieved");
+    println!("✅ Reused buffers retain correct G.711 output");
 }
 
 #[tokio::test]

--- a/crates/media/media-core/tests/performance_tests.rs
+++ b/crates/media/media-core/tests/performance_tests.rs
@@ -1,7 +1,11 @@
 //! Performance optimization tests
 //!
-//! This module tests the zero-copy and object pooling optimizations
-//! to validate performance improvements.
+//! This module tests the zero-copy and object pooling optimizations.
+//!
+//! Wall-clock measurements are printed as local diagnostics only. Comparative
+//! timing belongs in the Criterion benchmarks (`cargo bench -p
+//! rvoip-media-core`), because a single sample inside `cargo test` is sensitive
+//! to scheduler contention on hosted CI.
 
 use rvoip_media_core::performance::{
     metrics::{BenchmarkConfig, BenchmarkResults, PerformanceMetrics},
@@ -162,6 +166,35 @@ impl AudioFrameBenchmark {
     }
 }
 
+/// Validate the deterministic work and allocation invariants behind a benchmark
+/// run. Timing is intentionally excluded: ordinary tests should prove that each
+/// strategy did equivalent work and retained its allocation characteristics,
+/// while Criterion owns comparative timing.
+fn assert_benchmark_invariants(results: &BenchmarkResults) {
+    let iterations = results.test_config.iterations as u64;
+    let frame_bytes = results.test_config.frame_size as u64
+        * u64::from(results.test_config.channels)
+        * std::mem::size_of::<i16>() as u64;
+
+    assert_eq!(results.traditional_metrics.operation_count, iterations);
+    assert_eq!(results.zero_copy_metrics.operation_count, iterations);
+    assert_eq!(results.pooled_metrics.operation_count, iterations);
+
+    assert_eq!(results.traditional_metrics.allocation_count, iterations);
+    assert_eq!(results.zero_copy_metrics.allocation_count, iterations);
+    assert_eq!(results.pooled_metrics.allocation_count, 0);
+
+    assert_eq!(
+        results.traditional_metrics.memory_allocated,
+        iterations * frame_bytes * 3
+    );
+    assert_eq!(
+        results.zero_copy_metrics.memory_allocated,
+        iterations * frame_bytes
+    );
+    assert_eq!(results.pooled_metrics.memory_allocated, 0);
+}
+
 #[tokio::test]
 #[serial]
 async fn test_zero_copy_audio_frame() {
@@ -276,23 +309,9 @@ async fn test_performance_benchmark_small() {
     let results = benchmark.run_comprehensive_benchmark();
 
     results.print_results();
+    assert_benchmark_invariants(&results);
 
-    // Verify improvements
-    let summary = results.calculate_improvements();
-
-    // Zero-copy should be at least as fast as traditional
-    assert!(
-        summary.zero_copy_speedup >= 0.8,
-        "Zero-copy should be competitive"
-    );
-
-    // Pooled should be at least as fast as traditional
-    assert!(
-        summary.pooled_speedup >= 0.8,
-        "Pooled should be competitive"
-    );
-
-    println!("✅ Performance improvements validated");
+    println!("✅ Benchmark work and allocation invariants validated");
 }
 
 #[tokio::test]
@@ -313,20 +332,9 @@ async fn test_performance_benchmark_large() {
     let results = benchmark.run_comprehensive_benchmark();
 
     results.print_results();
+    assert_benchmark_invariants(&results);
 
-    // Verify improvements are more pronounced with larger frames
-    let summary = results.calculate_improvements();
-
-    assert!(
-        summary.zero_copy_speedup >= 1.0,
-        "Zero-copy should show improvement with larger frames"
-    );
-    assert!(
-        summary.pooled_speedup >= 1.0,
-        "Pooled should show improvement with larger frames"
-    );
-
-    println!("✅ Large frame performance improvements validated");
+    println!("✅ Large-frame work and allocation invariants validated");
 }
 
 #[tokio::test]
@@ -376,7 +384,9 @@ async fn test_audio_processing_pipeline_performance() {
     let frame_size = 160;
     let sample_rate = 8000;
 
-    // Traditional pipeline timing
+    // Traditional pipeline timing. Retain the final output so this ordinary
+    // test gates semantic equivalence instead of a scheduler-sensitive ratio.
+    let mut traditional_output = None;
     let start = Instant::now();
     for _i in 0..iterations {
         let samples = vec![100i16; frame_size];
@@ -400,16 +410,18 @@ async fn test_audio_processing_pipeline_performance() {
         );
 
         let final_samples = stage2_frame.samples.clone();
-        let _final_frame = AudioFrame::new(
+        let final_frame = AudioFrame::new(
             final_samples,
             stage2_frame.sample_rate,
             stage2_frame.channels,
             stage2_frame.timestamp,
         );
+        traditional_output = Some(final_frame);
     }
     let traditional_time = start.elapsed();
 
     // Zero-copy pipeline timing
+    let mut zero_copy_output = None;
     let start = Instant::now();
     for _i in 0..iterations {
         let samples = vec![100i16; frame_size];
@@ -418,7 +430,8 @@ async fn test_audio_processing_pipeline_performance() {
         // Simulate 3-stage processing pipeline with no copies
         let stage1_frame = input_frame.clone();
         let stage2_frame = stage1_frame.clone();
-        let _final_frame = stage2_frame.clone();
+        let final_frame = stage2_frame.clone();
+        zero_copy_output = Some(final_frame);
     }
     let zero_copy_time = start.elapsed();
 
@@ -428,12 +441,14 @@ async fn test_audio_processing_pipeline_performance() {
     println!("Zero-copy pipeline:   {:?}", zero_copy_time);
     println!("Speedup: {:.2}x", speedup);
 
-    assert!(
-        speedup >= 1.0,
-        "Zero-copy pipeline should be at least as fast as traditional, got {:.2}x",
-        speedup
-    );
-    println!("✅ Zero-copy pipeline performance improvement verified");
+    let traditional_output = traditional_output.expect("traditional pipeline produced a frame");
+    let zero_copy_output = zero_copy_output.expect("zero-copy pipeline produced a frame");
+    assert_eq!(traditional_output.samples, zero_copy_output.samples());
+    assert_eq!(traditional_output.sample_rate, zero_copy_output.sample_rate);
+    assert_eq!(traditional_output.channels, zero_copy_output.channels);
+    assert_eq!(traditional_output.timestamp, zero_copy_output.timestamp);
+
+    println!("✅ Pipeline output equivalence verified");
 }
 
 #[tokio::test]
@@ -448,19 +463,24 @@ async fn test_pool_vs_allocation_performance() {
 
     // Pre-warm pool
     pool.prewarm(50);
+    let warmed_pool_size = pool.get_stats().pool_size;
 
     // Fresh allocation timing
+    let mut allocated_sample_total = 0i64;
     let start = Instant::now();
     for _i in 0..iterations {
         let samples = vec![100i16; 160];
-        let _frame = ZeroCopyAudioFrame::new(samples, 8000, 1, 0);
+        let frame = ZeroCopyAudioFrame::new(samples, 8000, 1, 0);
+        allocated_sample_total += i64::from(frame.samples()[0]);
     }
     let allocation_time = start.elapsed();
 
     // Pool reuse timing
+    let mut pooled_sample_total = 0i64;
     let start = Instant::now();
     for _i in 0..iterations {
-        let _frame = pool.get_frame();
+        let frame = pool.get_frame();
+        pooled_sample_total += i64::from(frame.samples()[0]);
     }
     let pool_time = start.elapsed();
 
@@ -476,10 +496,13 @@ async fn test_pool_vs_allocation_performance() {
         pool_stats.pool_hits, pool_stats.pool_misses
     );
 
-    assert!(
-        speedup >= 0.9,
-        "Pool should be competitive with fresh allocation, got {:.2}x",
-        speedup
-    );
-    println!("✅ Pool performance improvement verified");
+    assert_eq!(allocated_sample_total, iterations as i64 * 100);
+    assert_eq!(pooled_sample_total, 0);
+    assert_eq!(pool_stats.pool_hits, iterations);
+    assert_eq!(pool_stats.pool_misses, 0);
+    assert_eq!(pool_stats.allocated_count, iterations);
+    assert_eq!(pool_stats.returned_count, iterations);
+    assert_eq!(pool_stats.pool_size, warmed_pool_size);
+
+    println!("✅ Pool reuse and accounting invariants verified");
 }

--- a/crates/media/media-core/tests/rtp_performance_integration.rs
+++ b/crates/media/media-core/tests/rtp_performance_integration.rs
@@ -1,8 +1,9 @@
 //! RTP-Core Performance Integration Tests
 //!
 //! This module tests the integration between media-core's performance optimizations
-//! and rtp-core's RTP packet handling, validating zero-copy performance across
-//! the complete RTP → Audio Processing → RTP pipeline.
+//! and rtp-core's RTP packet handling across the complete RTP → Audio Processing
+//! → RTP pipeline. Wall-clock values are diagnostic only; Criterion and beta
+//! qualification own comparative performance gates.
 
 use rvoip_media_core::performance::{
     pool::{AudioFramePool, PoolConfig},
@@ -401,8 +402,19 @@ async fn test_rtp_pooled_performance() {
             create_test_rtp_packet(1000 + i, 160000 + (i as u32 * 160), config.frame_size);
 
         let start = Instant::now();
-        let _output_packet = pipeline.process_rtp_packet_pooled(&input_packet).unwrap();
+        let output_packet = pipeline.process_rtp_packet_pooled(&input_packet).unwrap();
         total_processing_time += start.elapsed();
+
+        assert_eq!(
+            output_packet.header.sequence_number,
+            input_packet.header.sequence_number.wrapping_add(1)
+        );
+        assert_eq!(
+            output_packet.header.timestamp,
+            input_packet.header.timestamp
+        );
+        assert_eq!(output_packet.header.ssrc, input_packet.header.ssrc);
+        assert_eq!(output_packet.payload.len(), input_packet.payload.len());
     }
 
     let avg_processing_time = total_processing_time / 10;
@@ -416,14 +428,14 @@ async fn test_rtp_pooled_performance() {
         100.0 * pool_stats.pool_hits as f32 / pool_stats.allocated_count as f32
     );
 
-    // Pool should be highly efficient
-    assert!(pool_stats.pool_hits >= 8, "Pool should have high hit rate");
-    assert!(
-        avg_processing_time < std::time::Duration::from_micros(500),
-        "Should be reasonably fast with pooling"
-    );
+    // The pool was prewarmed and every checkout is returned before the next
+    // iteration, so misses would indicate a functional pooling regression.
+    assert_eq!(pool_stats.pool_hits, 10);
+    assert_eq!(pool_stats.pool_misses, 0);
+    assert_eq!(pool_stats.allocated_count, 10);
+    assert_eq!(pool_stats.returned_count, 10);
 
-    println!("✅ Pooled RTP processing highly efficient");
+    println!("✅ Pooled RTP processing and reuse accounting verified");
 }
 
 #[tokio::test]
@@ -463,6 +475,14 @@ async fn test_rtp_performance_comparison() {
             .process_rtp_packet_pooled(&test_packets[0])
             .unwrap(),
     );
+
+    let zero_copy_output = pipeline
+        .process_rtp_packet_zero_copy(&test_packets[0])
+        .unwrap();
+    let pooled_output = pipeline
+        .process_rtp_packet_pooled(&test_packets[0])
+        .unwrap();
+    assert_eq!(zero_copy_output, pooled_output);
 
     let measure_zero_copy = || {
         let start = Instant::now();
@@ -509,25 +529,7 @@ async fn test_rtp_performance_comparison() {
         100.0 * pool_stats.pool_hits as f32 / pool_stats.allocated_count as f32
     );
 
-    // Pooled should remain competitive. Under `memory-diagnostics`, every pool
-    // checkout and return intentionally records lifecycle evidence while the
-    // zero-copy comparator has no equivalent instrumentation, so allow that
-    // bounded diagnostic overhead. Release performance regressions are gated
-    // by the dedicated criterion/beta performance profiles, not this
-    // debug-build integration smoke test.
-    let minimum_competitive_ratio = if cfg!(feature = "memory-diagnostics") {
-        0.75
-    } else {
-        0.85
-    };
-    assert!(
-        speedup >= minimum_competitive_ratio,
-        "Pooled processing should be competitive with zero-copy, got {:.2}x (minimum {:.2}x)",
-        speedup,
-        minimum_competitive_ratio,
-    );
-
-    println!("✅ Performance comparison validates optimization benefits");
+    println!("✅ Pooled and zero-copy RTP paths produce identical output");
 }
 
 #[tokio::test]
@@ -594,13 +596,7 @@ async fn test_rtp_simd_integration() {
     // Verify audio was processed (gain applied)
     assert_ne!(output_packet.payload, input_packet.payload);
 
-    // Should be reasonably fast with SIMD
-    assert!(
-        simd_time < std::time::Duration::from_millis(1),
-        "SIMD processing should be fast"
-    );
-
-    println!("✅ SIMD integration working with RTP processing");
+    println!("✅ SIMD integration output verified");
 }
 
 #[tokio::test]
@@ -638,7 +634,8 @@ async fn test_rtp_end_to_end_latency() {
 
         // Step 3: RTP packet serialization (rtp-core)
         let serialize_start = Instant::now();
-        let _final_bytes = processed_packet.serialize().unwrap();
+        let final_bytes = processed_packet.serialize().unwrap();
+        std::hint::black_box(final_bytes);
         serialize_time = serialize_time.min(serialize_start.elapsed());
 
         total_time = total_time.min(start.elapsed());
@@ -649,19 +646,15 @@ async fn test_rtp_end_to_end_latency() {
     println!("RTP serialize time:   {:?}", serialize_time);
     println!("Total end-to-end:     {:?}", total_time);
 
-    // Total latency should be well under 1ms for real-time processing
-    assert!(
-        total_time < std::time::Duration::from_millis(1),
-        "End-to-end latency should be <1ms, got {:?}",
-        total_time
-    );
+    let serialized = input_packet.serialize().unwrap();
+    let parsed_packet = RtpPacket::parse(&serialized).unwrap();
+    assert_eq!(parsed_packet, input_packet);
+    let processed_packet = pipeline
+        .process_rtp_packet_zero_copy(&parsed_packet)
+        .unwrap();
+    let final_bytes = processed_packet.serialize().unwrap();
+    let reparsed_packet = RtpPacket::parse(&final_bytes).unwrap();
+    assert_eq!(reparsed_packet, processed_packet);
 
-    // Audio processing should be fast enough for real-time (under 100µs in debug builds)
-    assert!(
-        process_time < std::time::Duration::from_micros(100),
-        "Audio processing should be <100µs for real-time, got {:?}",
-        process_time
-    );
-
-    println!("✅ End-to-end latency achieves real-time performance target");
+    println!("✅ End-to-end RTP processing and serialization verified");
 }


### PR DESCRIPTION
## Summary

- replace wall-clock pass/fail assertions in ordinary media tests with deterministic work, output-equivalence, allocation, and pool-accounting checks
- retain timing diagnostics and move allocation-versus-pool measurement into Criterion
- raise the core CI timeout from 30 to 60 minutes after the expanded suite completed in 28m24s
- leave production behavior unchanged

## Regression evidence

Under 12-way CPU load, current main reproduced a scheduler-skewed failure at a 0.52x ratio after 18 successful runs. The deterministic replacement passed 30 focused and 5 broader loaded repetitions.

## Validation

- full media-core default and all-feature suites, including the long RTP test
- targeted tests after rebasing onto current main
- strict all-target/all-feature package Clippy with dependencies excluded
- Criterion release build and quick benchmark run
- workflow YAML, formatting, and diff checks
- independent audit: zero blockers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests, benchmarks, and CI timeout; production media paths are unchanged and assertions become more stable on hosted runners.
> 
> **Overview**
> **Media performance tests no longer fail on wall-clock ratios** under CI scheduler noise. `cargo test` now asserts deterministic behavior—output equivalence, allocation counts, pool hit/miss accounting, and iteration invariants—while timing is kept as diagnostic `println` output only.
> 
> **Comparative timing moves to Criterion**: `audio_frame_pipeline` gains an `audio_frame_acquisition` bench (fresh allocation vs prewarmed `AudioFramePool`). Module docs in G.711, performance, and RTP integration tests state that release performance belongs in Criterion/beta qualification lanes.
> 
> **CI**: `workspace-test-clippy` core `cargo test` job timeout increases from 30 to 60 minutes to accommodate the longer post-RTP suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4c88752b3304b97f686b20b66e81c6adfa9005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->