### PR TITLE
Repair low-level SDES key direction

### DIFF
--- a/crates/media/rtp-core/src/api/client/security/srtp/sdes.rs
+++ b/crates/media/rtp-core/src/api/client/security/srtp/sdes.rs
@@ -171,23 +171,39 @@ impl SdesClient {
 
                 let answer_lines: Vec<String> = answer_str.lines().map(|s| s.to_string()).collect();
 
-                // Set up SRTP context if keys are available
-                if let (Some(srtp_key), Some(srtp_suite)) =
-                    (sdes.get_srtp_key(), sdes.get_srtp_suite())
-                {
-                    match SrtpContext::new(srtp_suite, srtp_key) {
-                        Ok(context) => {
-                            *self.srtp_context.write().await = Some(context);
-                            info!("SDES client: SRTP context established");
-                        }
-                        Err(e) => {
-                            error!("Failed to create SRTP context: {}", e);
-                            *self.state.write().await = SdesClientState::Failed;
-                            return Err(SecurityError::CryptoError(format!(
-                                "Failed to create SRTP context: {}",
-                                e
-                            )));
-                        }
+                // SDES is directional: completing signaling without both
+                // local-transmit and remote-receive material must fail closed.
+                let keys = match sdes.get_directional_keys() {
+                    Ok(keys) => keys,
+                    Err(error) => {
+                        *self.state.write().await = SdesClientState::Failed;
+                        return Err(SecurityError::CryptoError(format!(
+                            "SDES completed without both directional keys: {error}"
+                        )));
+                    }
+                };
+                let srtp_suite = match sdes.get_srtp_suite() {
+                    Some(suite) => suite,
+                    None => {
+                        *self.state.write().await = SdesClientState::Failed;
+                        return Err(SecurityError::CryptoError(
+                            "SDES completed without an SRTP suite".to_string(),
+                        ));
+                    }
+                };
+
+                match SrtpContext::new_directional(srtp_suite, keys.local_tx, keys.remote_rx) {
+                    Ok(context) => {
+                        *self.srtp_context.write().await = Some(context);
+                        info!("SDES client: SRTP context established");
+                    }
+                    Err(e) => {
+                        error!("Failed to create SRTP context: {}", e);
+                        *self.state.write().await = SdesClientState::Failed;
+                        return Err(SecurityError::CryptoError(format!(
+                            "Failed to create SRTP context: {}",
+                            e
+                        )));
                     }
                 }
 

--- a/crates/media/rtp-core/src/api/common/unified_security.rs
+++ b/crates/media/rtp-core/src/api/common/unified_security.rs
@@ -321,22 +321,42 @@ impl UnifiedSecurityContext {
 
         // Check if key exchange is complete
         if key_exchange.is_complete() {
-            // Get the negotiated keys and set up SRTP
-            if let (Some(srtp_key), Some(srtp_suite)) =
-                (key_exchange.get_srtp_key(), key_exchange.get_srtp_suite())
-            {
-                let srtp_context = SrtpContext::new(srtp_suite, srtp_key).map_err(|e| {
-                    SecurityError::CryptoError(format!("Failed to create SRTP context: {}", e))
-                })?;
-
-                *self.srtp_context.write().await = Some(Arc::new(RwLock::new(srtp_context)));
-                *self.state.write().await = SecurityState::Established;
-            } else {
+            let Some(local_key) = key_exchange.get_srtp_key() else {
                 *self.state.write().await = SecurityState::Failed;
                 return Err(SecurityError::CryptoError(
-                    "Key exchange completed but no keys available".to_string(),
+                    "Key exchange completed without a local transmit key".to_string(),
                 ));
-            }
+            };
+            let Some(srtp_suite) = key_exchange.get_srtp_suite() else {
+                *self.state.write().await = SecurityState::Failed;
+                return Err(SecurityError::CryptoError(
+                    "Key exchange completed without an SRTP suite".to_string(),
+                ));
+            };
+
+            let context = if self.method == KeyExchangeMethod::Sdes {
+                let Some(remote_key) = key_exchange.get_remote_srtp_key() else {
+                    *self.state.write().await = SecurityState::Failed;
+                    return Err(SecurityError::CryptoError(
+                        "SDES completed without a remote receive key".to_string(),
+                    ));
+                };
+                SrtpContext::new_directional(srtp_suite, local_key, remote_key)
+            } else {
+                SrtpContext::new(srtp_suite, local_key)
+            };
+            let srtp_context = match context {
+                Ok(context) => context,
+                Err(error) => {
+                    *self.state.write().await = SecurityState::Failed;
+                    return Err(SecurityError::CryptoError(format!(
+                        "Failed to create SRTP context: {error}"
+                    )));
+                }
+            };
+
+            *self.srtp_context.write().await = Some(Arc::new(RwLock::new(srtp_context)));
+            *self.state.write().await = SecurityState::Established;
         }
 
         Ok(response)

--- a/crates/media/rtp-core/src/api/server/security/srtp/sdes.rs
+++ b/crates/media/rtp-core/src/api/server/security/srtp/sdes.rs
@@ -256,26 +256,42 @@ impl SdesServerSession {
         match sdes.process_message(answer_message.as_bytes()) {
             Ok(None) => {
                 // Answer processed successfully
-                // Set up SRTP context if keys are available
-                if let (Some(srtp_key), Some(srtp_suite)) =
-                    (sdes.get_srtp_key(), sdes.get_srtp_suite())
-                {
-                    match SrtpContext::new(srtp_suite, srtp_key) {
-                        Ok(context) => {
-                            *self.srtp_context.write().await = Some(context);
-                            info!(
-                                "SDES server session {}: SRTP context established",
-                                self.session_id
-                            );
-                        }
-                        Err(e) => {
-                            error!("Failed to create SRTP context: {}", e);
-                            *self.state.write().await = SdesServerState::Failed;
-                            return Err(SecurityError::CryptoError(format!(
-                                "Failed to create SRTP context: {}",
-                                e
-                            )));
-                        }
+                // SDES is directional: completing signaling without both
+                // local-transmit and remote-receive material must fail closed.
+                let keys = match sdes.get_directional_keys() {
+                    Ok(keys) => keys,
+                    Err(error) => {
+                        *self.state.write().await = SdesServerState::Failed;
+                        return Err(SecurityError::CryptoError(format!(
+                            "SDES completed without both directional keys: {error}"
+                        )));
+                    }
+                };
+                let srtp_suite = match sdes.get_srtp_suite() {
+                    Some(suite) => suite,
+                    None => {
+                        *self.state.write().await = SdesServerState::Failed;
+                        return Err(SecurityError::CryptoError(
+                            "SDES completed without an SRTP suite".to_string(),
+                        ));
+                    }
+                };
+
+                match SrtpContext::new_directional(srtp_suite, keys.local_tx, keys.remote_rx) {
+                    Ok(context) => {
+                        *self.srtp_context.write().await = Some(context);
+                        info!(
+                            "SDES server session {}: SRTP context established",
+                            self.session_id
+                        );
+                    }
+                    Err(e) => {
+                        error!("Failed to create SRTP context: {}", e);
+                        *self.state.write().await = SdesServerState::Failed;
+                        return Err(SecurityError::CryptoError(format!(
+                            "Failed to create SRTP context: {}",
+                            e
+                        )));
                     }
                 }
 

--- a/crates/media/rtp-core/src/security/mod.rs
+++ b/crates/media/rtp-core/src/security/mod.rs
@@ -22,8 +22,20 @@ pub trait SecurityKeyExchange {
     /// Process incoming message from peer
     fn process_message(&mut self, message: &[u8]) -> Result<Option<Vec<u8>>, Error>;
 
-    /// Get the negotiated SRTP crypto key if available
+    /// Get the local transmit key when key exchange material is available.
+    ///
+    /// This is the historical single-key compatibility accessor. Directional
+    /// exchanges must also expose the peer key through
+    /// [`SecurityKeyExchange::get_remote_srtp_key`].
     fn get_srtp_key(&self) -> Option<SrtpCryptoKey>;
+
+    /// Get the peer's transmit key for inbound unprotection, when the key
+    /// exchange negotiates independent directions.
+    ///
+    /// Shared-key exchanges retain the compatibility default of `None`.
+    fn get_remote_srtp_key(&self) -> Option<SrtpCryptoKey> {
+        None
+    }
 
     /// Get the negotiated SRTP crypto suite if available
     fn get_srtp_suite(&self) -> Option<SrtpCryptoSuite>;

--- a/crates/media/rtp-core/src/security/sdes/mod.rs
+++ b/crates/media/rtp-core/src/security/sdes/mod.rs
@@ -141,6 +141,15 @@ pub struct SdesConfig {
     pub offer_count: usize,
 }
 
+/// Directional key material produced by an SDES offer/answer exchange.
+#[derive(Debug, Clone)]
+pub struct SdesKeyMaterial {
+    /// Key this endpoint uses to protect outbound RTP and RTCP.
+    pub local_tx: SrtpCryptoKey,
+    /// Peer key this endpoint uses to unprotect inbound RTP and RTCP.
+    pub remote_rx: SrtpCryptoKey,
+}
+
 impl Default for SdesConfig {
     fn default() -> Self {
         Self {
@@ -164,8 +173,10 @@ pub struct Sdes {
     remote_attrs: Vec<SdesCryptoAttribute>,
     /// Selected crypto attribute
     selected_attr: Option<SdesCryptoAttribute>,
-    /// Negotiated SRTP crypto key
-    srtp_key: Option<SrtpCryptoKey>,
+    /// Local transmit key advertised by this endpoint.
+    local_srtp_key: Option<SrtpCryptoKey>,
+    /// Remote transmit key used by this endpoint for inbound unprotection.
+    remote_srtp_key: Option<SrtpCryptoKey>,
     /// Negotiated SRTP crypto suite
     srtp_suite: Option<SrtpCryptoSuite>,
 }
@@ -180,7 +191,8 @@ impl Sdes {
             local_attrs: Vec::new(),
             remote_attrs: Vec::new(),
             selected_attr: None,
-            srtp_key: None,
+            local_srtp_key: None,
+            remote_srtp_key: None,
             srtp_suite: None,
         }
     }
@@ -332,7 +344,7 @@ impl Sdes {
 
             // Save key if it's the first one (the default)
             if i == 0 {
-                self.srtp_key = Some(srtp_key);
+                self.local_srtp_key = Some(srtp_key);
                 self.srtp_suite = Some(suite.clone());
             }
         }
@@ -384,18 +396,27 @@ impl Sdes {
                     "No mutually configured, implemented SDES crypto suite".to_string(),
                 )
             })?;
-        let srtp_key = Self::decode_key(selected, &srtp_suite)?;
+        let remote_srtp_key = Self::decode_key(selected, &srtp_suite)?;
         let selected = selected.clone();
 
-        // Store key for later use
+        // RFC 4568 uses independent key material in each direction. The
+        // answer keeps the offered key only for inbound traffic and advertises
+        // a freshly generated local transmit key with the selected tag/suite.
+        let (local_attr, local_srtp_key) =
+            self.create_crypto_attribute(selected.tag, &srtp_suite)?;
+
+        // Commit negotiation state only after both directional keys and the
+        // answer attribute have been validated and created successfully.
         self.remote_attrs = remote_attrs;
-        self.srtp_key = Some(srtp_key);
+        self.local_attrs = vec![local_attr.clone()];
+        self.local_srtp_key = Some(local_srtp_key);
+        self.remote_srtp_key = Some(remote_srtp_key);
         self.srtp_suite = Some(srtp_suite);
-        self.selected_attr = Some(selected.clone());
+        self.selected_attr = Some(local_attr.clone());
 
         // Create answer
         let mut answer = Vec::new();
-        answer.push(format!("a=crypto:{}", selected.to_string()));
+        answer.push(format!("a=crypto:{}", local_attr.to_string()));
 
         // Update state
         self.state = SdesState::Completed;
@@ -461,17 +482,43 @@ impl Sdes {
             ));
         }
         let local_key = Self::decode_key(local_attr, &suite)?;
+        let remote_key = Self::decode_key(&selected, &suite)?;
 
-        // Store selected attribute
+        // Commit only after the answer and both directional keys are valid.
         self.remote_attrs = remote_attrs;
         self.selected_attr = Some(selected);
-        self.srtp_key = Some(local_key);
+        self.local_srtp_key = Some(local_key);
+        self.remote_srtp_key = Some(remote_key);
         self.srtp_suite = Some(suite);
 
         // Update state
         self.state = SdesState::Completed;
 
         Ok(())
+    }
+}
+
+impl Sdes {
+    /// Return both directional keys after negotiation completes.
+    ///
+    /// An incomplete exchange returns an error instead of falling back to the
+    /// local key for both directions.
+    pub fn get_directional_keys(&self) -> Result<SdesKeyMaterial, Error> {
+        let local_tx = self.local_srtp_key.clone().ok_or_else(|| {
+            Error::InvalidState("SDES local transmit key is not available".to_string())
+        })?;
+        let remote_rx = self.remote_srtp_key.clone().ok_or_else(|| {
+            Error::InvalidState("SDES remote receive key is not available".to_string())
+        })?;
+        Ok(SdesKeyMaterial {
+            local_tx,
+            remote_rx,
+        })
+    }
+
+    /// Return the peer's transmit key used for inbound unprotection.
+    pub fn get_remote_srtp_key(&self) -> Option<SrtpCryptoKey> {
+        self.remote_srtp_key.clone()
     }
 }
 
@@ -513,7 +560,13 @@ impl SecurityKeyExchange for Sdes {
     }
 
     fn get_srtp_key(&self) -> Option<SrtpCryptoKey> {
-        self.srtp_key.clone()
+        // Compatibility accessor: SDES now has directional keys, so this
+        // continues to expose the key used for local transmission.
+        self.local_srtp_key.clone()
+    }
+
+    fn get_remote_srtp_key(&self) -> Option<SrtpCryptoKey> {
+        self.remote_srtp_key.clone()
     }
 
     fn get_srtp_suite(&self) -> Option<SrtpCryptoSuite> {

--- a/crates/media/rtp-core/src/security/sdes/tests/sdes_tests.rs
+++ b/crates/media/rtp-core/src/security/sdes/tests/sdes_tests.rs
@@ -2,6 +2,7 @@ use crate::security::sdes::{Sdes, SdesConfig, SdesCryptoAttribute, SdesRole, Sde
 use crate::security::SecurityKeyExchange;
 use crate::srtp::{SRTP_AES128_CM_SHA1_32, SRTP_AES128_CM_SHA1_80};
 use crate::Error;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
 #[test]
 fn test_sdes_crypto_attribute_parsing() {
@@ -99,20 +100,104 @@ fn test_sdes_offer_answer_exchange() {
     assert!(offerer.is_complete());
     assert!(answerer.is_complete());
 
-    // Verify both sides have SRTP keys
-    assert!(offerer.get_srtp_key().is_some());
-    assert!(answerer.get_srtp_key().is_some());
+    let offerer_keys = offerer
+        .get_directional_keys()
+        .expect("offerer directional keys");
+    let answerer_keys = answerer
+        .get_directional_keys()
+        .expect("answerer directional keys");
 
-    // The keys should match
+    // Every endpoint advertises a fresh transmit key, and each peer installs
+    // that key only on its receive side.
+    assert_ne!(offerer_keys.local_tx.key(), answerer_keys.local_tx.key());
+    assert_ne!(offerer_keys.local_tx.salt(), answerer_keys.local_tx.salt());
+    assert_eq!(offerer_keys.local_tx.key(), answerer_keys.remote_rx.key());
+    assert_eq!(offerer_keys.local_tx.salt(), answerer_keys.remote_rx.salt());
+    assert_eq!(answerer_keys.local_tx.key(), offerer_keys.remote_rx.key());
+    assert_eq!(answerer_keys.local_tx.salt(), offerer_keys.remote_rx.salt());
+
+    // The compatibility accessor remains the local transmit key.
     assert_eq!(
         offerer.get_srtp_key().unwrap().key(),
-        answerer.get_srtp_key().unwrap().key()
+        offerer_keys.local_tx.key()
     );
-
     assert_eq!(
-        offerer.get_srtp_key().unwrap().salt(),
-        answerer.get_srtp_key().unwrap().salt()
+        answerer.get_srtp_key().unwrap().key(),
+        answerer_keys.local_tx.key()
     );
+}
+
+#[test]
+fn test_sdes_answer_selects_the_matching_offered_transmit_key() {
+    let mut offerer = Sdes::new(SdesConfig::default(), SdesRole::Offerer);
+    let offer = offerer
+        .process_message(b"")
+        .expect("create offer")
+        .expect("offer body");
+    let offer = std::str::from_utf8(&offer).expect("UTF-8 offer");
+    let tag_two = offer
+        .lines()
+        .find(|line| line.starts_with("a=crypto:2 "))
+        .expect("second offered crypto attribute");
+    let offered = SdesCryptoAttribute::parse(tag_two.trim_start_matches("a=crypto:"))
+        .expect("parse second offered attribute");
+    let offered_key = BASE64
+        .decode(&offered.key_info)
+        .expect("decode offered key");
+
+    let remote_key = vec![0x5a; 30];
+    let answer = format!(
+        "a=crypto:2 AES_CM_128_HMAC_SHA1_32 inline:{}",
+        BASE64.encode(&remote_key)
+    );
+    offerer
+        .process_message(answer.as_bytes())
+        .expect("process tag-two answer");
+
+    let directional = offerer.get_directional_keys().expect("directional keys");
+    assert_eq!(directional.local_tx.key(), &offered_key[..16]);
+    assert_eq!(directional.local_tx.salt(), &offered_key[16..30]);
+    assert_eq!(directional.remote_rx.key(), &remote_key[..16]);
+    assert_eq!(directional.remote_rx.salt(), &remote_key[16..30]);
+    assert_eq!(offerer.get_srtp_suite(), Some(SRTP_AES128_CM_SHA1_32));
+}
+
+#[test]
+fn test_sdes_answer_cannot_change_the_suite_for_an_offered_tag() {
+    let mut offerer = Sdes::new(SdesConfig::default(), SdesRole::Offerer);
+    offerer
+        .process_message(b"")
+        .expect("create offer")
+        .expect("offer body");
+
+    let answer = format!(
+        "a=crypto:2 AES_CM_128_HMAC_SHA1_80 inline:{}",
+        BASE64.encode(vec![0x7c; 30])
+    );
+    let error = offerer
+        .process_message(answer.as_bytes())
+        .expect_err("answer must preserve the suite associated with its tag");
+    assert!(error.to_string().contains("changed suite"));
+    assert!(!offerer.is_complete());
+    assert!(offerer.get_directional_keys().is_err());
+}
+
+#[test]
+fn test_sdes_directional_keys_fail_closed_without_remote_material() {
+    let mut offerer = Sdes::new(SdesConfig::default(), SdesRole::Offerer);
+    offerer
+        .process_message(b"")
+        .expect("create offer")
+        .expect("offer body");
+
+    // The compatibility accessor may expose the local offer key, but callers
+    // cannot obtain a usable directional pair until a peer key is validated.
+    assert!(offerer.get_srtp_key().is_some());
+    assert!(offerer.get_remote_srtp_key().is_none());
+    let error = offerer
+        .get_directional_keys()
+        .expect_err("an incomplete exchange must not yield usable key material");
+    assert!(error.to_string().contains("remote receive key"));
 }
 
 #[test]
@@ -219,7 +304,8 @@ fn unsupported_sdes_parameters_fail_without_answerer_state_or_key_mutation() {
         assert!(answerer.local_attrs.is_empty());
         assert!(answerer.remote_attrs.is_empty());
         assert!(answerer.selected_attr.is_none());
-        assert!(answerer.srtp_key.is_none());
+        assert!(answerer.local_srtp_key.is_none());
+        assert!(answerer.remote_srtp_key.is_none());
         assert!(answerer.srtp_suite.is_none());
     }
 }
@@ -256,6 +342,7 @@ fn unsupported_sdes_parameters_fail_without_offerer_state_or_key_mutation() {
         assert_eq!(offerer.local_attrs, before_local_attrs);
         assert!(offerer.remote_attrs.is_empty());
         assert!(offerer.selected_attr.is_none());
+        assert!(offerer.remote_srtp_key.is_none());
         assert_eq!(offerer.get_srtp_key().unwrap().key(), before_key.key());
         assert_eq!(offerer.get_srtp_key().unwrap().salt(), before_key.salt());
         assert_eq!(offerer.get_srtp_suite(), before_suite);

--- a/crates/media/rtp-core/src/srtp/integration_tests.rs
+++ b/crates/media/rtp-core/src/srtp/integration_tests.rs
@@ -51,24 +51,20 @@ fn test_srtp_with_sdes_key_exchange() {
     assert!(offerer.is_complete());
     assert!(answerer.is_complete());
 
-    // Verify both sides have SRTP keys
-    assert!(offerer.get_srtp_key().is_some());
-    assert!(answerer.get_srtp_key().is_some());
-
     // 2. Use the negotiated keys with SRTP
 
-    // Create SRTP contexts
-    let offerer_srtp = SrtpContext::new(
-        offerer.get_srtp_suite().unwrap(),
-        offerer.get_srtp_key().unwrap(),
-    )
-    .expect("Failed to create offerer SRTP context");
+    // Create directional SRTP contexts. Each endpoint protects with its own
+    // advertised key and unprotects with the peer's advertised key.
+    let offerer_keys = offerer.get_directional_keys().unwrap();
+    let answerer_keys = answerer.get_directional_keys().unwrap();
+    let suite = offerer.get_srtp_suite().unwrap();
+    let mut offerer_srtp =
+        SrtpContext::new_directional(suite.clone(), offerer_keys.local_tx, offerer_keys.remote_rx)
+            .expect("Failed to create offerer SRTP context");
 
-    let mut answerer_srtp = SrtpContext::new(
-        answerer.get_srtp_suite().unwrap(),
-        answerer.get_srtp_key().unwrap(),
-    )
-    .expect("Failed to create answerer SRTP context");
+    let mut answerer_srtp =
+        SrtpContext::new_directional(suite, answerer_keys.local_tx, answerer_keys.remote_rx)
+            .expect("Failed to create answerer SRTP context");
 
     // 3. Test SRTP encryption and decryption
 
@@ -78,8 +74,7 @@ fn test_srtp_with_sdes_key_exchange() {
     let packet = RtpPacket::new(header, payload);
 
     // Encrypt with offerer's context
-    let mut offerer_srtp_mut = offerer_srtp;
-    let protected = offerer_srtp_mut
+    let protected = offerer_srtp
         .protect(&packet)
         .expect("Failed to protect RTP packet");
 
@@ -102,6 +97,50 @@ fn test_srtp_with_sdes_key_exchange() {
     assert_eq!(decrypted.header.timestamp, packet.header.timestamp);
     assert_eq!(decrypted.header.ssrc, packet.header.ssrc);
     assert_eq!(decrypted.payload, packet.payload);
+
+    // The answerer's independent transmit key works in the reverse direction.
+    let reverse = RtpPacket::new(
+        RtpHeader::new(96, 1001, 12505, 0xabcdef02),
+        Bytes::from_static(b"Hello back from the answerer!"),
+    );
+    let protected = answerer_srtp
+        .protect(&reverse)
+        .expect("Failed to protect reverse RTP packet")
+        .serialize()
+        .expect("Failed to serialize reverse RTP packet");
+    let decrypted = offerer_srtp
+        .unprotect(&protected)
+        .expect("Failed to unprotect reverse RTP packet");
+    assert_eq!(decrypted.payload, reverse.payload);
+
+    // SRTCP uses the same directional material in both directions.
+    let mut offerer_report = vec![0x80, 200, 0, 6];
+    offerer_report.extend_from_slice(&0xabcdef01_u32.to_be_bytes());
+    offerer_report.extend_from_slice(&[0x11; 20]);
+    let protected = offerer_srtp
+        .protect_rtcp(&offerer_report)
+        .expect("Failed to protect offerer RTCP");
+    assert_eq!(
+        answerer_srtp
+            .unprotect_rtcp(&protected)
+            .expect("Failed to unprotect offerer RTCP")
+            .as_ref(),
+        offerer_report
+    );
+
+    let mut answerer_report = vec![0x80, 200, 0, 6];
+    answerer_report.extend_from_slice(&0xabcdef02_u32.to_be_bytes());
+    answerer_report.extend_from_slice(&[0x22; 20]);
+    let protected = answerer_srtp
+        .protect_rtcp(&answerer_report)
+        .expect("Failed to protect answerer RTCP");
+    assert_eq!(
+        offerer_srtp
+            .unprotect_rtcp(&protected)
+            .expect("Failed to unprotect answerer RTCP")
+            .as_ref(),
+        answerer_report
+    );
 }
 
 #[test]

--- a/crates/media/rtp-core/tests/sdes_direction_regression_first.rs
+++ b/crates/media/rtp-core/tests/sdes_direction_regression_first.rs
@@ -1,0 +1,19 @@
+use rvoip_rtp_core::security::sdes::{Sdes, SdesConfig, SdesRole};
+use rvoip_rtp_core::security::SecurityKeyExchange;
+
+#[test]
+fn sdes_answerer_generates_fresh_transmit_key_material() {
+    let mut offerer = Sdes::new(SdesConfig::default(), SdesRole::Offerer);
+    let offer = offerer.process_message(b"").unwrap().unwrap();
+    let offerer_key = offerer.get_srtp_key().unwrap();
+
+    let mut answerer = Sdes::new(SdesConfig::default(), SdesRole::Answerer);
+    let _answer = answerer.process_message(&offer).unwrap().unwrap();
+    let answerer_key = answerer.get_srtp_key().unwrap();
+
+    assert_ne!(
+        (offerer_key.key(), offerer_key.salt()),
+        (answerer_key.key(), answerer_key.salt()),
+        "an SDES answer must carry fresh local transmit key material"
+    );
+}


### PR DESCRIPTION
## What changed

- generate fresh local answerer key and salt material instead of echoing the offerer's key
- keep separate local-transmit and remote-receive SDES key material
- expose directional key access while retaining the compatibility accessor as the local-transmit key
- select the key material associated with the negotiated crypto tag
- fail explicitly when directional key material is incomplete
- wire the directional keys through client, server, unified-security, SRTP, and SRTCP adapter paths

The existing SIP wrapper behavior is preserved; this PR repairs only the low-level RTP-core SDES API.

## Regression proof

The first commit adds a low-level offer/answer regression that fails on the prior implementation because the answer repeats the offered key. It passes after the answerer generates independent local material.

## Validation

- offer and answer keys differ
- each endpoint uses its local key for transmit and the peer key for receive
- bidirectional SRTP and SRTCP protect/unprotect
- tag-specific offer selection and incomplete-key failure
- all three RTP-core adapter paths
- default RTP suite: 383 unit tests plus integrations and docs
- all-feature RTP suite
- strict all-feature/all-target RTP-core Clippy
- formatting and diff checks

The prerequisite SRTP/SRTCP state repair merged in #42.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/crypto key derivation and SRTP context construction for SDES across core and API layers; incorrect wiring would break media security or interoperability.
> 
> **Overview**
> Fixes **low-level SDES** so each side uses **independent transmit/receive key material** (RFC 4568) instead of treating negotiation as a single shared key.
> 
> The answerer now **generates a fresh local `a=crypto` key** for outbound traffic while keeping the selected offer key only for inbound unprotect. Core state splits into **local transmit** and **remote receive** keys, with **`get_directional_keys()`** and **`get_remote_srtp_key()`** on the key-exchange trait; incomplete negotiation **errors** rather than reusing one key both ways. The offerer binds keys by **negotiated tag** and rejects **suite changes** for that tag.
> 
> **Client, server, unified-security**, and SRTP setup paths now build contexts via **`SrtpContext::new_directional`** when SDES completes. Tests cover distinct answer keys, bidirectional RTP/SRTCP, tag selection, and fail-closed incomplete exchanges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1516ce299d4be1c5ff30b87b7e4f308d75329d07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->