### PR TITLE
Make codec support honest and consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6781,6 +6781,7 @@ name = "rvoip-codec-core"
 version = "0.3.4"
 dependencies = [
  "criterion",
+ "opus",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6945,7 +6946,6 @@ dependencies = [
  "num-complex",
  "num_cpus",
  "once_cell",
- "opus",
  "parking_lot",
  "rand 0.8.7",
  "rustfft",

--- a/crates/media/codec-core/Cargo.toml
+++ b/crates/media/codec-core/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 keywords.workspace = true
 
 # Crate-specific description
-description = "G.711 and optional G.729A/G.729AB audio codec implementation for RVOIP"
+description = "G.711 and optional G.729/Opus audio codec implementations for RVOIP"
 
 [lib]
 name = "codec_core"
@@ -40,6 +40,7 @@ criterion = { workspace = true }
 [[bench]]
 name = "g711_codec"
 harness = false
+required-features = ["g711"]
 
 [features]
 default = ["g711"]
@@ -51,3 +52,4 @@ opus = ["dep:opus"]          # Opus codec backed by libopus
 # Deprecated compatibility alias. This now enables the real backend; it no
 # longer selects a simulated codec.
 opus-sim = ["opus"]
+all-codecs = ["g711", "g729", "opus"]

--- a/crates/media/codec-core/Cargo.toml
+++ b/crates/media/codec-core/Cargo.toml
@@ -30,6 +30,7 @@ tracing.workspace = true
 
 # Crate-specific dependencies not in workspace
 tracing-subscriber = "0.3"   # Logging initialization
+opus = { version = "0.3", optional = true }
 
 [dev-dependencies]
 # Testing
@@ -46,5 +47,7 @@ default = ["g711"]
 # Codec features
 g711 = []                    # G.711 μ-law/A-law codec (always available)
 g729 = []                    # G.729A/G.729AB codec
-opus = []                    # Opus codec (real impl in src/codecs/opus.rs)
-opus-sim = []                # Opus codec simulator variant
+opus = ["dep:opus"]          # Opus codec backed by libopus
+# Deprecated compatibility alias. This now enables the real backend; it no
+# longer selects a simulated codec.
+opus-sim = ["opus"]

--- a/crates/media/codec-core/src/codecs/g711/mod.rs
+++ b/crates/media/codec-core/src/codecs/g711/mod.rs
@@ -36,7 +36,7 @@
 //! let decoded: Vec<i16> = encoded.iter().map(|&e| alaw_expand(e)).collect();
 //! ```
 //!
-//! ### Using the G711Codec Struct
+//! ### Using the `G711Codec` Struct
 //!
 //! ```rust
 //! use codec_core::codecs::g711::{G711Codec, G711Variant};
@@ -85,7 +85,9 @@ pub enum G711Variant {
 
 impl G711Codec {
     /// Create a new G.711 codec with the specified variant
-    pub fn new(variant: G711Variant) -> Self {
+    #[must_use]
+    #[allow(clippy::needless_pass_by_value)]
+    pub const fn new(variant: G711Variant) -> Self {
         Self {
             variant,
             frame_size: 160, // Default 20ms at 8kHz
@@ -93,6 +95,16 @@ impl G711Codec {
     }
 
     /// Create a new G.711 codec with configuration
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the configuration uses a sample rate, channel
+    /// count, or frame duration unsupported by G.711.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::needless_pass_by_value
+    )]
     pub fn new_with_config(
         variant: G711Variant,
         config: crate::types::CodecConfig,
@@ -114,12 +126,10 @@ impl G711Codec {
         }
 
         // Calculate frame size from config
-        let frame_size = if let Some(frame_ms) = config.frame_size_ms {
+        let frame_size = config.frame_size_ms.map_or(160, |frame_ms| {
             let samples_per_ms = 8000.0 / 1000.0; // 8 samples per ms at 8kHz
             (samples_per_ms * frame_ms) as usize
-        } else {
-            160 // Default 20ms
-        };
+        });
 
         // Validate frame size
         let valid_sizes = [80, 160, 240, 320];
@@ -137,21 +147,35 @@ impl G711Codec {
     }
 
     /// Create a new G.711 μ-law (PCMU) codec
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `config` is not a supported G.711 configuration.
     pub fn new_pcmu(config: crate::types::CodecConfig) -> Result<Self, CodecError> {
         Self::new_with_config(G711Variant::MuLaw, config)
     }
 
     /// Create a new G.711 A-law (PCMA) codec
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `config` is not a supported G.711 configuration.
     pub fn new_pcma(config: crate::types::CodecConfig) -> Result<Self, CodecError> {
         Self::new_with_config(G711Variant::ALaw, config)
     }
 
     /// Get the codec variant
-    pub fn variant(&self) -> G711Variant {
+    #[must_use]
+    pub const fn variant(&self) -> G711Variant {
         self.variant
     }
 
     /// Compress samples using the configured variant
+    ///
+    /// # Errors
+    ///
+    /// This implementation is infallible; the result type is retained for API
+    /// compatibility with other codecs.
     pub fn compress(&self, samples: &[i16]) -> Result<Vec<u8>, CodecError> {
         match self.variant {
             G711Variant::ALaw => Ok(samples
@@ -166,6 +190,11 @@ impl G711Codec {
     }
 
     /// Expand samples using the configured variant
+    ///
+    /// # Errors
+    ///
+    /// This implementation is infallible; the result type is retained for API
+    /// compatibility with other codecs.
     pub fn expand(&self, compressed: &[u8]) -> Result<Vec<i16>, CodecError> {
         match self.variant {
             G711Variant::ALaw => Ok(compressed
@@ -180,6 +209,11 @@ impl G711Codec {
     }
 
     /// Compress samples using A-law
+    ///
+    /// # Errors
+    ///
+    /// This implementation is infallible; the result type is retained for API
+    /// compatibility.
     pub fn compress_alaw(&self, samples: &[i16]) -> Result<Vec<u8>, CodecError> {
         Ok(samples
             .iter()
@@ -188,6 +222,11 @@ impl G711Codec {
     }
 
     /// Expand A-law samples
+    ///
+    /// # Errors
+    ///
+    /// This implementation is infallible; the result type is retained for API
+    /// compatibility.
     pub fn expand_alaw(&self, compressed: &[u8]) -> Result<Vec<i16>, CodecError> {
         Ok(compressed
             .iter()
@@ -196,6 +235,11 @@ impl G711Codec {
     }
 
     /// Compress samples using μ-law
+    ///
+    /// # Errors
+    ///
+    /// This implementation is infallible; the result type is retained for API
+    /// compatibility.
     pub fn compress_ulaw(&self, samples: &[i16]) -> Result<Vec<u8>, CodecError> {
         Ok(samples
             .iter()
@@ -204,6 +248,11 @@ impl G711Codec {
     }
 
     /// Expand μ-law samples
+    ///
+    /// # Errors
+    ///
+    /// This implementation is infallible; the result type is retained for API
+    /// compatibility.
     pub fn expand_ulaw(&self, compressed: &[u8]) -> Result<Vec<i16>, CodecError> {
         Ok(compressed
             .iter()
@@ -316,6 +365,6 @@ impl crate::types::AudioCodecExt for G711Codec {
 }
 
 /// Initialize G.711 lookup tables (stub for compatibility)
-pub fn init_tables() {
+pub const fn init_tables() {
     // No initialization needed with our implementation
 }

--- a/crates/media/codec-core/src/codecs/g711/reference.rs
+++ b/crates/media/codec-core/src/codecs/g711/reference.rs
@@ -37,9 +37,10 @@
 /// # Algorithm
 ///
 /// Based on ITU-T G.711 specification and reference implementation.
-pub fn alaw_compress(sample: i16) -> u8 {
+#[must_use]
+pub const fn alaw_compress(sample: i16) -> u8 {
     let mut ix = if sample < 0 {
-        (((!sample) as u16) >> 4) as i16
+        ((!sample).cast_unsigned() >> 4).cast_signed()
     } else {
         sample >> 4
     };
@@ -58,7 +59,7 @@ pub fn alaw_compress(sample: i16) -> u8 {
         ix |= 0x0080;
     }
 
-    (ix ^ 0x0055) as u8
+    (ix ^ 0x0055).to_le_bytes()[0]
 }
 
 /// A-law expansion according to ITU-T G.711
@@ -76,7 +77,9 @@ pub fn alaw_compress(sample: i16) -> u8 {
 /// # Algorithm
 ///
 /// Based on ITU-T G.711 specification and reference implementation.
-pub fn alaw_expand(compressed: u8) -> i16 {
+#[must_use]
+#[allow(clippy::cast_lossless)]
+pub const fn alaw_expand(compressed: u8) -> i16 {
     let mut ix = (compressed ^ 0x0055) as i16;
 
     ix &= 0x007F;
@@ -84,13 +87,13 @@ pub fn alaw_expand(compressed: u8) -> i16 {
     let mut mant = ix & 0x000F;
 
     if iexp > 0 {
-        mant = mant + 16;
+        mant += 16;
     }
 
     mant = (mant << 4) + 0x0008;
 
     if iexp > 1 {
-        mant = mant << (iexp - 1);
+        mant <<= iexp - 1;
     }
 
     if compressed > 127 {
@@ -115,9 +118,10 @@ pub fn alaw_expand(compressed: u8) -> i16 {
 /// # Algorithm
 ///
 /// Based on ITU-T G.711 specification.
-pub fn ulaw_compress(sample: i16) -> u8 {
+#[must_use]
+pub const fn ulaw_compress(sample: i16) -> u8 {
     let absno = if sample < 0 {
-        (((!sample) as u16) >> 2) as i16 + 33
+        ((!sample).cast_unsigned() >> 2).cast_signed() + 33
     } else {
         (sample >> 2) + 33
     };
@@ -139,7 +143,7 @@ pub fn ulaw_compress(sample: i16) -> u8 {
         result |= 0x0080;
     }
 
-    result as u8
+    result.to_le_bytes()[0]
 }
 
 /// μ-law expansion according to ITU-T G.711
@@ -157,7 +161,9 @@ pub fn ulaw_compress(sample: i16) -> u8 {
 /// # Algorithm
 ///
 /// Based on ITU-T G.711 specification.
-pub fn ulaw_expand(compressed: u8) -> i16 {
+#[must_use]
+#[allow(clippy::cast_lossless)]
+pub const fn ulaw_expand(compressed: u8) -> i16 {
     let sign = if compressed < 0x0080 { -1 } else { 1 };
     let mantissa = (!compressed) as i16;
     let exponent = (mantissa >> 4) & 0x0007;
@@ -170,6 +176,7 @@ pub fn ulaw_expand(compressed: u8) -> i16 {
 }
 
 #[cfg(test)]
+#[allow(clippy::uninlined_format_args)]
 mod tests {
     use super::*;
 

--- a/crates/media/codec-core/src/codecs/g711/tests/decoder_tests.rs
+++ b/crates/media/codec-core/src/codecs/g711/tests/decoder_tests.rs
@@ -20,9 +20,8 @@ mod tests {
         let test_values = vec![0u8, 0x55, 0xD5, 0x2A, 0xFF];
 
         for &encoded in &test_values {
-            let decoded = alaw_expand(encoded);
-            // Should produce valid 16-bit samples
-            assert!(decoded >= i16::MIN && decoded <= i16::MAX);
+            // Decoding every selected input should complete without panicking.
+            let _decoded = alaw_expand(encoded);
         }
     }
 
@@ -32,9 +31,8 @@ mod tests {
         let test_values = vec![0u8, 0x7F, 0xFF, 0x80, 0x00];
 
         for &encoded in &test_values {
-            let decoded = ulaw_expand(encoded);
-            // Should produce valid 16-bit samples
-            assert!(decoded >= i16::MIN && decoded <= i16::MAX);
+            // Decoding every selected input should complete without panicking.
+            let _decoded = ulaw_expand(encoded);
         }
     }
 
@@ -42,12 +40,9 @@ mod tests {
     fn test_decoding_all_values() {
         // Test decoding all possible 8-bit values for both laws
         for encoded in 0u8..=255u8 {
-            let alaw_decoded = alaw_expand(encoded);
-            let mulaw_decoded = ulaw_expand(encoded);
-
-            // All decoded values should be valid 16-bit samples
-            assert!(alaw_decoded >= i16::MIN && alaw_decoded <= i16::MAX);
-            assert!(mulaw_decoded >= i16::MIN && mulaw_decoded <= i16::MAX);
+            // Both decoders must accept every possible encoded byte.
+            let _alaw_decoded = alaw_expand(encoded);
+            let _mulaw_decoded = ulaw_expand(encoded);
         }
     }
 
@@ -69,10 +64,6 @@ mod tests {
                 "Encoded 0x{:02x}: A-law -> {}, μ-law -> {}",
                 encoded, alaw_decoded, mulaw_decoded
             );
-
-            // Should be valid 16-bit range
-            assert!(alaw_decoded >= i16::MIN && alaw_decoded <= i16::MAX);
-            assert!(mulaw_decoded >= i16::MIN && mulaw_decoded <= i16::MAX);
         }
     }
 

--- a/crates/media/codec-core/src/codecs/g711/tests/itu_test_standalone.rs
+++ b/crates/media/codec-core/src/codecs/g711/tests/itu_test_standalone.rs
@@ -114,8 +114,10 @@ pub fn test_g711_itu_compliance() {
             perfect_roundtrips += 1;
         } else if i < 5 {
             // Show first few errors if any
-            println!("  [{:3}] Input: {:6}, A-law error: {:3} (tol: {:3}), μ-law error: {:3} (tol: {:3})",
-                     i, input, alaw_error, alaw_tolerance, mulaw_error, mulaw_tolerance);
+            println!(
+                "  [{:3}] Input: {:6}, A-law error: {:3} (tol: {:3}), μ-law error: {:3} (tol: {:3})",
+                i, input, alaw_error, alaw_tolerance, mulaw_error, mulaw_tolerance
+            );
         }
     }
 

--- a/crates/media/codec-core/src/codecs/g711/tests/mod.rs
+++ b/crates/media/codec-core/src/codecs/g711/tests/mod.rs
@@ -3,6 +3,26 @@
 //! This module contains comprehensive tests for the G.711 codec implementation,
 //! including unit tests, integration tests, and ITU-T compliance validation.
 
+// Test vectors intentionally exercise lossy numeric conversions and print
+// detailed diagnostics. Keep these test-only exceptions scoped to this module;
+// production G.711 code remains under the full lint policy.
+#![allow(
+    clippy::cast_abs_to_unsigned,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::checked_conversions,
+    clippy::doc_markdown,
+    clippy::float_cmp,
+    clippy::needless_range_loop,
+    clippy::suboptimal_flops,
+    clippy::too_many_lines,
+    clippy::uninlined_format_args,
+    clippy::useless_vec
+)]
+
 pub mod algorithm_verification;
 pub mod decoder_tests;
 pub mod encoder_tests;

--- a/crates/media/codec-core/src/codecs/g711/tests/wav_roundtrip_test.rs
+++ b/crates/media/codec-core/src/codecs/g711/tests/wav_roundtrip_test.rs
@@ -85,11 +85,12 @@ struct WavHeader {
 }
 
 impl WavHeader {
+    #[allow(clippy::cast_possible_truncation)]
     fn new(num_samples: usize) -> Self {
         let data_size = (num_samples * 2) as u32; // 16-bit samples
         let file_size = data_size + 36; // 44 - 8
 
-        WavHeader {
+        Self {
             riff_id: *b"RIFF",
             file_size,
             wave_id: *b"WAVE",
@@ -108,6 +109,7 @@ impl WavHeader {
 }
 
 /// Download a file from a URL
+#[allow(clippy::unused_async)]
 async fn download_file(url: &str, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     // Simple HTTP client without external dependencies
     let response = std::process::Command::new("curl")
@@ -268,14 +270,14 @@ mod tests {
         let original_wav_path = test_dir.join("OSR_us_000_0010_8k.wav");
 
         // Only download if file doesn't exist (to avoid unnecessary downloads)
-        if !original_wav_path.exists() {
+        if original_wav_path.exists() {
+            println!("Using existing WAV file: {:?}", original_wav_path);
+        } else {
             println!("Downloading WAV file from: {}", WAV_URL);
             download_file(WAV_URL, &original_wav_path)
                 .await
                 .expect("Failed to download WAV file");
             println!("Downloaded WAV file to: {:?}", original_wav_path);
-        } else {
-            println!("Using existing WAV file: {:?}", original_wav_path);
         }
 
         // Read the original WAV file

--- a/crates/media/codec-core/src/codecs/g729/impls/mod.rs
+++ b/crates/media/codec-core/src/codecs/g729/impls/mod.rs
@@ -1,5 +1,37 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
+// This private subtree is a bit-exact fixed-point transcription of the G.729
+// reference algorithm. These narrowly enumerated lints conflict with its
+// deliberate wrapping casts, reference-style names and layout. Keep the
+// exemption here so the public adapter and the rest of codec-core remain under
+// the full strict lint policy.
+#![allow(
+    clippy::bool_to_int_with_if,
+    clippy::branches_sharing_code,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::if_not_else,
+    clippy::inline_always,
+    clippy::many_single_char_names,
+    clippy::manual_contains,
+    clippy::manual_let_else,
+    clippy::match_same_arms,
+    clippy::missing_const_for_fn,
+    clippy::needless_pass_by_ref_mut,
+    clippy::needless_pass_by_value,
+    clippy::redundant_pub_crate,
+    clippy::similar_names,
+    clippy::single_match_else,
+    clippy::too_many_lines,
+    clippy::trivially_copy_pass_by_ref,
+    clippy::unreadable_literal,
+    clippy::unused_self,
+    clippy::use_self,
+    clippy::useless_let_if_seq,
+    clippy::verbose_bit_mask
+)]
 
 /// Public API layer (`G729Encoder`, `G729Decoder`, configs, and frame types).
 pub mod api;

--- a/crates/media/codec-core/src/codecs/g729/mod.rs
+++ b/crates/media/codec-core/src/codecs/g729/mod.rs
@@ -55,6 +55,7 @@ impl G729Codec {
     ///
     /// Returns an error when the configuration requests unsupported audio
     /// format settings or the unimplemented full-complexity base G.729 path.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new(config: CodecConfig) -> Result<Self> {
         config.validate()?;
         validate_g729_format(&config)?;
@@ -72,7 +73,8 @@ impl G729Codec {
     }
 
     /// Return whether Annex B VAD/DTX/CNG behavior is enabled.
-    pub fn annex_b_enabled(&self) -> bool {
+    #[must_use]
+    pub const fn annex_b_enabled(&self) -> bool {
         self.profile.annex_b()
     }
 }
@@ -174,6 +176,7 @@ impl AudioCodecExt for G729Codec {
     }
 }
 
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn validate_g729_format(config: &CodecConfig) -> Result<()> {
     if config.sample_rate.hz() != 8000 {
         return Err(CodecError::InvalidSampleRate {
@@ -212,8 +215,8 @@ fn profile_from_config(config: &CodecConfig) -> Result<G729Profile> {
     let params = &config.parameters.g729;
 
     #[allow(deprecated)]
-    let annex_a_enabled = params.annex_a && params.reduced_complexity;
-    if !annex_a_enabled {
+    let reduced_complexity_enabled = params.annex_a && params.reduced_complexity;
+    if !reduced_complexity_enabled {
         return Err(CodecError::invalid_config(
             "Full-complexity base G.729 is not implemented; use Annex A",
         ));
@@ -273,6 +276,12 @@ fn map_g729_error(error: g729_impl::CodecError) -> CodecError {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
 mod tests {
     use super::*;
     use crate::codecs::CodecFactory;
@@ -389,7 +398,7 @@ mod tests {
 
         let (decoded, encoded_lengths) = round_trip_frames(&mut codec, &input);
         assert_eq!(decoded.len(), input.len());
-        assert!(encoded_lengths.iter().any(|&len| len == 10));
+        assert!(encoded_lengths.contains(&10));
 
         let warmup = G729Codec::FRAME_SAMPLES * 5;
         let corr = correlation(&input[warmup..], &decoded[warmup..]);
@@ -426,9 +435,8 @@ mod tests {
         let mut config = CodecConfig::new(CodecType::G729);
         config.parameters.g729.annex_a = false;
 
-        let error = match G729Codec::new(config) {
-            Ok(_) => panic!("full-complexity G.729 config should be rejected"),
-            Err(error) => error,
+        let Err(error) = G729Codec::new(config) else {
+            panic!("full-complexity G.729 config should be rejected");
         };
         assert!(matches!(error, CodecError::InvalidConfig { .. }));
     }
@@ -439,9 +447,8 @@ mod tests {
         let mut config = CodecConfig::new(CodecType::G729);
         config.parameters.g729.reduced_complexity = false;
 
-        let error = match G729Codec::new(config) {
-            Ok(_) => panic!("legacy full-complexity G.729 config should be rejected"),
-            Err(error) => error,
+        let Err(error) = G729Codec::new(config) else {
+            panic!("legacy full-complexity G.729 config should be rejected");
         };
         assert!(matches!(error, CodecError::InvalidConfig { .. }));
     }
@@ -449,9 +456,8 @@ mod tests {
     #[test]
     fn g729_validates_frame_size() {
         let config = CodecConfig::new(CodecType::G729A).with_frame_size_ms(20.0);
-        let error = match G729Codec::new(config) {
-            Ok(_) => panic!("20 ms G.729 frames should be rejected"),
-            Err(error) => error,
+        let Err(error) = G729Codec::new(config) else {
+            panic!("20 ms G.729 frames should be rejected");
         };
         assert!(matches!(error, CodecError::InvalidFrameSize { .. }));
     }

--- a/crates/media/codec-core/src/codecs/mod.rs
+++ b/crates/media/codec-core/src/codecs/mod.rs
@@ -94,6 +94,13 @@ impl CodecFactory {
     ///
     /// Returns an error when the configuration is invalid, the codec feature
     /// is disabled, or codec construction fails.
+    // Preserve the public by-value constructor in a build where every codec
+    // branch is compiled out; feature-enabled branches transfer ownership to
+    // their concrete codec constructors.
+    #[cfg_attr(
+        not(any(feature = "g711", feature = "g729", feature = "opus")),
+        allow(clippy::needless_pass_by_value)
+    )]
     pub fn create(config: CodecConfig) -> Result<Box<dyn AudioCodec>> {
         // Validate configuration first
         config.validate()?;

--- a/crates/media/codec-core/src/codecs/mod.rs
+++ b/crates/media/codec-core/src/codecs/mod.rs
@@ -75,7 +75,7 @@ pub mod g711;
 #[cfg(feature = "g729")]
 pub mod g729;
 
-#[cfg(any(feature = "opus", feature = "opus-sim"))]
+#[cfg(feature = "opus")]
 pub mod opus;
 
 /// Codec factory for creating codec instances
@@ -106,7 +106,7 @@ impl CodecFactory {
                 Ok(Box::new(codec))
             }
 
-            #[cfg(any(feature = "opus", feature = "opus-sim"))]
+            #[cfg(feature = "opus")]
             CodecType::Opus => {
                 let codec = opus::OpusCodec::new(config)?;
                 Ok(Box::new(codec))
@@ -173,7 +173,7 @@ impl CodecFactory {
             "G729A",
             #[cfg(feature = "g729")]
             "G729BA",
-            #[cfg(any(feature = "opus", feature = "opus-sim"))]
+            #[cfg(feature = "opus")]
             "OPUS",
         ]
     }
@@ -186,7 +186,7 @@ impl CodecFactory {
             "PCMU" | "PCMA" => true,
             #[cfg(feature = "g729")]
             "G729" | "G729A" | "G729AB" | "G729BA" => true,
-            #[cfg(any(feature = "opus", feature = "opus-sim"))]
+            #[cfg(feature = "opus")]
             "OPUS" => true,
             _ => false,
         }
@@ -269,7 +269,11 @@ pub struct CodecCapabilities {
 impl CodecCapabilities {
     /// Get capabilities for all supported codecs
     pub fn get_all() -> Self {
+        // Both values are populated by feature-gated blocks. In a deliberately
+        // codec-free build they remain empty and therefore need no mutation.
+        #[allow(unused_mut)]
         let mut codec_types = Vec::new();
+        #[allow(unused_mut)]
         let mut codec_info = HashMap::new();
 
         #[cfg(feature = "g711")]
@@ -302,7 +306,7 @@ impl CodecCapabilities {
             );
         }
 
-        #[cfg(any(feature = "opus", feature = "opus-sim"))]
+        #[cfg(feature = "opus")]
         {
             codec_types.push(CodecType::Opus);
             codec_info.insert(
@@ -402,6 +406,16 @@ mod tests {
         }
 
         assert!(!CodecFactory::is_supported("UNSUPPORTED"));
+        assert!(!CodecFactory::is_supported("G722"));
+
+        #[cfg(feature = "opus")]
+        for name in ["opus", "Opus", "OPUS"] {
+            assert!(CodecFactory::is_supported(name));
+        }
+        #[cfg(not(feature = "opus"))]
+        for name in ["opus", "Opus", "OPUS"] {
+            assert!(!CodecFactory::is_supported(name));
+        }
     }
 
     #[test]

--- a/crates/media/codec-core/src/codecs/mod.rs
+++ b/crates/media/codec-core/src/codecs/mod.rs
@@ -1,6 +1,6 @@
 //! # Audio Codec Implementations
 //!
-//! This module contains G.711 audio codec implementation for VoIP applications.
+//! This module contains G.711 audio codec implementation for `VoIP` applications.
 //!
 //! ## Available Codecs
 //!
@@ -83,6 +83,11 @@ pub struct CodecFactory;
 
 impl CodecFactory {
     /// Create a codec instance from configuration
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the configuration is invalid, the codec feature
+    /// is disabled, or codec construction fails.
     pub fn create(config: CodecConfig) -> Result<Box<dyn AudioCodec>> {
         // Validate configuration first
         config.validate()?;
@@ -113,13 +118,17 @@ impl CodecFactory {
             }
 
             codec_type => Err(CodecError::feature_not_enabled(format!(
-                "Codec {} not enabled in build features",
-                codec_type.name()
+                "Codec {codec_type} not enabled in build features"
             ))),
         }
     }
 
     /// Create a codec by name
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `name` is unknown, its feature is disabled, or
+    /// the configuration is invalid.
     pub fn create_by_name(name: &str, config: CodecConfig) -> Result<Box<dyn AudioCodec>> {
         let codec_type = match normalize_codec_name(name).as_str() {
             "PCMU" => CodecType::G711Pcmu,
@@ -140,6 +149,11 @@ impl CodecFactory {
     }
 
     /// Create a codec by RTP payload type
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the payload type is unknown, its codec feature is
+    /// disabled, or the configuration is invalid.
     pub fn create_by_payload_type(
         payload_type: u8,
         config: CodecConfig,
@@ -149,7 +163,7 @@ impl CodecFactory {
             8 => CodecType::G711Pcma,
             18 => CodecType::G729,
 
-            _ => return Err(CodecError::unsupported_codec(format!("PT{}", payload_type))),
+            _ => return Err(CodecError::unsupported_codec(format!("PT{payload_type}"))),
         };
 
         let config = CodecConfig {
@@ -161,6 +175,7 @@ impl CodecFactory {
     }
 
     /// Get all supported codec names
+    #[must_use]
     pub fn supported_codecs() -> Vec<&'static str> {
         vec![
             #[cfg(feature = "g711")]
@@ -179,6 +194,7 @@ impl CodecFactory {
     }
 
     /// Check if a codec is supported
+    #[must_use]
     pub fn is_supported(name: &str) -> bool {
         let normalized = normalize_codec_name(name);
         match normalized.as_str() {
@@ -204,6 +220,7 @@ pub struct CodecRegistry {
 
 impl CodecRegistry {
     /// Create a new empty registry
+    #[must_use]
     pub fn new() -> Self {
         Self {
             codecs: HashMap::new(),
@@ -216,8 +233,9 @@ impl CodecRegistry {
     }
 
     /// Get a codec by name
+    #[must_use]
     pub fn get(&self, name: &str) -> Option<&dyn AudioCodec> {
-        self.codecs.get(name).map(|codec| codec.as_ref())
+        self.codecs.get(name).map(std::convert::AsRef::as_ref)
     }
 
     /// Get a mutable codec by name
@@ -231,16 +249,19 @@ impl CodecRegistry {
     }
 
     /// List all registered codec names
+    #[must_use]
     pub fn list_codecs(&self) -> Vec<&String> {
         self.codecs.keys().collect()
     }
 
     /// Get the count of registered codecs
+    #[must_use]
     pub fn len(&self) -> usize {
         self.codecs.len()
     }
 
     /// Check if the registry is empty
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.codecs.is_empty()
     }
@@ -268,6 +289,7 @@ pub struct CodecCapabilities {
 
 impl CodecCapabilities {
     /// Get capabilities for all supported codecs
+    #[must_use]
     pub fn get_all() -> Self {
         // Both values are populated by feature-gated blocks. In a deliberately
         // codec-free build they remain empty and therefore need no mutation.
@@ -370,11 +392,13 @@ impl CodecCapabilities {
     }
 
     /// Check if a codec type is supported
+    #[must_use]
     pub fn is_supported(&self, codec_type: CodecType) -> bool {
         self.codec_types.contains(&codec_type)
     }
 
     /// Get information for a specific codec type
+    #[must_use]
     pub fn get_info(&self, codec_type: CodecType) -> Option<&CodecInfo> {
         self.codec_info.get(&codec_type)
     }

--- a/crates/media/codec-core/src/codecs/mod.rs
+++ b/crates/media/codec-core/src/codecs/mod.rs
@@ -23,6 +23,8 @@
 //!
 //! ### Using the Codec Factory
 //! ```rust
+//! # #[cfg(feature = "g711")]
+//! # {
 //! use codec_core::codecs::CodecFactory;
 //! use codec_core::types::{CodecConfig, CodecType, SampleRate};
 //!
@@ -35,16 +37,20 @@
 //! let samples = vec![0i16; 160];
 //! let encoded = codec.encode(&samples)?;
 //! let decoded = codec.decode(&encoded)?;
+//! # }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! ### Direct Codec Access
 //! ```rust
+//! # #[cfg(feature = "g711")]
+//! # {
 //! use codec_core::codecs::g711::{G711Codec, G711Variant};
 //!
 //! // Direct instantiation
 //! let mut g711_ulaw = G711Codec::new(G711Variant::MuLaw);
 //! let mut g711_alaw = G711Codec::new(G711Variant::ALaw);
+//! # }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
@@ -411,7 +417,12 @@ mod tests {
     #[test]
     fn test_codec_factory_supported_codecs() {
         let supported = CodecFactory::supported_codecs();
+
+        #[cfg(any(feature = "g711", feature = "g729", feature = "opus"))]
         assert!(!supported.is_empty());
+
+        #[cfg(not(any(feature = "g711", feature = "g729", feature = "opus")))]
+        assert!(supported.is_empty());
 
         #[cfg(feature = "g711")]
         {
@@ -466,8 +477,18 @@ mod tests {
     #[test]
     fn test_codec_capabilities() {
         let caps = CodecCapabilities::get_all();
-        assert!(!caps.codec_types.is_empty());
-        assert!(!caps.codec_info.is_empty());
+
+        #[cfg(any(feature = "g711", feature = "g729", feature = "opus"))]
+        {
+            assert!(!caps.codec_types.is_empty());
+            assert!(!caps.codec_info.is_empty());
+        }
+
+        #[cfg(not(any(feature = "g711", feature = "g729", feature = "opus")))]
+        {
+            assert!(caps.codec_types.is_empty());
+            assert!(caps.codec_info.is_empty());
+        }
 
         #[cfg(feature = "g711")]
         {

--- a/crates/media/codec-core/src/codecs/opus.rs
+++ b/crates/media/codec-core/src/codecs/opus.rs
@@ -10,7 +10,11 @@ use crate::utils::validate_opus_frame;
 use std::sync::Mutex;
 use tracing::{debug, trace};
 
-const MAX_OPUS_PACKET_BYTES: usize = 1275;
+// libopus permits callers to provide up to 4,000 bytes to one encode call.
+// RFC 6716's 1,275-byte limit is per frame; a packet can contain multiple
+// frames (including a 60 ms high-bitrate packet), so it is not a safe output
+// buffer contract for the encoder API.
+const MAX_OPUS_PACKET_BYTES: usize = 4_000;
 
 // Re-export OpusApplication from types to avoid duplication
 pub use crate::types::OpusApplication;
@@ -695,6 +699,25 @@ mod tests {
                 .unwrap(),
             5_760
         );
+    }
+
+    #[test]
+    fn max_bitrate_sixty_ms_encode_uses_the_libopus_packet_contract() {
+        let config = create_test_config()
+            .with_channels(2)
+            .with_frame_size_ms(60.0)
+            .with_bitrate(510_000);
+        let mut codec = OpusCodec::new(config).unwrap();
+        let samples: Vec<i16> = (0_usize..2_880)
+            .flat_map(|index| {
+                let left = ((index.wrapping_mul(7_919) % 65_535) as i32 - 32_767) as i16;
+                [left, left.wrapping_neg()]
+            })
+            .collect();
+        let encoded = codec.encode(&samples).unwrap();
+        assert!(!encoded.is_empty());
+        assert!(encoded.len() <= MAX_OPUS_PACKET_BYTES);
+        assert_eq!(codec.max_encoded_size(samples.len()), MAX_OPUS_PACKET_BYTES);
     }
 
     #[test]

--- a/crates/media/codec-core/src/codecs/opus.rs
+++ b/crates/media/codec-core/src/codecs/opus.rs
@@ -710,7 +710,8 @@ mod tests {
         let mut codec = OpusCodec::new(config).unwrap();
         let samples: Vec<i16> = (0_usize..2_880)
             .flat_map(|index| {
-                let left = ((index.wrapping_mul(7_919) % 65_535) as i32 - 32_767) as i16;
+                let value = u16::try_from(index.wrapping_mul(7_919) % 65_535).unwrap();
+                let left = i16::try_from(i32::from(value) - 32_767).unwrap();
                 [left, left.wrapping_neg()]
             })
             .collect();

--- a/crates/media/codec-core/src/codecs/opus.rs
+++ b/crates/media/codec-core/src/codecs/opus.rs
@@ -7,7 +7,10 @@
 use crate::error::{CodecError, Result};
 use crate::types::{AudioCodec, AudioCodecExt, CodecConfig, CodecInfo, SampleRate};
 use crate::utils::validate_opus_frame;
-use tracing::{debug, trace, warn};
+use std::sync::Mutex;
+use tracing::{debug, trace};
+
+const MAX_OPUS_PACKET_BYTES: usize = 1275;
 
 // Re-export OpusApplication from types to avoid duplication
 pub use crate::types::OpusApplication;
@@ -22,12 +25,18 @@ pub struct OpusCodec {
     frame_size: usize,
     /// Codec configuration
     config: OpusConfig,
+    /// The real libopus encoder. A mutex is used only to satisfy the codec
+    /// trait's `Sync` bound; codec operations already require `&mut self`.
+    encoder: Mutex<opus::Encoder>,
+    /// The matching libopus decoder.
+    decoder: Mutex<opus::Decoder>,
 }
 
-/// Opus codec configuration
+/// `Opus` codec configuration.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub struct OpusConfig {
-    /// Application type (VoIP, Audio, or Low Delay)
+    /// Application type (`VoIP`, audio, or low delay).
     pub application: OpusApplication,
     /// Bitrate in bits per second
     pub bitrate: u32,
@@ -64,9 +73,21 @@ impl Default for OpusConfig {
 }
 
 impl OpusCodec {
-    /// Create a new Opus codec
+    /// Create a new `Opus` codec.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unsupported parameters or if libopus cannot create
+    /// and configure the encoder and decoder.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new(config: CodecConfig) -> Result<Self> {
-        // Validate configuration
+        if config.codec_type != crate::types::CodecType::Opus {
+            return Err(CodecError::unsupported_codec(format!(
+                "{} configuration passed to OpusCodec",
+                config.codec_type
+            )));
+        }
+        config.validate()?;
         let sample_rate = config.sample_rate.hz();
 
         // Opus supports 8, 12, 16, 24, 48 kHz
@@ -86,15 +107,16 @@ impl OpusCodec {
         }
 
         // Calculate frame size based on frame_size_ms or use default
-        let frame_size = if let Some(frame_ms) = config.frame_size_ms {
-            let samples_per_ms = sample_rate as f32 / 1000.0;
-            (samples_per_ms * frame_ms) as usize
-        } else {
-            // Default to 20ms
-            (sample_rate * 20 / 1000) as usize
-        };
+        let frame_duration_ms = config.frame_size_ms.unwrap_or(20.0);
+        let frame_size = opus_frame_size(sample_rate, frame_duration_ms).ok_or_else(|| {
+            CodecError::invalid_config(format!(
+                "Unsupported Opus frame duration: {frame_duration_ms}ms"
+            ))
+        })?;
 
-        // Create Opus configuration
+        // The codec-specific field was the public Opus configuration surface
+        // before the real backend landed, so it remains authoritative. The
+        // generic `with_bitrate` convenience setter keeps both values in sync.
         let opus_config = OpusConfig {
             application: config.parameters.opus.application,
             bitrate: config.parameters.opus.bitrate,
@@ -107,6 +129,47 @@ impl OpusCodec {
             force_mono: config.parameters.opus.force_mono,
         };
 
+        if opus_config.complexity > 10 {
+            return Err(CodecError::invalid_config(
+                "Opus complexity must be in the range 0-10",
+            ));
+        }
+        if opus_config.packet_loss_perc > 100 {
+            return Err(CodecError::invalid_config(
+                "Opus packet loss percentage must be in the range 0-100",
+            ));
+        }
+        if !(6_000..=510_000).contains(&opus_config.bitrate) {
+            return Err(CodecError::InvalidBitrate {
+                bitrate: opus_config.bitrate,
+                min: 6_000,
+                max: 510_000,
+            });
+        }
+
+        let opus_channels = match config.channels {
+            1 => opus::Channels::Mono,
+            2 => opus::Channels::Stereo,
+            _ => unreachable!("channel count was validated above"),
+        };
+        let application = match opus_config.application {
+            OpusApplication::Voip => opus::Application::Voip,
+            OpusApplication::Audio => opus::Application::Audio,
+            OpusApplication::RestrictedLowDelay => opus::Application::LowDelay,
+        };
+
+        let mut encoder =
+            opus::Encoder::new(sample_rate, opus_channels, application).map_err(|error| {
+                CodecError::initialization_failed(format!(
+                    "libopus encoder creation failed: {error}"
+                ))
+            })?;
+        let decoder = opus::Decoder::new(sample_rate, opus_channels).map_err(|error| {
+            CodecError::initialization_failed(format!("libopus decoder creation failed: {error}"))
+        })?;
+
+        configure_encoder(&mut encoder, &opus_config)?;
+
         debug!(
             "Creating Opus codec: {}Hz, {}ch, {}bps, {:?} mode",
             sample_rate, config.channels, opus_config.bitrate, opus_config.application
@@ -117,82 +180,156 @@ impl OpusCodec {
             channels: config.channels,
             frame_size,
             config: opus_config,
+            encoder: Mutex::new(encoder),
+            decoder: Mutex::new(decoder),
         })
     }
 
-    /// Get the compression ratio (variable for Opus)
+    /// Get the compression ratio (variable for `Opus`).
+    #[allow(clippy::cast_precision_loss)]
     pub fn compression_ratio(&self) -> f32 {
-        let uncompressed_bits = self.frame_size as f32 * 16.0 * self.channels as f32;
+        let uncompressed_bits = self.frame_size as f32 * 16.0 * f32::from(self.channels);
         let compressed_bits =
             self.config.bitrate as f32 * (self.frame_size as f32 / self.sample_rate as f32);
         compressed_bits / uncompressed_bits
     }
 
-    /// Set the bitrate
+    /// Set the bitrate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bitrate is outside libopus's supported range
+    /// or if libopus rejects the update.
     pub fn set_bitrate(&mut self, bitrate: u32) -> Result<()> {
-        if bitrate < 6000 || bitrate > 510000 {
+        if !(6_000..=510_000).contains(&bitrate) {
             return Err(CodecError::InvalidBitrate {
                 bitrate,
-                min: 6000,
-                max: 510000,
+                min: 6_000,
+                max: 510_000,
             });
         }
 
+        let backend_bitrate = i32::try_from(bitrate)
+            .map_err(|_| CodecError::internal_error("validated Opus bitrate did not fit i32"))?;
+        self.encoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus encoder lock was poisoned"))?
+            .set_bitrate(opus::Bitrate::Bits(backend_bitrate))
+            .map_err(|error| {
+                CodecError::encoding_failed(format!("libopus bitrate update failed: {error}"))
+            })?;
         self.config.bitrate = bitrate;
         debug!("Opus bitrate set to {} bps", bitrate);
         Ok(())
     }
 
-    /// Set complexity level (0-10)
+    /// Set complexity level (0-10).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an out-of-range value or if libopus rejects the
+    /// update.
     pub fn set_complexity(&mut self, complexity: u8) -> Result<()> {
         if complexity > 10 {
             return Err(CodecError::invalid_config("Complexity must be 0-10"));
         }
 
+        self.encoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus encoder lock was poisoned"))?
+            .set_complexity(i32::from(complexity))
+            .map_err(|error| {
+                CodecError::encoding_failed(format!("libopus complexity update failed: {error}"))
+            })?;
         self.config.complexity = complexity;
         debug!("Opus complexity set to {}", complexity);
         Ok(())
     }
 
-    /// Simulate Opus encoding
-    fn simulate_encode(&mut self, samples: &[i16]) -> Result<Vec<u8>> {
-        // Calculate target size based on bitrate
-        let frame_duration_ms =
-            (samples.len() as f32 * 1000.0) / (self.sample_rate as f32 * self.channels as f32);
-        let target_bits = (self.config.bitrate as f32 * frame_duration_ms / 1000.0) as usize;
-        let target_bytes = target_bits / 8;
-
-        let mut encoded = Vec::with_capacity(target_bytes.max(10));
-
-        // Simple simulation - just create dummy data
-        for i in 0..target_bytes {
-            encoded.push((i % 256) as u8);
+    fn validate_input(&self, samples: &[i16]) -> Result<()> {
+        let channels = usize::from(self.channels);
+        if !samples.len().is_multiple_of(channels) {
+            return Err(CodecError::invalid_format(format!(
+                "Opus input sample count {} is not divisible by {} channels",
+                samples.len(),
+                self.channels
+            )));
         }
-
-        Ok(encoded)
+        validate_opus_frame(
+            &samples[..samples.len() / channels],
+            SampleRate::from_hz(self.sample_rate),
+        )
     }
+}
 
-    /// Simulate Opus decoding
-    fn simulate_decode(&mut self, data: &[u8]) -> Result<Vec<i16>> {
-        let mut samples = vec![0i16; self.frame_size * self.channels as usize];
+fn opus_frame_size(sample_rate: u32, frame_duration_ms: f32) -> Option<usize> {
+    let divisor = match frame_duration_ms {
+        2.5 => 400,
+        5.0 => 200,
+        10.0 => 100,
+        20.0 => 50,
+        40.0 => 25,
+        60.0 => return usize::try_from(sample_rate.checked_mul(3)? / 50).ok(),
+        _ => return None,
+    };
+    usize::try_from(sample_rate / divisor).ok()
+}
 
-        // Simple simulation - generate noise based on input
-        for (i, sample) in samples.iter_mut().enumerate() {
-            let data_idx = i % data.len();
-            *sample = ((data[data_idx] as i16) << 8) | (i as i16 & 0xFF);
-        }
+fn configure_encoder(encoder: &mut opus::Encoder, config: &OpusConfig) -> Result<()> {
+    let configure = |operation: &'static str, result: opus::Result<()>| {
+        result.map_err(|error| {
+            CodecError::initialization_failed(format!("libopus {operation} failed: {error}"))
+        })
+    };
 
-        Ok(samples)
-    }
+    let bitrate = i32::try_from(config.bitrate)
+        .map_err(|_| CodecError::invalid_config("Opus bitrate does not fit i32"))?;
+    configure(
+        "bitrate configuration",
+        encoder.set_bitrate(opus::Bitrate::Bits(bitrate)),
+    )?;
+    configure("VBR configuration", encoder.set_vbr(config.vbr))?;
+    configure(
+        "constrained VBR configuration",
+        encoder.set_vbr_constraint(config.cvbr),
+    )?;
+    configure(
+        "complexity configuration",
+        encoder.set_complexity(i32::from(config.complexity)),
+    )?;
+    configure(
+        "in-band FEC configuration",
+        encoder.set_inband_fec(config.inband_fec),
+    )?;
+    configure(
+        "packet-loss configuration",
+        encoder.set_packet_loss_perc(i32::from(config.packet_loss_perc)),
+    )?;
+    configure("DTX configuration", encoder.set_dtx(config.dtx))?;
+    configure(
+        "channel configuration",
+        encoder.set_force_channels(if config.force_mono {
+            Some(opus::Channels::Mono)
+        } else {
+            None
+        }),
+    )?;
+    Ok(())
 }
 
 impl AudioCodec for OpusCodec {
     fn encode(&mut self, samples: &[i16]) -> Result<Vec<u8>> {
-        // Validate input
-        validate_opus_frame(samples, SampleRate::from_hz(self.sample_rate))?;
-
-        // Simulate Opus encoding
-        let encoded = self.simulate_encode(samples)?;
+        self.validate_input(samples)?;
+        let mut encoded = vec![0; MAX_OPUS_PACKET_BYTES];
+        let encoded_len = self
+            .encoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus encoder lock was poisoned"))?
+            .encode(samples, &mut encoded)
+            .map_err(|error| {
+                CodecError::encoding_failed(format!("libopus encoding failed: {error}"))
+            })?;
+        encoded.truncate(encoded_len);
 
         trace!(
             "Opus encoded {} samples to {} bytes",
@@ -210,8 +347,19 @@ impl AudioCodec for OpusCodec {
             });
         }
 
-        // Simulate Opus decoding
-        let decoded = self.simulate_decode(data)?;
+        // A decoder output buffer must accommodate the maximum Opus packet
+        // duration (120ms), regardless of the configured encoder frame size.
+        let max_samples_per_channel = self.sample_rate as usize * 120 / 1000;
+        let mut decoded = vec![0; max_samples_per_channel * usize::from(self.channels)];
+        let decoded_samples_per_channel = self
+            .decoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus decoder lock was poisoned"))?
+            .decode(data, &mut decoded, false)
+            .map_err(|error| {
+                CodecError::decoding_failed(format!("libopus decoding failed: {error}"))
+            })?;
+        decoded.truncate(decoded_samples_per_channel * usize::from(self.channels));
 
         trace!(
             "Opus decoded {} bytes to {} samples",
@@ -229,11 +377,25 @@ impl AudioCodec for OpusCodec {
             channels: self.channels,
             bitrate: self.config.bitrate,
             frame_size: self.frame_size,
-            payload_type: Some(111), // Dynamic payload type
+            payload_type: None, // Opus payload types are negotiated dynamically
         }
     }
 
     fn reset(&mut self) -> Result<()> {
+        self.encoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus encoder lock was poisoned"))?
+            .reset_state()
+            .map_err(|error| CodecError::ResetFailed {
+                reason: format!("libopus encoder reset failed: {error}"),
+            })?;
+        self.decoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus decoder lock was poisoned"))?
+            .reset_state()
+            .map_err(|error| CodecError::ResetFailed {
+                reason: format!("libopus decoder reset failed: {error}"),
+            })?;
         debug!("Opus codec reset");
         Ok(())
     }
@@ -249,28 +411,36 @@ impl AudioCodec for OpusCodec {
 
 impl AudioCodecExt for OpusCodec {
     fn encode_to_buffer(&mut self, samples: &[i16], output: &mut [u8]) -> Result<usize> {
-        // Validate input
-        validate_opus_frame(samples, SampleRate::from_hz(self.sample_rate))?;
-
-        // Simulate Opus encoding
-        let encoded = self.simulate_encode(samples)?;
-
-        if output.len() < encoded.len() {
+        self.validate_input(samples)?;
+        // Opus is variable-rate, so the exact encoded size is not knowable
+        // without advancing the stateful encoder. Require the documented
+        // worst-case packet capacity and fail before touching encoder state.
+        if output.len() < MAX_OPUS_PACKET_BYTES {
             return Err(CodecError::BufferTooSmall {
-                needed: encoded.len(),
+                needed: MAX_OPUS_PACKET_BYTES,
                 actual: output.len(),
             });
         }
-
-        output[..encoded.len()].copy_from_slice(&encoded);
+        let encoded_len = self
+            .encoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus encoder lock was poisoned"))?
+            .encode(samples, output)
+            .map_err(|error| match error.code() {
+                opus::ErrorCode::BufferTooSmall => CodecError::BufferTooSmall {
+                    needed: MAX_OPUS_PACKET_BYTES,
+                    actual: output.len(),
+                },
+                _ => CodecError::encoding_failed(format!("libopus encoding failed: {error}")),
+            })?;
 
         trace!(
             "Opus encoded {} samples to {} bytes (zero-alloc)",
             samples.len(),
-            encoded.len()
+            encoded_len
         );
 
-        Ok(encoded.len())
+        Ok(encoded_len)
     }
 
     fn decode_to_buffer(&mut self, data: &[u8], output: &mut [i16]) -> Result<usize> {
@@ -280,38 +450,48 @@ impl AudioCodecExt for OpusCodec {
             });
         }
 
-        // Simulate Opus decoding
-        let decoded = self.simulate_decode(data)?;
-
-        if output.len() < decoded.len() {
+        let channels = usize::from(self.channels);
+        let decoder = self
+            .decoder
+            .get_mut()
+            .map_err(|_| CodecError::internal_error("Opus decoder lock was poisoned"))?;
+        let decoded_samples_per_channel = decoder.get_nb_samples(data).map_err(|error| {
+            CodecError::decoding_failed(format!("invalid Opus packet: {error}"))
+        })?;
+        let needed = decoded_samples_per_channel * channels;
+        if output.len() < needed {
             return Err(CodecError::BufferTooSmall {
-                needed: decoded.len(),
+                needed,
                 actual: output.len(),
             });
         }
-
-        output[..decoded.len()].copy_from_slice(&decoded);
+        let decoded_samples_per_channel =
+            decoder
+                .decode(data, output, false)
+                .map_err(|error| match error.code() {
+                    opus::ErrorCode::BufferTooSmall => CodecError::BufferTooSmall {
+                        needed,
+                        actual: output.len(),
+                    },
+                    _ => CodecError::decoding_failed(format!("libopus decoding failed: {error}")),
+                })?;
+        let decoded_len = decoded_samples_per_channel * channels;
 
         trace!(
             "Opus decoded {} bytes to {} samples (zero-alloc)",
             data.len(),
-            decoded.len()
+            decoded_len
         );
 
-        Ok(decoded.len())
+        Ok(decoded_len)
     }
 
-    fn max_encoded_size(&self, input_samples: usize) -> usize {
-        // Opus maximum frame size is 1275 bytes
-        let bits_per_sample = self.config.bitrate as f32 / self.sample_rate as f32;
-        let max_bytes = (input_samples as f32 * bits_per_sample / 8.0) as usize;
-        max_bytes.min(1275)
+    fn max_encoded_size(&self, _input_samples: usize) -> usize {
+        MAX_OPUS_PACKET_BYTES
     }
 
     fn max_decoded_size(&self, _input_bytes: usize) -> usize {
-        // Opus can decode to various frame sizes
-        let max_frame_ms = 60.0; // 60ms is the maximum
-        ((self.sample_rate as f32 * max_frame_ms / 1000.0) as usize) * self.channels as usize
+        self.sample_rate as usize * 120 / 1000 * usize::from(self.channels)
     }
 }
 
@@ -339,7 +519,7 @@ mod tests {
         let info = codec.info();
         assert_eq!(info.name, "Opus");
         assert_eq!(info.sample_rate, 48000);
-        assert_eq!(info.payload_type, Some(111));
+        assert_eq!(info.payload_type, None);
     }
 
     #[test]
@@ -347,21 +527,174 @@ mod tests {
         let config = create_test_config();
         let mut codec = OpusCodec::new(config).unwrap();
 
-        // Create test signal
-        let mut samples = Vec::new();
-        for i in 0..960 {
-            let t = i as f32 / 48000.0;
-            let sample = ((2.0 * std::f32::consts::PI * 1000.0 * t).sin() * 16000.0) as i16;
-            samples.push(sample);
-        }
+        // Create a deterministic square-wave test signal without lossy casts.
+        let samples: Vec<i16> = (0..960)
+            .map(|index| {
+                if (index / 24) % 2 == 0 {
+                    16_000
+                } else {
+                    -16_000
+                }
+            })
+            .collect();
 
         // Encode
         let encoded = codec.encode(&samples).unwrap();
-        assert!(encoded.len() > 0);
+        assert!(!encoded.is_empty());
 
         // Decode
         let decoded = codec.decode(&encoded).unwrap();
         assert_eq!(decoded.len(), samples.len());
+    }
+
+    #[test]
+    fn test_real_backend_output_depends_on_pcm_input() {
+        let silence = vec![0; 960];
+        let tone: Vec<i16> = (0..960)
+            .map(|index| {
+                if (index / 55) % 2 == 0 {
+                    12_000
+                } else {
+                    -12_000
+                }
+            })
+            .collect();
+
+        // Use independent encoders so codec history cannot explain a packet
+        // difference. The retired simulator ignored PCM input and emitted the
+        // same counter bytes for both frames.
+        let silence_packet = OpusCodec::new(create_test_config())
+            .unwrap()
+            .encode(&silence)
+            .unwrap();
+        let tone_packet = OpusCodec::new(create_test_config())
+            .unwrap()
+            .encode(&tone)
+            .unwrap();
+
+        assert_ne!(silence_packet, tone_packet);
+        assert_eq!(
+            opus::packet::get_nb_samples(&tone_packet, 48_000).unwrap(),
+            960
+        );
+    }
+
+    #[cfg(feature = "opus-sim")]
+    #[test]
+    fn test_deprecated_opus_sim_alias_uses_real_backend() {
+        let mut codec = OpusCodec::new(create_test_config()).unwrap();
+        let packet = codec.encode(&[0; 960]).unwrap();
+
+        assert_eq!(opus::packet::get_nb_samples(&packet, 48_000).unwrap(), 960);
+        assert_eq!(codec.decode(&packet).unwrap().len(), 960);
+    }
+
+    #[test]
+    fn test_opus_bitrate_configuration_remains_backward_compatible() {
+        let mut specific_config = create_test_config();
+        assert_eq!(specific_config.bitrate, Some(64_000));
+        specific_config.parameters.opus.bitrate = 32_000;
+        let specific_codec = OpusCodec::new(specific_config).unwrap();
+        assert_eq!(specific_codec.info().bitrate, 32_000);
+
+        let generic_config = create_test_config().with_bitrate(48_000);
+        assert_eq!(generic_config.bitrate, Some(48_000));
+        assert_eq!(generic_config.parameters.opus.bitrate, 48_000);
+        let generic_codec = OpusCodec::new(generic_config).unwrap();
+        assert_eq!(generic_codec.info().bitrate, 48_000);
+    }
+
+    #[test]
+    fn test_non_opus_configuration_is_rejected() {
+        assert!(matches!(
+            OpusCodec::new(CodecConfig::g711_pcmu()),
+            Err(CodecError::UnsupportedCodec { .. })
+        ));
+    }
+
+    #[test]
+    fn test_invalid_frames_are_rejected() {
+        let mut codec = OpusCodec::new(create_test_config()).unwrap();
+        assert!(matches!(
+            codec.encode(&[0; 123]),
+            Err(CodecError::InvalidFrameSize { .. })
+        ));
+        assert!(matches!(
+            codec.decode(&[]),
+            Err(CodecError::InvalidPayload { .. })
+        ));
+        assert!(matches!(
+            codec.decode(&[0x03]),
+            Err(CodecError::DecodingFailed { .. })
+        ));
+
+        let invalid_duration = create_test_config().with_frame_size_ms(7.0);
+        assert!(matches!(
+            OpusCodec::new(invalid_duration),
+            Err(CodecError::InvalidConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn test_stereo_and_variable_duration_buffer_contracts() {
+        let stereo_20ms_config = create_test_config().with_channels(2);
+        let mut stereo_encoder = OpusCodec::new(stereo_20ms_config.clone()).unwrap();
+        assert!(matches!(
+            stereo_encoder.encode(&[0; 1_919]),
+            Err(CodecError::InvalidFormat { .. })
+        ));
+
+        let stereo_frame = vec![1_000; 1_920];
+        let mut tiny_encoded = [0; 1];
+        let tiny_result = stereo_encoder.encode_to_buffer(&stereo_frame, &mut tiny_encoded);
+        assert!(
+            matches!(
+                tiny_result,
+                Err(CodecError::BufferTooSmall {
+                    needed: MAX_OPUS_PACKET_BYTES,
+                    actual: 1
+                })
+            ),
+            "unexpected tiny-buffer result: {tiny_result:?}"
+        );
+
+        let mut long_encoder = OpusCodec::new(
+            create_test_config()
+                .with_channels(2)
+                .with_frame_size_ms(60.0),
+        )
+        .unwrap();
+        let long_stereo_frame: Vec<i16> = (0..2_880)
+            .flat_map(|index| {
+                let sample = if (index / 27) % 2 == 0 {
+                    10_000
+                } else {
+                    -10_000
+                };
+                [sample, -sample]
+            })
+            .collect();
+        let long_packet = long_encoder.encode(&long_stereo_frame).unwrap();
+
+        // A decoder configured for 20 ms must still size the output from the
+        // packet on the wire, which may legally contain a longer duration.
+        let mut decoder = OpusCodec::new(stereo_20ms_config).unwrap();
+        let mut configured_size_only = vec![0; 1_920];
+        assert!(matches!(
+            decoder.decode_to_buffer(&long_packet, &mut configured_size_only),
+            Err(CodecError::BufferTooSmall {
+                needed: 5_760,
+                actual: 1_920
+            })
+        ));
+
+        let mut full_output = vec![0; decoder.max_decoded_size(long_packet.len())];
+        assert_eq!(
+            decoder
+                .decode_to_buffer(&long_packet, &mut full_output)
+                .unwrap(),
+            5_760
+        );
     }
 
     #[test]
@@ -370,12 +703,12 @@ mod tests {
         let mut codec = OpusCodec::new(config).unwrap();
 
         // Test valid bitrates
-        assert!(codec.set_bitrate(32000).is_ok());
-        assert!(codec.set_bitrate(128000).is_ok());
+        assert!(codec.set_bitrate(32_000).is_ok());
+        assert!(codec.set_bitrate(128_000).is_ok());
 
         // Test invalid bitrates
-        assert!(codec.set_bitrate(1000).is_err());
-        assert!(codec.set_bitrate(1000000).is_err());
+        assert!(codec.set_bitrate(1_000).is_err());
+        assert!(codec.set_bitrate(1_000_000).is_err());
     }
 
     #[test]

--- a/crates/media/codec-core/src/error.rs
+++ b/crates/media/codec-core/src/error.rs
@@ -158,7 +158,8 @@ impl CodecError {
     }
 
     /// Check if this error is recoverable
-    pub fn is_recoverable(&self) -> bool {
+    #[must_use]
+    pub const fn is_recoverable(&self) -> bool {
         match self {
             // Configuration errors are not recoverable
             Self::InvalidConfig { .. }
@@ -169,7 +170,9 @@ impl CodecError {
             | Self::InvalidBitrate { .. }
             | Self::FeatureNotEnabled { .. }
             | Self::CodecNotFound { .. }
-            | Self::InternalError { .. } => false,
+            | Self::InternalError { .. }
+            | Self::InitializationFailed { .. }
+            | Self::ResetFailed { .. } => false,
 
             // Operational errors may be recoverable
             Self::InvalidFrameSize { .. }
@@ -182,14 +185,12 @@ impl CodecError {
             | Self::MathError { .. }
             | Self::IoError { .. }
             | Self::ExternalLibraryError { .. } => true,
-
-            // Reset and initialization errors depend on the specific cause
-            Self::InitializationFailed { .. } | Self::ResetFailed { .. } => false,
         }
     }
 
     /// Get the error category
-    pub fn category(&self) -> ErrorCategory {
+    #[must_use]
+    pub const fn category(&self) -> ErrorCategory {
         match self {
             Self::InvalidConfig { .. }
             | Self::UnsupportedCodec { .. }
@@ -351,7 +352,7 @@ mod tests {
             expected: 160,
             actual: 80,
         };
-        let display = format!("{}", err);
+        let display = format!("{err}");
         assert!(display.contains("expected 160"));
         assert!(display.contains("got 80"));
     }

--- a/crates/media/codec-core/src/lib.rs
+++ b/crates/media/codec-core/src/lib.rs
@@ -21,6 +21,8 @@
 //! ### Quick Start
 //!
 //! ```rust
+//! # #[cfg(feature = "g711")]
+//! # {
 //! use codec_core::codecs::g711::G711Codec;
 //! use codec_core::types::{AudioCodec, CodecConfig, CodecType, SampleRate};
 //!
@@ -36,6 +38,7 @@
 //!
 //! // Decode back to samples
 //! let decoded = codec.decode(&encoded)?;
+//! # }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
@@ -62,6 +65,8 @@
 //! All codec operations return `Result` types with detailed error information:
 //!
 //! ```rust
+//! # #[cfg(feature = "g711")]
+//! # {
 //! use codec_core::codecs::g711::G711Codec;
 //! use codec_core::types::{CodecConfig, CodecType, SampleRate};
 //! use codec_core::error::CodecError;
@@ -78,6 +83,7 @@
 //!     }
 //!     Err(e) => println!("Other error: {}", e),
 //! }
+//! # }
 //! ```
 //!
 //! ## Performance Tips
@@ -88,6 +94,8 @@
 //! ### Direct G.711 Functions
 //!
 //! ```rust
+//! # #[cfg(feature = "g711")]
+//! # {
 //! use codec_core::codecs::g711::{alaw_compress, alaw_expand, ulaw_compress, ulaw_expand};
 //!
 //! // Single sample processing
@@ -97,11 +105,14 @@
 //!
 //! let ulaw_encoded = ulaw_compress(sample);
 //! let ulaw_decoded = ulaw_expand(ulaw_encoded);
+//! # }
 //! ```
 //!
 //! ### Frame-Based Processing
 //!
 //! ```rust
+//! # #[cfg(feature = "g711")]
+//! # {
 //! use codec_core::codecs::g711::{G711Codec, G711Variant};
 //!
 //! let mut codec = G711Codec::new(G711Variant::MuLaw);
@@ -113,6 +124,7 @@
 //! // Decode back to samples (same count for G.711)
 //! let decoded = codec.expand(&encoded).unwrap();
 //! assert_eq!(input_frame.len(), decoded.len());
+//! # }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
@@ -224,12 +236,21 @@ mod tests {
     fn test_info() {
         let info = info();
         assert_eq!(info.version, VERSION);
+
+        #[cfg(any(feature = "g711", feature = "g729", feature = "opus"))]
         assert!(!info.supported_codecs.is_empty());
+
+        #[cfg(not(any(feature = "g711", feature = "g729", feature = "opus")))]
+        assert!(info.supported_codecs.is_empty());
     }
 
     #[test]
     fn test_supported_codecs() {
+        #[cfg(any(feature = "g711", feature = "g729", feature = "opus"))]
         assert!(!SUPPORTED_CODECS.is_empty());
+
+        #[cfg(not(any(feature = "g711", feature = "g729", feature = "opus")))]
+        assert!(SUPPORTED_CODECS.is_empty());
 
         #[cfg(feature = "g711")]
         {

--- a/crates/media/codec-core/src/lib.rs
+++ b/crates/media/codec-core/src/lib.rs
@@ -167,6 +167,8 @@ pub const SUPPORTED_CODECS: &[&str] = &[
     "G729A",
     #[cfg(feature = "g729")]
     "G729BA",
+    #[cfg(feature = "opus")]
+    "opus",
 ];
 
 /// Initialize the codec library
@@ -241,7 +243,7 @@ mod tests {
             assert!(SUPPORTED_CODECS.contains(&"G729BA"));
         }
 
-        #[cfg(any(feature = "opus", feature = "opus-sim"))]
+        #[cfg(feature = "opus")]
         assert!(SUPPORTED_CODECS.contains(&"opus"));
     }
 }

--- a/crates/media/codec-core/src/lib.rs
+++ b/crates/media/codec-core/src/lib.rs
@@ -1,7 +1,7 @@
-//! # Codec-Core: Audio Codec Library for VoIP
+//! # `Codec-Core`: Audio Codec Library for `VoIP`
 //!
-//! A simple implementation of G.711 audio codec for VoIP applications.
-//! This library provides ITU-T compliant G.711 μ-law and A-law encoding/decoding
+//! A simple implementation of G.711 audio codec for `VoIP` applications.
+//! This library provides `ITU-T` compliant G.711 μ-law and A-law encoding/decoding
 //! with lookup table optimizations.
 //!
 //! ## Features
@@ -194,6 +194,7 @@ pub fn init() -> Result<()> {
 }
 
 /// Get library information
+#[must_use]
 pub fn info() -> LibraryInfo {
     LibraryInfo {
         version: VERSION,

--- a/crates/media/codec-core/src/types.rs
+++ b/crates/media/codec-core/src/types.rs
@@ -414,8 +414,16 @@ impl CodecConfig {
     }
 
     /// Set bitrate
+    #[must_use]
     pub fn with_bitrate(mut self, bitrate: u32) -> Self {
         self.bitrate = Some(bitrate);
+        // Opus historically treated the codec-specific bitrate as the
+        // authoritative value. Keep the generic convenience setter and that
+        // public field synchronized so existing callers do not silently get
+        // the default 64 kbit/s configuration.
+        if self.codec_type == CodecType::Opus {
+            self.parameters.opus.bitrate = bitrate;
+        }
         self
     }
 
@@ -532,7 +540,7 @@ impl CodecType {
             Self::G711Pcmu | Self::G711Pcma => (64000, 64000),
 
             Self::G729 | Self::G729A | Self::G729BA => (8000, 8000),
-            Self::Opus => (6000, 510000),
+            Self::Opus => (6_000, 510_000),
         }
     }
 }

--- a/crates/media/codec-core/src/types.rs
+++ b/crates/media/codec-core/src/types.rs
@@ -48,6 +48,10 @@ pub trait AudioCodec: Send + Sync {
     ///
     /// This clears all internal state and prepares the codec for fresh input.
     /// Useful for handling stream discontinuities.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the codec cannot reset its internal state.
     fn reset(&mut self) -> Result<()>;
 
     /// Get the expected frame size in samples
@@ -71,6 +75,11 @@ pub trait AudioCodecExt: AudioCodec {
     /// # Returns
     ///
     /// Number of bytes written to output buffer
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the input is invalid, encoding fails, or the
+    /// output buffer is too small.
     fn encode_to_buffer(&mut self, samples: &[i16], output: &mut [u8]) -> Result<usize>;
 
     /// Decode with pre-allocated output buffer (zero-copy)
@@ -83,6 +92,11 @@ pub trait AudioCodecExt: AudioCodec {
     /// # Returns
     ///
     /// Number of samples written to output buffer
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the packet is invalid, decoding fails, or the
+    /// output buffer is too small.
     fn decode_to_buffer(&mut self, data: &[u8], output: &mut [i16]) -> Result<usize>;
 
     /// Get maximum encoded size for a given input size
@@ -133,7 +147,8 @@ pub enum CodecType {
 
 impl CodecType {
     /// Get the codec name
-    pub fn name(self) -> &'static str {
+    #[must_use]
+    pub const fn name(self) -> &'static str {
         match self {
             Self::G711Pcmu => "PCMU",
             Self::G711Pcma => "PCMA",
@@ -146,27 +161,26 @@ impl CodecType {
     }
 
     /// Get the default sample rate
-    pub fn default_sample_rate(self) -> u32 {
+    #[must_use]
+    pub const fn default_sample_rate(self) -> u32 {
         match self {
-            Self::G711Pcmu | Self::G711Pcma => 8000,
-
-            Self::G729 | Self::G729A | Self::G729BA => 8000,
+            Self::G711Pcmu | Self::G711Pcma | Self::G729 | Self::G729A | Self::G729BA => 8000,
             Self::Opus => 48000,
         }
     }
 
     /// Get the default bitrate
-    pub fn default_bitrate(self) -> u32 {
+    #[must_use]
+    pub const fn default_bitrate(self) -> u32 {
         match self {
-            Self::G711Pcmu | Self::G711Pcma => 64000,
-
+            Self::G711Pcmu | Self::G711Pcma | Self::Opus => 64000,
             Self::G729 | Self::G729A | Self::G729BA => 8000,
-            Self::Opus => 64000,
         }
     }
 
     /// Get the standard RTP payload type
-    pub fn payload_type(self) -> Option<u8> {
+    #[must_use]
+    pub const fn payload_type(self) -> Option<u8> {
         match self {
             Self::G711Pcmu => Some(0),
             Self::G711Pcma => Some(8),
@@ -177,17 +191,17 @@ impl CodecType {
     }
 
     /// Get supported sample rates
-    pub fn supported_sample_rates(self) -> &'static [u32] {
+    #[must_use]
+    pub const fn supported_sample_rates(self) -> &'static [u32] {
         match self {
-            Self::G711Pcmu | Self::G711Pcma => &[8000],
-
-            Self::G729 | Self::G729A | Self::G729BA => &[8000],
+            Self::G711Pcmu | Self::G711Pcma | Self::G729 | Self::G729A | Self::G729BA => &[8000],
             Self::Opus => &[8000, 12000, 16000, 24000, 48000],
         }
     }
 
     /// Get supported channel counts
-    pub fn supported_channels(self) -> &'static [u8] {
+    #[must_use]
+    pub const fn supported_channels(self) -> &'static [u8] {
         match self {
             Self::G711Pcmu | Self::G711Pcma | Self::G729 | Self::G729A | Self::G729BA => &[1],
             Self::Opus => &[1, 2],
@@ -224,7 +238,8 @@ pub enum SampleRate {
 
 impl SampleRate {
     /// Get the sample rate value in Hz
-    pub fn hz(self) -> u32 {
+    #[must_use]
+    pub const fn hz(self) -> u32 {
         match self {
             Self::Rate8000 => 8000,
             Self::Rate12000 => 12000,
@@ -238,7 +253,8 @@ impl SampleRate {
     }
 
     /// Create from Hz value
-    pub fn from_hz(hz: u32) -> Self {
+    #[must_use]
+    pub const fn from_hz(hz: u32) -> Self {
         match hz {
             8000 => Self::Rate8000,
             12000 => Self::Rate12000,
@@ -252,12 +268,14 @@ impl SampleRate {
     }
 
     /// Check if this is a standard telephony rate
-    pub fn is_telephony(self) -> bool {
+    #[must_use]
+    pub const fn is_telephony(self) -> bool {
         matches!(self, Self::Rate8000 | Self::Rate16000)
     }
 
     /// Check if this is a standard audio rate
-    pub fn is_audio(self) -> bool {
+    #[must_use]
+    pub const fn is_audio(self) -> bool {
         matches!(self, Self::Rate44100 | Self::Rate48000)
     }
 }
@@ -283,7 +301,8 @@ pub struct AudioFrame {
 
 impl AudioFrame {
     /// Create a new audio frame
-    pub fn new(samples: Vec<i16>, sample_rate: SampleRate, channels: u8) -> Self {
+    #[must_use]
+    pub const fn new(samples: Vec<i16>, sample_rate: SampleRate, channels: u8) -> Self {
         Self {
             samples,
             sample_rate,
@@ -293,7 +312,8 @@ impl AudioFrame {
     }
 
     /// Create a new audio frame with timestamp
-    pub fn new_with_timestamp(
+    #[must_use]
+    pub const fn new_with_timestamp(
         samples: Vec<i16>,
         sample_rate: SampleRate,
         channels: u8,
@@ -308,17 +328,25 @@ impl AudioFrame {
     }
 
     /// Get the frame duration in milliseconds
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
     pub fn duration_ms(&self) -> f64 {
-        let samples_per_channel = self.samples.len() / self.channels as usize;
-        (samples_per_channel as f64 * 1000.0) / self.sample_rate.hz() as f64
+        let samples_per_channel = self.samples.len() / usize::from(self.channels);
+        (samples_per_channel as f64 * 1000.0) / f64::from(self.sample_rate.hz())
     }
 
     /// Get the frame size in samples per channel
-    pub fn frame_size(&self) -> usize {
+    #[must_use]
+    pub const fn frame_size(&self) -> usize {
         self.samples.len() / self.channels as usize
     }
 
     /// Validate the frame structure
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the channel count is zero, the frame is empty,
+    /// or the samples cannot be divided evenly among the channels.
     pub fn validate(&self) -> Result<()> {
         if self.channels == 0 {
             return Err(CodecError::InvalidChannelCount {
@@ -327,7 +355,11 @@ impl AudioFrame {
             });
         }
 
-        if self.samples.len() % self.channels as usize != 0 {
+        if !self
+            .samples
+            .len()
+            .is_multiple_of(usize::from(self.channels))
+        {
             return Err(CodecError::invalid_format(
                 "Sample count must be divisible by channel count",
             ));
@@ -360,6 +392,7 @@ pub struct CodecConfig {
 
 impl CodecConfig {
     /// Create a new codec configuration
+    #[must_use]
     pub fn new(codec_type: CodecType) -> Self {
         Self {
             codec_type,
@@ -372,43 +405,51 @@ impl CodecConfig {
     }
 
     /// Create G.711 PCMU configuration
+    #[must_use]
     pub fn g711_pcmu() -> Self {
         Self::new(CodecType::G711Pcmu)
     }
 
     /// Create G.711 PCMA configuration
+    #[must_use]
     pub fn g711_pcma() -> Self {
         Self::new(CodecType::G711Pcma)
     }
 
     /// Create G.729 configuration
+    #[must_use]
     pub fn g729() -> Self {
         Self::new(CodecType::G729)
     }
 
     /// Create G.729 Annex A configuration
+    #[must_use]
     pub fn g729a() -> Self {
         Self::new(CodecType::G729A).with_g729_annex_b(false)
     }
 
     /// Create G.729 Annex A plus Annex B configuration
+    #[must_use]
     pub fn g729ba() -> Self {
         Self::new(CodecType::G729BA).with_g729_annex_b(true)
     }
 
     /// Create Opus configuration
+    #[must_use]
     pub fn opus() -> Self {
         Self::new(CodecType::Opus)
     }
 
     /// Set sample rate
-    pub fn with_sample_rate(mut self, sample_rate: SampleRate) -> Self {
+    #[must_use]
+    pub const fn with_sample_rate(mut self, sample_rate: SampleRate) -> Self {
         self.sample_rate = sample_rate;
         self
     }
 
     /// Set channel count
-    pub fn with_channels(mut self, channels: u8) -> Self {
+    #[must_use]
+    pub const fn with_channels(mut self, channels: u8) -> Self {
         self.channels = channels;
         self
     }
@@ -428,37 +469,43 @@ impl CodecConfig {
     }
 
     /// Set frame size in milliseconds
-    pub fn with_frame_size_ms(mut self, frame_size_ms: f32) -> Self {
+    #[must_use]
+    pub const fn with_frame_size_ms(mut self, frame_size_ms: f32) -> Self {
         self.frame_size_ms = Some(frame_size_ms);
         self
     }
 
     /// Set codec parameters
-    pub fn with_parameters(mut self, parameters: CodecParameters) -> Self {
+    #[must_use]
+    pub const fn with_parameters(mut self, parameters: CodecParameters) -> Self {
         self.parameters = parameters;
         self
     }
 
     /// Set Opus application type
-    pub fn with_opus_application(mut self, application: OpusApplication) -> Self {
+    #[must_use]
+    pub const fn with_opus_application(mut self, application: OpusApplication) -> Self {
         self.parameters.opus.application = application;
         self
     }
 
     /// Set Opus VBR mode
-    pub fn with_opus_vbr(mut self, vbr: bool) -> Self {
+    #[must_use]
+    pub const fn with_opus_vbr(mut self, vbr: bool) -> Self {
         self.parameters.opus.vbr = vbr;
         self
     }
 
     /// Set Opus complexity
-    pub fn with_opus_complexity(mut self, complexity: u8) -> Self {
+    #[must_use]
+    pub const fn with_opus_complexity(mut self, complexity: u8) -> Self {
         self.parameters.opus.complexity = complexity;
         self
     }
 
     /// Set Opus FEC
-    pub fn with_opus_fec(mut self, fec: bool) -> Self {
+    #[must_use]
+    pub const fn with_opus_fec(mut self, fec: bool) -> Self {
         self.parameters.opus.inband_fec = fec;
         self
     }
@@ -467,16 +514,18 @@ impl CodecConfig {
     ///
     /// Setting this to `false` requests full-complexity base G.729, which is
     /// not implemented by the built-in G.729 codec and will be rejected.
+    #[must_use]
     #[allow(deprecated)] // keep the legacy mirror field in sync
-    pub fn with_g729_annex_a(mut self, annex_a: bool) -> Self {
+    pub const fn with_g729_annex_a(mut self, annex_a: bool) -> Self {
         self.parameters.g729.annex_a = annex_a;
         self.parameters.g729.reduced_complexity = annex_a;
         self
     }
 
     /// Set whether G.729 Annex B VAD/DTX/CNG is enabled.
+    #[must_use]
     #[allow(deprecated)] // keep legacy VAD/CNG mirror fields in sync
-    pub fn with_g729_annex_b(mut self, annex_b: bool) -> Self {
+    pub const fn with_g729_annex_b(mut self, annex_b: bool) -> Self {
         self.parameters.g729.annex_b = annex_b;
         self.parameters.g729.vad_enabled = annex_b;
         self.parameters.g729.cng_enabled = annex_b;
@@ -484,20 +533,27 @@ impl CodecConfig {
     }
 
     /// Set G.729 VAD
+    #[must_use]
     #[allow(deprecated)] // intentionally writes the legacy field for backward compat
-    pub fn with_g729_vad(mut self, vad: bool) -> Self {
+    pub const fn with_g729_vad(mut self, vad: bool) -> Self {
         self.parameters.g729.vad_enabled = vad;
         self
     }
 
     /// Set G.729 CNG
+    #[must_use]
     #[allow(deprecated)] // intentionally writes the legacy field for backward compat
-    pub fn with_g729_cng(mut self, cng: bool) -> Self {
+    pub const fn with_g729_cng(mut self, cng: bool) -> Self {
         self.parameters.g729.cng_enabled = cng;
         self
     }
 
     /// Validate the configuration
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the sample rate, channel count, or bitrate is not
+    /// supported by the selected codec.
     pub fn validate(&self) -> Result<()> {
         // Check if sample rate is supported
         let supported_rates = self.codec_type.supported_sample_rates();
@@ -535,7 +591,8 @@ impl CodecConfig {
 
 impl CodecType {
     /// Get the bitrate range for this codec type
-    pub fn bitrate_range(self) -> (u32, u32) {
+    #[must_use]
+    pub const fn bitrate_range(self) -> (u32, u32) {
         match self {
             Self::G711Pcmu | Self::G711Pcma => (64000, 64000),
 
@@ -546,7 +603,7 @@ impl CodecType {
 }
 
 /// Codec-specific parameters
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CodecParameters {
     /// G.711 specific parameters
     pub g711: G711Parameters,
@@ -565,6 +622,7 @@ pub struct G711Parameters {
 }
 
 /// G.729 codec parameters
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct G729Parameters {
     /// Enable G.729 Annex A (reduced complexity - ~40% faster)
@@ -573,13 +631,13 @@ pub struct G729Parameters {
     pub annex_b: bool,
 
     // Legacy fields for backward compatibility (deprecated)
-    /// Use reduced complexity mode (Annex A) - DEPRECATED: use annex_a instead
+    /// Use reduced complexity mode (Annex A) - DEPRECATED: use `annex_a` instead
     #[deprecated(since = "0.1.14", note = "use annex_a instead")]
     pub reduced_complexity: bool,
-    /// Enable Voice Activity Detection (VAD) - DEPRECATED: use annex_b instead
+    /// Enable Voice Activity Detection (VAD) - DEPRECATED: use `annex_b` instead
     #[deprecated(since = "0.1.14", note = "use annex_b instead")]
     pub vad_enabled: bool,
-    /// Enable Comfort Noise Generation (CNG) - DEPRECATED: use annex_b instead
+    /// Enable Comfort Noise Generation (CNG) - DEPRECATED: use `annex_b` instead
     #[deprecated(since = "0.1.14", note = "use annex_b instead")]
     pub cng_enabled: bool,
 }
@@ -600,7 +658,8 @@ impl Default for G729Parameters {
 }
 
 /// Opus codec parameters
-#[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpusParameters {
     /// Application type
     pub application: OpusApplication,
@@ -641,7 +700,7 @@ impl Default for OpusParameters {
 /// Opus application type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpusApplication {
-    /// VoIP application
+    /// `VoIP` application
     Voip,
     /// Audio application
     Audio,
@@ -666,6 +725,7 @@ pub struct CodecCapability {
 
 impl CodecCapability {
     /// Create capability info for a codec type
+    #[must_use]
     pub fn for_codec(codec_type: CodecType) -> Self {
         Self {
             codec_type,
@@ -679,7 +739,8 @@ impl CodecCapability {
 
 impl CodecType {
     /// Get the quality score for this codec type
-    pub fn quality_score(self) -> u8 {
+    #[must_use]
+    pub const fn quality_score(self) -> u8 {
         match self {
             Self::G711Pcmu | Self::G711Pcma => 70,
 
@@ -714,7 +775,7 @@ mod tests {
         assert_eq!(frame.samples, samples);
         assert_eq!(frame.sample_rate, SampleRate::Rate8000);
         assert_eq!(frame.channels, 1);
-        assert_eq!(frame.duration_ms(), 20.0);
+        assert!((frame.duration_ms() - 20.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/media/codec-core/src/utils/simd.rs
+++ b/crates/media/codec-core/src/utils/simd.rs
@@ -8,20 +8,26 @@ use std::sync::OnceLock;
 /// SIMD support information
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SimdSupport {
-    /// x86_64 SSE2 support
+    /// `x86_64` SSE2 support
     pub sse2: bool,
-    /// x86_64 AVX2 support
+    /// `x86_64` AVX2 support
     pub avx2: bool,
-    /// AArch64 NEON support
+    /// `AArch64` NEON support
     pub neon: bool,
 }
 
 /// Global SIMD support detection
 static SIMD_SUPPORT: OnceLock<SimdSupport> = OnceLock::new();
 
+#[cfg(target_arch = "x86_64")]
+const fn extracted_i16(value: i32) -> i16 {
+    let bytes = value.to_le_bytes();
+    i16::from_le_bytes([bytes[0], bytes[1]])
+}
+
 /// Initialize SIMD support detection
 pub fn init_simd_support() {
-    SIMD_SUPPORT.get_or_init(|| detect_simd_support());
+    SIMD_SUPPORT.get_or_init(detect_simd_support);
 }
 
 /// Internal function to detect SIMD support
@@ -53,11 +59,13 @@ fn detect_simd_support() -> SimdSupport {
 }
 
 /// Get SIMD support information
+#[must_use]
 pub fn get_simd_support() -> SimdSupport {
-    *SIMD_SUPPORT.get_or_init(|| detect_simd_support())
+    *SIMD_SUPPORT.get_or_init(detect_simd_support)
 }
 
 /// Check if any SIMD support is available
+#[must_use]
 pub fn has_simd_support() -> bool {
     let support = get_simd_support();
     support.sse2 || support.avx2 || support.neon
@@ -78,18 +86,26 @@ pub fn encode_mulaw_simd_sse2(samples: &[i16], output: &mut [u8]) {
     unsafe {
         for chunk in chunks.by_ref() {
             // Load 8 samples at once
-            let samples_vec = _mm_loadu_si128(chunk.as_ptr() as *const __m128i);
+            let samples_vec = _mm_loadu_si128(chunk.as_ptr().cast::<__m128i>());
 
             // Process each sample - need to unroll or use different approach
             // _mm_extract_epi16 requires compile-time constant, so we unroll
-            output[out_idx] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 0) as i16);
-            output[out_idx + 1] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 1) as i16);
-            output[out_idx + 2] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 2) as i16);
-            output[out_idx + 3] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 3) as i16);
-            output[out_idx + 4] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 4) as i16);
-            output[out_idx + 5] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 5) as i16);
-            output[out_idx + 6] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 6) as i16);
-            output[out_idx + 7] = linear_to_mulaw_scalar(_mm_extract_epi16(samples_vec, 7) as i16);
+            output[out_idx] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 0)));
+            output[out_idx + 1] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 1)));
+            output[out_idx + 2] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 2)));
+            output[out_idx + 3] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 3)));
+            output[out_idx + 4] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 4)));
+            output[out_idx + 5] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 5)));
+            output[out_idx + 6] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 6)));
+            output[out_idx + 7] =
+                linear_to_mulaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 7)));
             out_idx += 8;
         }
     }
@@ -101,7 +117,7 @@ pub fn encode_mulaw_simd_sse2(samples: &[i16], output: &mut [u8]) {
     }
 }
 
-/// SIMD-optimized μ-law encoding (AArch64 NEON)
+/// SIMD-optimized μ-law encoding (`AArch64` NEON)
 #[cfg(target_arch = "aarch64")]
 pub fn encode_mulaw_simd_neon(samples: &[i16], output: &mut [u8]) {
     if !get_simd_support().neon {
@@ -134,18 +150,26 @@ pub fn encode_alaw_simd_sse2(samples: &[i16], output: &mut [u8]) {
     unsafe {
         for chunk in chunks.by_ref() {
             // Load 8 samples at once
-            let samples_vec = _mm_loadu_si128(chunk.as_ptr() as *const __m128i);
+            let samples_vec = _mm_loadu_si128(chunk.as_ptr().cast::<__m128i>());
 
             // Process each sample - need to unroll or use different approach
             // _mm_extract_epi16 requires compile-time constant, so we unroll
-            output[out_idx] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 0) as i16);
-            output[out_idx + 1] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 1) as i16);
-            output[out_idx + 2] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 2) as i16);
-            output[out_idx + 3] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 3) as i16);
-            output[out_idx + 4] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 4) as i16);
-            output[out_idx + 5] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 5) as i16);
-            output[out_idx + 6] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 6) as i16);
-            output[out_idx + 7] = linear_to_alaw_scalar(_mm_extract_epi16(samples_vec, 7) as i16);
+            output[out_idx] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 0)));
+            output[out_idx + 1] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 1)));
+            output[out_idx + 2] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 2)));
+            output[out_idx + 3] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 3)));
+            output[out_idx + 4] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 4)));
+            output[out_idx + 5] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 5)));
+            output[out_idx + 6] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 6)));
+            output[out_idx + 7] =
+                linear_to_alaw_scalar(extracted_i16(_mm_extract_epi16(samples_vec, 7)));
             out_idx += 8;
         }
     }
@@ -157,7 +181,7 @@ pub fn encode_alaw_simd_sse2(samples: &[i16], output: &mut [u8]) {
     }
 }
 
-/// SIMD-optimized A-law encoding (AArch64 NEON)
+/// SIMD-optimized A-law encoding (`AArch64` NEON)
 #[cfg(target_arch = "aarch64")]
 pub fn encode_alaw_simd_neon(samples: &[i16], output: &mut [u8]) {
     if !get_simd_support().neon {
@@ -214,7 +238,8 @@ pub fn encode_alaw_optimized(samples: &[i16], output: &mut [u8]) {
 }
 
 /// Scalar μ-law conversion (ITU-T G.711)
-pub fn linear_to_mulaw_scalar(sample: i16) -> u8 {
+#[must_use]
+pub const fn linear_to_mulaw_scalar(sample: i16) -> u8 {
     const CLIP: i16 = 32635;
     const BIAS: i16 = 0x84;
     const MULAW_MAX: u8 = 0x7F;
@@ -236,7 +261,7 @@ pub fn linear_to_mulaw_scalar(sample: i16) -> u8 {
         sample = CLIP;
     }
 
-    sample = sample + BIAS;
+    sample += BIAS;
 
     let exponent = if sample <= 0x1F {
         0
@@ -257,13 +282,14 @@ pub fn linear_to_mulaw_scalar(sample: i16) -> u8 {
     };
 
     let mantissa = (sample >> (exponent + 3)) & 0x0F;
-    let mulaw = ((exponent << 4) | mantissa) as u8;
+    let mulaw = ((exponent << 4) | mantissa).to_le_bytes()[0];
 
     (mulaw ^ MULAW_MAX) | sign
 }
 
 /// Scalar A-law conversion (ITU-T G.711)
-pub fn linear_to_alaw_scalar(sample: i16) -> u8 {
+#[must_use]
+pub const fn linear_to_alaw_scalar(sample: i16) -> u8 {
     const CLIP: i16 = 32635;
     const ALAW_MAX: u8 = 0x7F;
 
@@ -307,11 +333,13 @@ pub fn linear_to_alaw_scalar(sample: i16) -> u8 {
         ((exponent << 4) | mantissa) + 16
     };
 
-    ((alaw as u8) ^ ALAW_MAX) | sign
+    (alaw.to_le_bytes()[0] ^ ALAW_MAX) | sign
 }
 
 /// Scalar μ-law to linear conversion
-pub fn mulaw_to_linear_scalar(mulaw: u8) -> i16 {
+#[must_use]
+#[allow(clippy::cast_lossless)]
+pub const fn mulaw_to_linear_scalar(mulaw: u8) -> i16 {
     const BIAS: i16 = 0x84;
     const MULAW_MAX: u8 = 0x7F;
 
@@ -334,6 +362,7 @@ pub fn mulaw_to_linear_scalar(mulaw: u8) -> i16 {
 }
 
 /// Scalar A-law to linear conversion
+#[must_use]
 pub fn alaw_to_linear_scalar(alaw: u8) -> i16 {
     const ALAW_MAX: u8 = 0x7F;
 
@@ -342,22 +371,22 @@ pub fn alaw_to_linear_scalar(alaw: u8) -> i16 {
     let magnitude = alaw & 0x7F;
 
     let sample = if magnitude < 16 {
-        (magnitude as u16) << 4
+        u16::from(magnitude) << 4
     } else {
         let exponent = (magnitude >> 4) & 0x07;
         let mantissa = magnitude & 0x0F;
 
         // Prevent overflow by clamping shift amounts and using wider types
-        let exp_shift = ((exponent + 3) as u32).min(15);
-        let gain_shift = ((exponent + 2) as u32).min(15);
+        let exp_shift = u32::from(exponent + 3).min(15);
+        let gain_shift = u32::from(exponent + 2).min(15);
 
-        ((mantissa as u16) << exp_shift) + ((1u16) << gain_shift)
+        (u16::from(mantissa) << exp_shift) + (1_u16 << gain_shift)
     } + 8;
 
     if sign != 0 {
-        -(sample as i16)
+        -sample.cast_signed()
     } else {
-        sample as i16
+        sample.cast_signed()
     }
 }
 
@@ -392,7 +421,7 @@ mod tests {
 
         // G.711 is lossy, so we expect some difference
         let error = (original - decoded).abs();
-        assert!(error < 1000, "Error too large: {}", error);
+        assert!(error < 1000, "Error too large: {error}");
     }
 
     #[test]
@@ -407,10 +436,7 @@ mod tests {
         let error = (original - decoded).abs();
         assert!(
             error < 5000,
-            "Error too large: {} (original: {}, decoded: {})",
-            error,
-            original,
-            decoded
+            "Error too large: {error} (original: {original}, decoded: {decoded})"
         );
     }
 

--- a/crates/media/codec-core/src/utils/tables.rs
+++ b/crates/media/codec-core/src/utils/tables.rs
@@ -42,22 +42,26 @@ pub static ALAW_DECODE_TABLE: [i16; 256] = [
 ];
 
 /// Fast μ-law encoding using direct computation
-pub fn encode_mulaw_table(sample: i16) -> u8 {
+#[must_use]
+pub const fn encode_mulaw_table(sample: i16) -> u8 {
     crate::utils::simd::linear_to_mulaw_scalar(sample)
 }
 
 /// Fast μ-law decoding using lookup table
-pub fn decode_mulaw_table(encoded: u8) -> i16 {
+#[must_use]
+pub const fn decode_mulaw_table(encoded: u8) -> i16 {
     MULAW_DECODE_TABLE[encoded as usize]
 }
 
 /// Fast A-law encoding using direct computation
-pub fn encode_alaw_table(sample: i16) -> u8 {
+#[must_use]
+pub const fn encode_alaw_table(sample: i16) -> u8 {
     crate::utils::simd::linear_to_alaw_scalar(sample)
 }
 
 /// Fast A-law decoding using lookup table
-pub fn decode_alaw_table(encoded: u8) -> i16 {
+#[must_use]
+pub const fn decode_alaw_table(encoded: u8) -> i16 {
     ALAW_DECODE_TABLE[encoded as usize]
 }
 
@@ -96,7 +100,8 @@ pub fn init_tables() {
 }
 
 /// Get memory usage of lookup tables
-pub fn get_table_memory_usage() -> usize {
+#[must_use]
+pub const fn get_table_memory_usage() -> usize {
     // Only decode tables:
     // μ-law: 256 * 2 = 512 bytes
     // A-law: 256 * 2 = 512 bytes
@@ -135,8 +140,7 @@ mod tests {
             let scalar_result = crate::utils::simd::mulaw_to_linear_scalar(encoded);
             assert_eq!(
                 table_result, scalar_result,
-                "μ-law decode table mismatch for encoded {}",
-                encoded
+                "μ-law decode table mismatch for encoded {encoded}"
             );
 
             // Test A-law decode
@@ -144,8 +148,7 @@ mod tests {
             let scalar_result = crate::utils::simd::alaw_to_linear_scalar(encoded);
             assert_eq!(
                 table_result, scalar_result,
-                "A-law decode table mismatch for encoded {}",
-                encoded
+                "A-law decode table mismatch for encoded {encoded}"
             );
         }
     }

--- a/crates/media/codec-core/src/utils/validation.rs
+++ b/crates/media/codec-core/src/utils/validation.rs
@@ -4,6 +4,10 @@ use crate::error::{CodecError, Result};
 use crate::types::{CodecType, SampleRate};
 
 /// Validate audio samples for codec processing
+///
+/// # Errors
+///
+/// Returns an error when `samples` is empty.
 pub fn validate_samples(samples: &[i16]) -> Result<()> {
     if samples.is_empty() {
         return Err(CodecError::invalid_format("Input samples cannot be empty"));
@@ -14,6 +18,10 @@ pub fn validate_samples(samples: &[i16]) -> Result<()> {
 }
 
 /// Validate encoded data for codec processing
+///
+/// # Errors
+///
+/// Returns an error when `data` is empty or exceeds the supported size limit.
 pub fn validate_encoded_data(data: &[u8]) -> Result<()> {
     if data.is_empty() {
         return Err(CodecError::invalid_format("Encoded data cannot be empty"));
@@ -31,6 +39,10 @@ pub fn validate_encoded_data(data: &[u8]) -> Result<()> {
 }
 
 /// Validate frame size for a specific codec
+///
+/// # Errors
+///
+/// Returns an error when `frame_size` is unsupported by `codec_type`.
 pub fn validate_frame_size(codec_type: CodecType, frame_size: usize) -> Result<()> {
     let expected_sizes = match codec_type {
         CodecType::G711Pcmu | CodecType::G711Pcma => {
@@ -59,6 +71,10 @@ pub fn validate_frame_size(codec_type: CodecType, frame_size: usize) -> Result<(
 }
 
 /// Validate sample rate for a specific codec
+///
+/// # Errors
+///
+/// Returns an error when `sample_rate` is unsupported by `codec_type`.
 pub fn validate_sample_rate(codec_type: CodecType, sample_rate: SampleRate) -> Result<()> {
     let supported_rates = codec_type.supported_sample_rates();
     let rate_hz = sample_rate.hz();
@@ -74,6 +90,10 @@ pub fn validate_sample_rate(codec_type: CodecType, sample_rate: SampleRate) -> R
 }
 
 /// Validate channel count for a specific codec
+///
+/// # Errors
+///
+/// Returns an error when `channels` is unsupported by `codec_type`.
 pub fn validate_channels(codec_type: CodecType, channels: u8) -> Result<()> {
     let supported_channels = codec_type.supported_channels();
 
@@ -88,7 +108,11 @@ pub fn validate_channels(codec_type: CodecType, channels: u8) -> Result<()> {
 }
 
 /// Validate bitrate for a specific codec
-pub fn validate_bitrate(codec_type: CodecType, bitrate: u32) -> Result<()> {
+///
+/// # Errors
+///
+/// Returns an error when `bitrate` is outside the codec's supported range.
+pub const fn validate_bitrate(codec_type: CodecType, bitrate: u32) -> Result<()> {
     let (min_bitrate, max_bitrate) = codec_type.bitrate_range();
 
     if bitrate < min_bitrate || bitrate > max_bitrate {
@@ -103,6 +127,16 @@ pub fn validate_bitrate(codec_type: CodecType, bitrate: u32) -> Result<()> {
 }
 
 /// Validate buffer sizes for encoding/decoding operations
+///
+/// # Errors
+///
+/// Returns an error when `output_size` is smaller than the size implied by
+/// `input_size` and `expected_ratio`.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
 pub fn validate_buffer_sizes(
     input_size: usize,
     output_size: usize,
@@ -121,8 +155,13 @@ pub fn validate_buffer_sizes(
 }
 
 /// Validate that frame samples are properly aligned for multi-channel audio
+///
+/// # Errors
+///
+/// Returns an error when the sample count is not divisible by `channels`.
+#[allow(clippy::manual_is_multiple_of)]
 pub fn validate_channel_alignment(samples: &[i16], channels: u8) -> Result<()> {
-    if samples.len() % channels as usize != 0 {
+    if samples.len() % usize::from(channels) != 0 {
         return Err(CodecError::invalid_format(format!(
             "Sample count {} not divisible by channel count {}",
             samples.len(),
@@ -134,6 +173,10 @@ pub fn validate_channel_alignment(samples: &[i16], channels: u8) -> Result<()> {
 }
 
 /// Validate G.711 specific parameters
+///
+/// # Errors
+///
+/// Returns an error when the frame is empty or has the wrong sample count.
 pub fn validate_g711_frame(samples: &[i16], expected_frame_size: usize) -> Result<()> {
     validate_samples(samples)?;
 
@@ -148,6 +191,11 @@ pub fn validate_g711_frame(samples: &[i16], expected_frame_size: usize) -> Resul
 }
 
 /// Validate G.722 specific parameters
+///
+/// # Errors
+///
+/// Returns an error when the frame is empty, has the wrong sample count, or
+/// contains an odd number of samples.
 pub fn validate_g722_frame(samples: &[i16], expected_frame_size: usize) -> Result<()> {
     validate_samples(samples)?;
 
@@ -159,7 +207,7 @@ pub fn validate_g722_frame(samples: &[i16], expected_frame_size: usize) -> Resul
     }
 
     // G.722 requires even number of samples for QMF processing
-    if samples.len() % 2 != 0 {
+    if !samples.len().is_multiple_of(2) {
         return Err(CodecError::invalid_format(
             "G.722 requires even number of samples for QMF processing",
         ));
@@ -169,6 +217,10 @@ pub fn validate_g722_frame(samples: &[i16], expected_frame_size: usize) -> Resul
 }
 
 /// Validate G.729 specific parameters
+///
+/// # Errors
+///
+/// Returns an error when the frame is empty or does not contain 80 samples.
 pub fn validate_g729_frame(samples: &[i16]) -> Result<()> {
     validate_samples(samples)?;
 
@@ -184,6 +236,11 @@ pub fn validate_g729_frame(samples: &[i16]) -> Result<()> {
 }
 
 /// Validate Opus specific parameters
+///
+/// # Errors
+///
+/// Returns an error when the frame is empty, its sample rate is unsupported,
+/// or its sample count is invalid for the selected rate.
 pub fn validate_opus_frame(samples: &[i16], sample_rate: SampleRate) -> Result<()> {
     validate_samples(samples)?;
 
@@ -201,7 +258,7 @@ pub fn validate_opus_frame(samples: &[i16], sample_rate: SampleRate) -> Result<(
             return Err(CodecError::InvalidSampleRate {
                 rate: rate_hz,
                 supported: vec![8000, 12000, 16000, 24000, 48000],
-            })
+            });
         }
     };
 
@@ -216,6 +273,16 @@ pub fn validate_opus_frame(samples: &[i16], sample_rate: SampleRate) -> Result<(
 }
 
 /// Validate that two buffers have compatible sizes for processing
+///
+/// # Errors
+///
+/// Returns an error when `output` is smaller than the size implied by the
+/// input length and `compression_ratio`.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
 pub fn validate_buffer_compatibility(
     input: &[i16],
     output: &[u8],
@@ -234,11 +301,16 @@ pub fn validate_buffer_compatibility(
 }
 
 /// Validate memory alignment for SIMD operations
+///
+/// # Errors
+///
+/// This check currently reports misalignment through tracing and always
+/// succeeds; the result type is retained for API compatibility.
 pub fn validate_simd_alignment(data: &[i16]) -> Result<()> {
     let ptr = data.as_ptr() as usize;
 
     // Check for 16-byte alignment (required for SSE)
-    if ptr % 16 != 0 {
+    if !ptr.is_multiple_of(16) {
         tracing::debug!("Data not aligned for SIMD operations, falling back to scalar");
     }
 
@@ -308,12 +380,12 @@ mod tests {
     #[test]
     fn test_validate_bitrate() {
         // G.711 has fixed bitrate
-        assert!(validate_bitrate(CodecType::G711Pcmu, 64000).is_ok());
-        assert!(validate_bitrate(CodecType::G711Pcmu, 128000).is_err());
+        assert!(validate_bitrate(CodecType::G711Pcmu, 64_000).is_ok());
+        assert!(validate_bitrate(CodecType::G711Pcmu, 128_000).is_err());
 
         // Opus has variable bitrate
-        assert!(validate_bitrate(CodecType::Opus, 32000).is_ok());
-        assert!(validate_bitrate(CodecType::Opus, 600000).is_err());
+        assert!(validate_bitrate(CodecType::Opus, 32_000).is_ok());
+        assert!(validate_bitrate(CodecType::Opus, 600_000).is_err());
     }
 
     #[test]

--- a/crates/media/media-core/Cargo.toml
+++ b/crates/media/media-core/Cargo.toml
@@ -94,7 +94,7 @@ g729 = ["rvoip-codec-core/g729"]
 opus = ["rvoip-codec-core/opus"]
 # Deprecated compatibility alias. It enables the real Opus backend.
 opus-sim = ["opus"]
-all-codecs = ["pcmu", "pcma", "g722", "g729", "opus"]
+all-codecs = ["pcmu", "pcma", "g729", "opus"]
 
 [dev-dependencies]
 serial_test = "3.0"

--- a/crates/media/media-core/Cargo.toml
+++ b/crates/media/media-core/Cargo.toml
@@ -71,9 +71,8 @@ num-complex = "0.4"          # Used in AEC v2 implementation
 apodize = "1.0"              # Used in VAD v2 for windowing functions
 biquad = "0.4"               # Used in AGC v2 for digital filters
 
-# Media codecs (optional)
-opus = { version = "0.3", optional = true }
-# g729 = { version = "0.3", optional = true }  # Commented out due to missing dependency
+# Media codecs are implemented by codec-core. media-core only provides the
+# media-frame adapter and negotiation/capability plumbing.
 
 # WAV file support
 hound = "3.5"
@@ -82,6 +81,9 @@ hound = "3.5"
 default = ["pcmu", "pcma"]
 pcmu = []
 pcma = []
+# Compatibility feature retained for callers that previously enabled it.
+# G.722 payload formatting remains available, but no encoder/decoder is
+# advertised or constructed.
 g722 = []
 memory-diagnostics = [
     "rvoip-infra-common/memory-diagnostics",
@@ -89,7 +91,9 @@ memory-diagnostics = [
 rtp-memory-diagnostics = ["rvoip-rtp-core/memory-diagnostics"]
 perf-diagnostics = []
 g729 = ["rvoip-codec-core/g729"]
-opus = ["dep:opus"]
+opus = ["rvoip-codec-core/opus"]
+# Deprecated compatibility alias. It enables the real Opus backend.
+opus-sim = ["opus"]
 all-codecs = ["pcmu", "pcma", "g722", "g729", "opus"]
 
 [dev-dependencies]

--- a/crates/media/media-core/README.md
+++ b/crates/media/media-core/README.md
@@ -115,12 +115,13 @@ Clean separation of concerns across the rvoip stack:
   - ✅ 8-sample parallel processing for audio operations
 
 #### **Codec Support and Transcoding**
-- ✅ **Multi-Codec Support**: Wired beta codecs plus optional G.729A/G.729AB
+- ✅ **Multi-Codec Support**: G.711 plus feature-gated G.729A/G.729AB and Opus
   - ✅ **G.711**: μ-law/A-law (PCMU/PCMA) with ITU-T compliance
   - ✅ **G.729A/G.729AB**: optional low-bitrate 8 kbps codec with Annex B VAD/DTX/CNG under the `g729` feature
-  - 🔮 **Opus/G.722**: post-beta full-media paths
+  - ✅ **Opus**: real libopus-backed encode/decode under the `opus` feature
+  - ⛔ **G.722**: RTP payload metadata only; encoder/decoder construction and negotiation are rejected
 - ✅ **Real-Time Transcoding**: Seamless format conversion
-  - ✅ PCMU ↔ PCMA and optional G.729A/G.729AB transcoding paths
+  - ✅ PCMU ↔ PCMA plus feature-gated G.729A/G.729AB and Opus paths
   - ✅ Session management with performance statistics
   - ✅ Format conversion with sample rate adaptation
 
@@ -474,11 +475,12 @@ The library provides cutting-edge audio processing algorithms competitive with c
 
 - **G.711 (PCMU/PCMA)**: ITU-T compliant μ-law/A-law implementation
 - **G.729A/G.729AB**: Optional low-bitrate 8 kbps codec with Annex B VAD/DTX/CNG
-- **Opus/G.722**: Post-beta full-media paths
+- **Opus**: Optional real libopus-backed codec
+- **G.722**: Unsupported as a working codec; low-level RTP payload handling remains available
 
 ### Transcoding Capabilities
 
-- **Real-Time Transcoding**: PCMU/PCMA and optional G.729A/G.729AB paths
+- **Real-Time Transcoding**: PCMU/PCMA and feature-gated G.729A/G.729AB and Opus paths
 - **Format Conversion**: Automatic sample rate and channel conversion
 - **Session Management**: Performance statistics and caching
 - **Quality Preservation**: Optimal transcoding paths to minimize quality loss

--- a/crates/media/media-core/src/api/types.rs
+++ b/crates/media/media-core/src/api/types.rs
@@ -121,18 +121,25 @@ impl MediaCodec {
     /// Check if this is an audio codec
     pub fn is_audio(&self) -> bool {
         matches!(
-            self.name.as_str(),
-            "PCMU" | "PCMA" | "G722" | "G729" | "opus" | "AMR" | "AMR-WB"
+            normalize_codec_name(&self.name).as_str(),
+            "PCMU" | "PCMA" | "G722" | "G729" | "OPUS" | "AMR" | "AMR-WB"
         )
     }
 
     /// Check if this is a video codec
     pub fn is_video(&self) -> bool {
         matches!(
-            self.name.as_str(),
-            "H264" | "H.264" | "H265" | "H.265" | "VP8" | "VP9" | "AV1"
+            normalize_codec_name(&self.name).as_str(),
+            "H264" | "H265" | "VP8" | "VP9" | "AV1"
         )
     }
+}
+
+fn normalize_codec_name(name: &str) -> String {
+    name.chars()
+        .filter(|character| *character != '.')
+        .map(|character| character.to_ascii_uppercase())
+        .collect()
 }
 
 /// Media stream direction
@@ -188,5 +195,26 @@ impl MediaStreamConfig {
     pub fn with_preferred_codec(mut self, codec: String) -> Self {
         self.preferred_codec = Some(codec);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn codec(name: &str) -> MediaCodec {
+        MediaCodec::new(name.to_string(), 96, 90_000)
+    }
+
+    #[test]
+    fn codec_media_classification_is_ascii_case_insensitive() {
+        for name in ["opus", "Opus", "OPUS", "pcmu", "PcMa", "g722"] {
+            assert!(codec(name).is_audio(), "{name} should be audio");
+        }
+        for name in ["h264", "H264", "H.264", "h.264", "Vp8", "AV1"] {
+            assert!(codec(name).is_video(), "{name} should be video");
+        }
+        assert!(!codec("not-a-codec").is_audio());
+        assert!(!codec("not-a-codec").is_video());
     }
 }

--- a/crates/media/media-core/src/codec/audio/opus.rs
+++ b/crates/media/media-core/src/codec/audio/opus.rs
@@ -1,203 +1,181 @@
-//! Opus Audio Codec Implementation
+//! Opus audio codec adapter.
 //!
-//! This module implements the Opus codec, a modern low-latency audio codec
-//! optimized for VoIP applications with excellent quality and adaptability.
+//! The actual encoder and decoder live in `rvoip-codec-core`. This module only
+//! converts between media-core frames and codec-core's PCM-oriented API.
 
 use super::common::{AudioCodec, CodecInfo};
 use crate::error::{CodecError, Result};
 use crate::types::{AudioFrame, SampleRate};
+#[cfg(feature = "opus")]
+use codec_core::codecs::opus::OpusCodec as CodecCoreOpus;
+#[cfg(feature = "opus")]
+use codec_core::types::{
+    AudioCodec as CodecCoreAudioCodec, CodecConfig as CodecCoreConfig, CodecType as CodecCoreType,
+    OpusApplication as CodecCoreApplication, SampleRate as CodecCoreSampleRate,
+};
+#[cfg(feature = "opus")]
 use tracing::debug;
-#[cfg(not(feature = "opus"))]
-use tracing::warn;
-/// Opus codec configuration
+
+/// Opus codec configuration.
 #[derive(Debug, Clone)]
 pub struct OpusConfig {
-    /// Target bitrate (6000-510000 bps)
+    /// Target bitrate (6000-510000 bps).
     pub bitrate: u32,
-    /// Encoding complexity (0-10, higher = better quality/more CPU)
+    /// Encoding complexity (0-10, higher is better quality/more CPU).
     pub complexity: u32,
-    /// Use variable bitrate
+    /// Use variable bitrate.
     pub vbr: bool,
-    /// Application type
+    /// Application type.
     pub application: OpusApplication,
-    /// Frame size in milliseconds (2.5, 5, 10, 20, 40, 60)
+    /// Frame size in milliseconds (2.5, 5, 10, 20, 40, or 60).
     pub frame_size_ms: f32,
 }
 
-/// Opus application types
+/// Opus application types.
 #[derive(Debug, Clone, Copy)]
 pub enum OpusApplication {
-    /// Voice over IP
+    /// Voice over IP.
     Voip,
-    /// Audio streaming
+    /// General audio streaming.
     Audio,
 }
 
 impl Default for OpusConfig {
     fn default() -> Self {
         Self {
-            bitrate: 64000, // 64 kbps - good quality for VoIP
-            complexity: 5,  // Balanced complexity
-            vbr: true,      // Variable bitrate for efficiency
+            bitrate: 64_000,
+            complexity: 5,
+            vbr: true,
             application: OpusApplication::Voip,
-            frame_size_ms: 20.0, // 20ms frames (standard for VoIP)
+            frame_size_ms: 20.0,
         }
     }
 }
 
-/// Opus audio codec implementation
+/// Media-core adapter for codec-core's real libopus implementation.
 pub struct OpusCodec {
-    /// Codec configuration
     config: OpusConfig,
-    /// Sample rate
     sample_rate: u32,
-    /// Number of channels
     channels: u8,
-    /// Opus encoder (when available)
     #[cfg(feature = "opus")]
-    encoder: Option<opus::Encoder>,
-    /// Opus decoder (when available)
-    #[cfg(feature = "opus")]
-    decoder: Option<opus::Decoder>,
-    /// Frame size in samples. Captured at construction so the encode
-    /// path can resize buffers without recomputing; the current
-    /// implementation derives the size from the input frame instead.
-    #[allow(dead_code)]
     frame_size: usize,
+    #[cfg(feature = "opus")]
+    inner: CodecCoreOpus,
 }
 
 impl OpusCodec {
-    /// Create a new Opus codec
+    /// Create a new Opus codec.
+    ///
+    /// Construction fails when the `opus` feature is disabled. This prevents
+    /// callers from mistaking a placeholder object for a working codec.
     pub fn new(sample_rate: SampleRate, channels: u8, config: OpusConfig) -> Result<Self> {
         let sample_rate_hz = sample_rate.as_hz();
-
-        // Validate parameters
         if channels == 0 || channels > 2 {
             return Err(CodecError::InvalidParameters {
-                details: format!("Invalid channel count: {}", channels),
+                details: format!("Invalid Opus channel count: {channels}"),
             }
             .into());
         }
-
-        // Validate sample rate (Opus supports 8, 12, 16, 24, 48 kHz)
-        if !matches!(sample_rate_hz, 8000 | 12000 | 16000 | 24000 | 48000) {
+        if !matches!(sample_rate_hz, 8_000 | 12_000 | 16_000 | 24_000 | 48_000) {
             return Err(CodecError::InvalidParameters {
-                details: format!("Invalid sample rate: {}", sample_rate_hz),
+                details: format!("Invalid Opus sample rate: {sample_rate_hz}"),
+            }
+            .into());
+        }
+        if !(6_000..=510_000).contains(&config.bitrate) {
+            return Err(CodecError::InvalidParameters {
+                details: format!("Invalid Opus bitrate: {}", config.bitrate),
+            }
+            .into());
+        }
+        if config.complexity > 10 {
+            return Err(CodecError::InvalidParameters {
+                details: format!("Invalid Opus complexity: {}", config.complexity),
+            }
+            .into());
+        }
+        if !matches!(config.frame_size_ms, 2.5 | 5.0 | 10.0 | 20.0 | 40.0 | 60.0) {
+            return Err(CodecError::InvalidParameters {
+                details: format!("Invalid Opus frame duration: {}ms", config.frame_size_ms),
             }
             .into());
         }
 
-        // Calculate frame size
-        let frame_size =
-            ((sample_rate_hz as f32 * config.frame_size_ms / 1000.0) as usize) * channels as usize;
+        #[cfg(not(feature = "opus"))]
+        {
+            let _ = (sample_rate_hz, channels, config);
+            return Err(CodecError::NotFound {
+                name: "Opus (enable the `opus` feature)".to_string(),
+            }
+            .into());
+        }
 
-        debug!(
-            "Creating Opus codec: {}Hz, {}ch, {}ms frames",
-            sample_rate_hz, channels, config.frame_size_ms
-        );
-
-        Ok(Self {
-            config,
-            sample_rate: sample_rate_hz,
-            channels,
-            #[cfg(feature = "opus")]
-            encoder: None,
-            #[cfg(feature = "opus")]
-            decoder: None,
-            frame_size,
-        })
-    }
-
-    /// Initialize encoder
-    #[cfg(feature = "opus")]
-    fn ensure_encoder(&mut self) -> Result<()> {
-        if self.encoder.is_none() {
-            let app = match self.config.application {
-                OpusApplication::Voip => opus::Application::Voip,
-                OpusApplication::Audio => opus::Application::Audio,
+        #[cfg(feature = "opus")]
+        {
+            let core_sample_rate = CodecCoreSampleRate::from_hz(sample_rate_hz);
+            let core_application = match config.application {
+                OpusApplication::Voip => CodecCoreApplication::Voip,
+                OpusApplication::Audio => CodecCoreApplication::Audio,
             };
+            let mut core_config = CodecCoreConfig::new(CodecCoreType::Opus)
+                .with_sample_rate(core_sample_rate)
+                .with_channels(channels)
+                .with_bitrate(config.bitrate)
+                .with_frame_size_ms(config.frame_size_ms)
+                .with_opus_application(core_application)
+                .with_opus_vbr(config.vbr)
+                .with_opus_complexity(config.complexity as u8);
+            core_config.parameters.opus.bitrate = config.bitrate;
 
-            let mut encoder = opus::Encoder::new(
-                self.sample_rate,
-                match self.channels {
-                    1 => opus::Channels::Mono,
-                    2 => opus::Channels::Stereo,
-                    _ => {
-                        return Err(CodecError::InitializationFailed {
-                            reason: "Unsupported channel count".to_string(),
-                        }
-                        .into())
-                    }
-                },
-                app,
-            )
-            .map_err(|e| CodecError::InitializationFailed {
-                reason: format!("Opus encoder creation failed: {:?}", e),
+            let inner = CodecCoreOpus::new(core_config).map_err(|error| {
+                CodecError::InitializationFailed {
+                    reason: format!("codec-core Opus initialization failed: {error}"),
+                }
             })?;
+            let frame_size = (sample_rate_hz as f32 * config.frame_size_ms / 1_000.0) as usize
+                * usize::from(channels);
 
-            // Configure encoder
-            encoder
-                .set_bitrate(opus::Bitrate::Bits(self.config.bitrate as i32))
-                .map_err(|e| CodecError::InitializationFailed {
-                    reason: format!("Failed to set bitrate: {:?}", e),
-                })?;
-
-            encoder
-                .set_vbr(self.config.vbr)
-                .map_err(|e| CodecError::InitializationFailed {
-                    reason: format!("Failed to set VBR: {:?}", e),
-                })?;
-
-            // Note: complexity setting not available in this opus crate version
-            // The complexity value is used as a hint but not directly configurable
-
-            self.encoder = Some(encoder);
-            debug!("Opus encoder initialized");
+            debug!(
+                "Creating codec-core Opus adapter: {}Hz, {}ch, {}ms frames",
+                sample_rate_hz, channels, config.frame_size_ms
+            );
+            Ok(Self {
+                config,
+                sample_rate: sample_rate_hz,
+                channels,
+                frame_size,
+                inner,
+            })
         }
-
-        Ok(())
-    }
-
-    /// Initialize decoder
-    #[cfg(feature = "opus")]
-    fn ensure_decoder(&mut self) -> Result<()> {
-        if self.decoder.is_none() {
-            let decoder = opus::Decoder::new(
-                self.sample_rate,
-                match self.channels {
-                    1 => opus::Channels::Mono,
-                    2 => opus::Channels::Stereo,
-                    _ => {
-                        return Err(CodecError::InitializationFailed {
-                            reason: "Unsupported channel count".to_string(),
-                        }
-                        .into())
-                    }
-                },
-            )
-            .map_err(|e| CodecError::InitializationFailed {
-                reason: format!("Opus decoder creation failed: {:?}", e),
-            })?;
-
-            self.decoder = Some(decoder);
-            debug!("Opus decoder initialized");
-        }
-
-        Ok(())
     }
 }
 
-// `audio_frame` / `encoded_data` parameters are consumed by the
-// `#[cfg(feature = "opus")]` arms and dropped in the
-// `#[cfg(not(feature = "opus"))]` stub arms; allow the unused
-// bindings since they're only "unused" with opus disabled.
-#[allow(unused_variables)]
 impl AudioCodec for OpusCodec {
     fn encode(&mut self, audio_frame: &AudioFrame) -> Result<Vec<u8>> {
+        #[cfg(not(feature = "opus"))]
+        {
+            let _ = audio_frame;
+            Err(CodecError::NotFound {
+                name: "Opus (enable the `opus` feature)".to_string(),
+            }
+            .into())
+        }
+
         #[cfg(feature = "opus")]
         {
-            self.ensure_encoder()?;
-
+            if audio_frame.sample_rate != self.sample_rate || audio_frame.channels != self.channels
+            {
+                return Err(CodecError::InvalidParameters {
+                    details: format!(
+                        "Opus frame format is {}Hz/{}ch, expected {}Hz/{}ch",
+                        audio_frame.sample_rate,
+                        audio_frame.channels,
+                        self.sample_rate,
+                        self.channels
+                    ),
+                }
+                .into());
+            }
             if audio_frame.samples.len() != self.frame_size {
                 return Err(CodecError::InvalidFrameSize {
                     expected: self.frame_size,
@@ -205,62 +183,40 @@ impl AudioCodec for OpusCodec {
                 }
                 .into());
             }
-
-            let encoder = self.encoder.as_mut().unwrap();
-            let mut output = vec![0u8; 4000]; // Max Opus packet size
-
-            let encoded_size = encoder
-                .encode(&audio_frame.samples, &mut output)
-                .map_err(|e| CodecError::EncodingFailed {
-                    reason: format!("Opus encoding failed: {:?}", e),
-                })?;
-
-            output.truncate(encoded_size);
-            Ok(output)
-        }
-
-        #[cfg(not(feature = "opus"))]
-        {
-            warn!("Opus codec not available - feature 'opus' not enabled");
-            Err(CodecError::NotFound {
-                name: "Opus".to_string(),
-            }
-            .into())
+            self.inner.encode(&audio_frame.samples).map_err(|error| {
+                CodecError::EncodingFailed {
+                    reason: format!("codec-core Opus encoding failed: {error}"),
+                }
+                .into()
+            })
         }
     }
 
     fn decode(&mut self, encoded_data: &[u8]) -> Result<AudioFrame> {
-        #[cfg(feature = "opus")]
-        {
-            self.ensure_decoder()?;
-
-            let decoder = self.decoder.as_mut().unwrap();
-            let mut output = vec![0i16; self.frame_size];
-
-            let decoded_samples =
-                decoder
-                    .decode(encoded_data, &mut output, false)
-                    .map_err(|e| CodecError::DecodingFailed {
-                        reason: format!("Opus decoding failed: {:?}", e),
-                    })?;
-
-            output.truncate(decoded_samples * self.channels as usize);
-
-            Ok(AudioFrame::new(
-                output,
-                self.sample_rate,
-                self.channels,
-                0, // Timestamp to be set by caller
-            ))
-        }
-
         #[cfg(not(feature = "opus"))]
         {
-            warn!("Opus codec not available - feature 'opus' not enabled");
+            let _ = encoded_data;
             Err(CodecError::NotFound {
-                name: "Opus".to_string(),
+                name: "Opus (enable the `opus` feature)".to_string(),
             }
             .into())
+        }
+
+        #[cfg(feature = "opus")]
+        {
+            if encoded_data.is_empty() {
+                return Err(CodecError::DecodingFailed {
+                    reason: "empty Opus packet".to_string(),
+                }
+                .into());
+            }
+            let samples =
+                self.inner
+                    .decode(encoded_data)
+                    .map_err(|error| CodecError::DecodingFailed {
+                        reason: format!("codec-core Opus decoding failed: {error}"),
+                    })?;
+            Ok(AudioFrame::new(samples, self.sample_rate, self.channels, 0))
         }
     }
 
@@ -275,14 +231,59 @@ impl AudioCodec for OpusCodec {
 
     fn reset(&mut self) {
         #[cfg(feature = "opus")]
-        {
-            if let Some(encoder) = &mut self.encoder {
-                let _ = encoder.reset_state();
-            }
-            if let Some(decoder) = &mut self.decoder {
-                let _ = decoder.reset_state();
-            }
+        if let Err(error) = self.inner.reset() {
+            tracing::warn!("codec-core Opus reset failed: {error}");
         }
-        debug!("Opus codec reset");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "opus")]
+    #[test]
+    fn real_opus_round_trip_uses_codec_core() {
+        let mut codec = OpusCodec::new(SampleRate::Rate48000, 1, OpusConfig::default()).unwrap();
+        let samples: Vec<i16> = (0..960)
+            .map(|index| {
+                let t = index as f32 / 48_000.0;
+                (12_000.0 * (2.0 * std::f32::consts::PI * 440.0 * t).sin()) as i16
+            })
+            .collect();
+        let encoded = codec
+            .encode(&AudioFrame::new(samples, 48_000, 1, 0))
+            .unwrap();
+        assert!(!encoded.is_empty());
+        assert_ne!(
+            encoded,
+            (0..encoded.len()).map(|i| i as u8).collect::<Vec<_>>()
+        );
+
+        let decoded = codec.decode(&encoded).unwrap();
+        assert_eq!(decoded.samples.len(), 960);
+        assert!(decoded.samples.iter().any(|sample| *sample != 0));
+    }
+
+    #[cfg(not(feature = "opus"))]
+    #[test]
+    fn opus_construction_fails_without_feature() {
+        assert!(matches!(
+            OpusCodec::new(SampleRate::Rate48000, 1, OpusConfig::default()),
+            Err(crate::error::Error::Codec(CodecError::NotFound { .. }))
+        ));
+    }
+
+    #[cfg(feature = "opus-sim")]
+    #[test]
+    fn deprecated_opus_sim_alias_constructs_the_real_backend() {
+        let mut codec = OpusCodec::new(SampleRate::Rate48000, 1, OpusConfig::default()).unwrap();
+        let samples = vec![0; 960];
+        let packet = codec
+            .encode(&AudioFrame::new(samples, 48_000, 1, 0))
+            .unwrap();
+
+        assert!(!packet.is_empty());
+        assert_eq!(codec.decode(&packet).unwrap().samples.len(), 960);
     }
 }

--- a/crates/media/media-core/src/codec/audio/opus.rs
+++ b/crates/media/media-core/src/codec/audio/opus.rs
@@ -104,7 +104,7 @@ impl OpusCodec {
         #[cfg(not(feature = "opus"))]
         {
             let _ = (sample_rate_hz, channels, config);
-            return Err(CodecError::NotFound {
+            return Err(CodecError::UnsupportedCodec {
                 name: "Opus (enable the `opus` feature)".to_string(),
             }
             .into());
@@ -155,7 +155,7 @@ impl AudioCodec for OpusCodec {
         #[cfg(not(feature = "opus"))]
         {
             let _ = audio_frame;
-            Err(CodecError::NotFound {
+            Err(CodecError::UnsupportedCodec {
                 name: "Opus (enable the `opus` feature)".to_string(),
             }
             .into())
@@ -196,7 +196,7 @@ impl AudioCodec for OpusCodec {
         #[cfg(not(feature = "opus"))]
         {
             let _ = encoded_data;
-            Err(CodecError::NotFound {
+            Err(CodecError::UnsupportedCodec {
                 name: "Opus (enable the `opus` feature)".to_string(),
             }
             .into())
@@ -270,7 +270,9 @@ mod tests {
     fn opus_construction_fails_without_feature() {
         assert!(matches!(
             OpusCodec::new(SampleRate::Rate48000, 1, OpusConfig::default()),
-            Err(crate::error::Error::Codec(CodecError::NotFound { .. }))
+            Err(crate::error::Error::Codec(
+                CodecError::UnsupportedCodec { .. }
+            ))
         ));
     }
 

--- a/crates/media/media-core/src/codec/factory.rs
+++ b/crates/media/media-core/src/codec/factory.rs
@@ -61,13 +61,11 @@ impl CodecFactory {
             }
             // G.722 RTP payload handling remains available, but there is no
             // encoder/decoder implementation to construct.
-            9 => Err(Error::Codec(crate::error::CodecError::NotFound {
-                name: "G.722 encoder/decoder is not implemented".to_string(),
-            })),
+            9 => Err(Error::unsupported_codec(
+                "G.722 (encoder/decoder is not implemented)",
+            )),
             #[cfg(not(feature = "opus"))]
-            111 => Err(Error::Codec(crate::error::CodecError::NotFound {
-                name: "Opus (enable the `opus` feature)".to_string(),
-            })),
+            111 => Err(Error::unsupported_codec("Opus (enable the `opus` feature)")),
             PCM_S16LE => Ok(Box::new(PcmS16LeCodec::new(
                 sample_rate,
                 u8::try_from(channels).map_err(|_| {

--- a/crates/media/media-core/src/codec/factory.rs
+++ b/crates/media/media-core/src/codec/factory.rs
@@ -7,10 +7,12 @@ use crate::codec::audio::common::AudioCodec;
 use crate::codec::audio::g711::G711Codec;
 #[cfg(feature = "g729")]
 use crate::codec::audio::g729::{G729Codec, G729Config};
+#[cfg(feature = "opus")]
+use crate::codec::audio::opus::{OpusCodec, OpusConfig};
 use crate::codec::audio::payload_type::PCM_S16LE;
 use crate::codec::audio::pcm::PcmS16LeCodec;
 use crate::error::{Error, Result};
-#[cfg(feature = "g729")]
+#[cfg(any(feature = "g729", feature = "opus"))]
 use crate::types::SampleRate;
 
 pub struct CodecFactory;
@@ -23,12 +25,12 @@ impl CodecFactory {
         channels: Option<u16>,
     ) -> Result<Box<dyn AudioCodec>> {
         // Default values if not specified
-        let sample_rate = sample_rate.unwrap_or(if payload_type == PCM_S16LE {
-            16_000
-        } else {
-            8_000
+        let sample_rate = sample_rate.unwrap_or(match payload_type {
+            PCM_S16LE => 16_000,
+            111 => 48_000,
+            _ => 8_000,
         });
-        let channels = channels.unwrap_or(1);
+        let channels = channels.unwrap_or(if payload_type == 111 { 2 } else { 1 });
 
         match payload_type {
             0 => Ok(Box::new(G711Codec::mu_law(sample_rate, channels)?)),
@@ -39,6 +41,33 @@ impl CodecFactory {
                 1,
                 G729Config::default(),
             )?)),
+            #[cfg(feature = "opus")]
+            111 => {
+                let sample_rate = SampleRate::from_hz(sample_rate).ok_or_else(|| {
+                    Error::Codec(crate::error::CodecError::InvalidParameters {
+                        details: format!("Invalid Opus sample rate: {sample_rate}"),
+                    })
+                })?;
+                let channels = u8::try_from(channels).map_err(|_| {
+                    Error::Codec(crate::error::CodecError::InvalidParameters {
+                        details: format!("Invalid channel count: {channels}"),
+                    })
+                })?;
+                Ok(Box::new(OpusCodec::new(
+                    sample_rate,
+                    channels,
+                    OpusConfig::default(),
+                )?))
+            }
+            // G.722 RTP payload handling remains available, but there is no
+            // encoder/decoder implementation to construct.
+            9 => Err(Error::Codec(crate::error::CodecError::NotFound {
+                name: "G.722 encoder/decoder is not implemented".to_string(),
+            })),
+            #[cfg(not(feature = "opus"))]
+            111 => Err(Error::Codec(crate::error::CodecError::NotFound {
+                name: "Opus (enable the `opus` feature)".to_string(),
+            })),
             PCM_S16LE => Ok(Box::new(PcmS16LeCodec::new(
                 sample_rate,
                 u8::try_from(channels).map_err(|_| {
@@ -94,6 +123,31 @@ mod tests {
         assert!(result.is_err());
         // Can't unwrap error because AudioCodec doesn't implement Debug
         // Just verify that creating codec with unsupported type fails
+    }
+
+    #[test]
+    fn test_g722_codec_is_explicitly_unsupported() {
+        let error = CodecFactory::create_codec_default(9).err().unwrap();
+        assert!(error.to_string().contains("G.722"));
+        assert!(error.to_string().contains("not implemented"));
+    }
+
+    #[cfg(feature = "opus")]
+    #[test]
+    fn test_real_opus_codec_is_constructible_with_feature() {
+        let codec = CodecFactory::create_codec_default(111).unwrap();
+        let info = codec.get_info();
+        assert_eq!(info.sample_rate, 48_000);
+        assert_eq!(info.channels, 2);
+    }
+
+    #[cfg(not(feature = "opus"))]
+    #[test]
+    fn test_opus_codec_is_unavailable_without_feature() {
+        let error = CodecFactory::create_codec(111, Some(48_000), Some(1))
+            .err()
+            .unwrap();
+        assert!(error.to_string().contains("enable the `opus` feature"));
     }
 
     #[test]

--- a/crates/media/media-core/src/codec/mapping.rs
+++ b/crates/media/media-core/src/codec/mapping.rs
@@ -65,26 +65,28 @@ impl OpusConfig {
 
     /// Parse codec string back to OpusConfig
     pub fn from_codec_string(codec_str: &str) -> Option<Self> {
-        if !codec_str.starts_with("opus@") {
+        let mut parts = codec_str.split('@');
+        if !parts.next()?.eq_ignore_ascii_case("opus") {
             return None;
         }
 
         let mut config = Self::new(48000, 1); // Default values
 
-        for part in codec_str.split('@').skip(1) {
-            if part.ends_with("Hz") {
-                if let Ok(rate) = part.trim_end_matches("Hz").parse::<u32>() {
+        for part in parts {
+            let lower = part.to_ascii_lowercase();
+            if lower.ends_with("hz") {
+                if let Ok(rate) = part[..part.len() - 2].parse::<u32>() {
                     config.sample_rate = rate;
                 }
-            } else if part.ends_with("ch") {
-                if let Ok(channels) = part.trim_end_matches("ch").parse::<u8>() {
+            } else if lower.ends_with("ch") {
+                if let Ok(channels) = part[..part.len() - 2].parse::<u8>() {
                     config.channels = channels;
                 }
-            } else if part.ends_with("bps") {
-                if let Ok(bitrate) = part.trim_end_matches("bps").parse::<u32>() {
+            } else if lower.ends_with("bps") {
+                if let Ok(bitrate) = part[..part.len() - 3].parse::<u32>() {
                     config.max_bitrate = Some(bitrate);
                 }
-            } else if part == "fec" {
+            } else if part.eq_ignore_ascii_case("fec") {
                 config.fec_enabled = Some(true);
             }
         }
@@ -195,7 +197,7 @@ impl CodecMapper {
         if let Some(old_payload) = self.name_to_payload.get(&name).cloned() {
             self.payload_to_name.remove(&old_payload);
             // Remove from Opus configs if it was an Opus codec
-            if name.starts_with("opus") {
+            if name.to_ascii_lowercase().starts_with("opus") {
                 self.opus_configs.remove(&old_payload);
             }
         }
@@ -203,7 +205,7 @@ impl CodecMapper {
             self.name_to_payload.remove(&old_name);
             self.codec_clock_rates.remove(&old_name);
             // Remove from Opus configs if it was an Opus codec
-            if old_name.starts_with("opus") {
+            if old_name.to_ascii_lowercase().starts_with("opus") {
                 if let Some(config) = self.opus_configs.remove(&payload_type) {
                     self.opus_config_to_payload.remove(&config);
                 }
@@ -303,7 +305,10 @@ impl CodecMapper {
             if codec_name.eq_ignore_ascii_case("opus") {
                 // Look for any registered Opus configuration
                 for (name, payload) in &self.name_to_payload {
-                    if name.starts_with("opus@") {
+                    if name
+                        .get(..5)
+                        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("opus@"))
+                    {
                         debug!("Found generic opus match: {} -> PT:{}", name, payload);
                         return Some(*payload);
                     }
@@ -349,7 +354,10 @@ impl CodecMapper {
         if codec_name.eq_ignore_ascii_case("opus") {
             // Look for any registered Opus configuration
             for (name, &clock_rate) in &self.codec_clock_rates {
-                if name.starts_with("opus@") {
+                if name
+                    .get(..5)
+                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case("opus@"))
+                {
                     debug!(
                         "Found generic opus clock rate: {} -> {}Hz",
                         name, clock_rate
@@ -360,7 +368,7 @@ impl CodecMapper {
         }
 
         // Fallback based on common codec knowledge
-        let fallback_rate = match codec_name.to_lowercase().as_str() {
+        let fallback_rate = match codec_name.to_ascii_lowercase().as_str() {
             "pcmu" | "pcma" | "g711" => 8000,
             "g729" => 8000,
             "opus" => 48000,
@@ -439,7 +447,7 @@ impl CodecMapper {
             self.codec_clock_rates.remove(codec_name);
 
             // Remove from Opus configs if it was an Opus codec
-            if codec_name.starts_with("opus") {
+            if codec_name.to_ascii_lowercase().starts_with("opus") {
                 if let Some(config) = self.opus_configs.remove(&payload_type) {
                     self.opus_config_to_payload.remove(&config);
                 }
@@ -615,6 +623,12 @@ mod tests {
         let config = OpusConfig::from_codec_string("opus@48000Hz@2ch").unwrap();
         assert_eq!(config.sample_rate, 48000);
         assert_eq!(config.channels, 2);
+
+        let config = OpusConfig::from_codec_string("OpUs@48000HZ@2CH@128000BPS@FEC").unwrap();
+        assert_eq!(config.sample_rate, 48000);
+        assert_eq!(config.channels, 2);
+        assert_eq!(config.max_bitrate, Some(128000));
+        assert_eq!(config.fec_enabled, Some(true));
 
         // Test parsing with bitrate
         let config = OpusConfig::from_codec_string("opus@16000Hz@32000bps").unwrap();

--- a/crates/media/media-core/src/codec/mapping.rs
+++ b/crates/media/media-core/src/codec/mapping.rs
@@ -514,6 +514,10 @@ pub struct CodecCapability {
 impl CodecMapper {
     /// Get codec capability information
     pub fn get_codec_capability(&self, codec_name: &str) -> Option<CodecCapability> {
+        let base_name = codec_name.split('@').next().unwrap_or(codec_name);
+        if !crate::codec::audio_codec_available(base_name) {
+            return None;
+        }
         let payload_type = self.codec_to_payload(codec_name)?;
         let clock_rate = self.get_clock_rate(codec_name);
         let is_static = !dynamic_range::is_dynamic(payload_type);
@@ -815,12 +819,21 @@ mod tests {
         let opus_config = OpusConfig::new(48000, 2);
         mapper.register_opus_config(opus_config.clone(), 96);
 
-        let opus_cap = mapper.get_codec_capability("opus@48000Hz@2ch").unwrap();
-        assert_eq!(opus_cap.name, "opus@48000Hz@2ch");
-        assert_eq!(opus_cap.payload_type, 96);
-        assert_eq!(opus_cap.clock_rate, 48000);
-        assert!(!opus_cap.is_static);
-        assert_eq!(opus_cap.opus_config, Some(opus_config));
+        #[cfg(feature = "opus")]
+        {
+            let opus_cap = mapper.get_codec_capability("opus@48000Hz@2ch").unwrap();
+            assert_eq!(opus_cap.name, "opus@48000Hz@2ch");
+            assert_eq!(opus_cap.payload_type, 96);
+            assert_eq!(opus_cap.clock_rate, 48000);
+            assert!(!opus_cap.is_static);
+            assert_eq!(opus_cap.opus_config, Some(opus_config));
+        }
+        #[cfg(not(feature = "opus"))]
+        {
+            assert!(mapper.get_codec_capability("opus@48000Hz@2ch").is_none());
+            assert_eq!(mapper.codec_to_payload("opus@48000Hz@2ch"), Some(96));
+            assert_eq!(mapper.get_opus_config(96), Some(&opus_config));
+        }
     }
 
     #[cfg(feature = "g729")]

--- a/crates/media/media-core/src/codec/mod.rs
+++ b/crates/media/media-core/src/codec/mod.rs
@@ -22,6 +22,24 @@ pub use mapping::{CodecCapability, CodecMapper};
 // Re-export codec factory
 pub use factory::CodecFactory;
 
+/// Whether this build can construct a working encoder and decoder for an
+/// audio codec name. Wire registries may still retain metadata for unsupported
+/// codecs so remote SDP can be parsed without advertising them locally.
+pub fn audio_codec_available(name: &str) -> bool {
+    let normalized: String = name
+        .chars()
+        .filter(|character| !matches!(character, '.' | '-' | '_' | ' '))
+        .map(|character| character.to_ascii_uppercase())
+        .collect();
+    match normalized.as_str() {
+        "PCMU" | "PCMA" | "G711MU" | "G711U" | "G711A" => true,
+        "G729" | "G729A" | "G729BA" | "G729AB" => cfg!(feature = "g729"),
+        "OPUS" => cfg!(feature = "opus"),
+        "G722" => false,
+        _ => false,
+    }
+}
+
 /// Basic codec trait for RTP payload processing
 pub trait Codec: Send + Sync {
     /// Get the RTP payload type for this codec

--- a/crates/media/media-core/src/codec/transcoding.rs
+++ b/crates/media/media-core/src/codec/transcoding.rs
@@ -7,7 +7,6 @@ use crate::codec::audio::common::AudioCodec;
 use crate::codec::audio::payload_type::PCM_S16LE;
 #[cfg(feature = "g729")]
 use crate::codec::audio::G729Codec;
-use crate::codec::audio::{OpusApplication, OpusCodec};
 use crate::codec::factory::CodecFactory;
 use crate::error::{CodecError, Result};
 use crate::processing::format::{ConversionParams, FormatConverter};
@@ -176,21 +175,13 @@ impl Transcoder {
             }
             #[cfg(not(feature = "g729"))]
             18 => Err(CodecError::UnsupportedPayloadType { payload_type }.into()),
-            111 => {
-                // Opus (dynamic)
-                let codec = OpusCodec::new(
-                    SampleRate::Rate48000,
-                    2,
-                    crate::codec::audio::OpusConfig {
-                        application: OpusApplication::Voip,
-                        bitrate: 64000,
-                        frame_size_ms: 20.0,
-                        vbr: true,
-                        complexity: 5,
-                    },
-                )?;
-                Ok(Box::new(codec))
+            #[cfg(feature = "opus")]
+            111 => CodecFactory::create_codec(111, Some(48_000), Some(2)),
+            #[cfg(not(feature = "opus"))]
+            111 => Err(CodecError::NotFound {
+                name: "Opus (enable the `opus` feature)".to_string(),
             }
+            .into()),
             _ => Err(CodecError::UnsupportedPayloadType { payload_type }.into()),
         }
     }
@@ -215,6 +206,7 @@ impl Transcoder {
             8u8, // PCMA
             #[cfg(feature = "g729")]
             18u8, // G.729
+            #[cfg(feature = "opus")]
             111u8, // Opus
             PCM_S16LE, // Internal pcm_s16le 16 kHz mono
         ];
@@ -371,14 +363,20 @@ mod tests {
             from_codec: 0,
             to_codec: 8
         }));
+        #[cfg(feature = "opus")]
         assert!(paths.contains(&TranscodingPath {
             from_codec: 0,
             to_codec: 111
         }));
+        #[cfg(not(feature = "opus"))]
+        assert!(!paths
+            .iter()
+            .any(|path| path.from_codec == 111 || path.to_codec == 111));
         assert!(paths.contains(&TranscodingPath {
             from_codec: PCM_S16LE,
             to_codec: 0
         }));
+        #[cfg(feature = "opus")]
         assert!(paths.contains(&TranscodingPath {
             from_codec: 111,
             to_codec: PCM_S16LE
@@ -541,10 +539,12 @@ mod tests {
             from_codec: 0,
             to_codec: 18
         })); // PCMU -> G.729
+        #[cfg(feature = "opus")]
         assert!(paths.contains(&TranscodingPath {
             from_codec: 18,
             to_codec: 111
         })); // G.729 -> Opus
+        #[cfg(feature = "opus")]
         assert!(paths.contains(&TranscodingPath {
             from_codec: 111,
             to_codec: 18

--- a/crates/media/media-core/src/codec/transcoding.rs
+++ b/crates/media/media-core/src/codec/transcoding.rs
@@ -174,11 +174,14 @@ impl Transcoder {
                 Ok(Box::new(codec))
             }
             #[cfg(not(feature = "g729"))]
-            18 => Err(CodecError::UnsupportedPayloadType { payload_type }.into()),
+            18 => Err(CodecError::UnsupportedCodec {
+                name: "G.729 (enable the `g729` feature)".to_string(),
+            }
+            .into()),
             #[cfg(feature = "opus")]
             111 => CodecFactory::create_codec(111, Some(48_000), Some(2)),
             #[cfg(not(feature = "opus"))]
-            111 => Err(CodecError::NotFound {
+            111 => Err(CodecError::UnsupportedCodec {
                 name: "Opus (enable the `opus` feature)".to_string(),
             }
             .into()),

--- a/crates/media/media-core/src/engine/config.rs
+++ b/crates/media/media-core/src/engine/config.rs
@@ -84,12 +84,19 @@ pub struct CodecConfig {
 
 impl Default for CodecConfig {
     fn default() -> Self {
+        let enabled_payload_types = vec![
+            0, // PCMU
+            8, // PCMA
+        ];
+        #[cfg(feature = "opus")]
+        let enabled_payload_types = {
+            let mut payload_types = enabled_payload_types;
+            payload_types.push(111); // Common dynamic Opus mapping
+            payload_types
+        };
+
         Self {
-            enabled_payload_types: vec![
-                0,   // PCMU
-                8,   // PCMA
-                111, // Opus (dynamic)
-            ],
+            enabled_payload_types,
             preferred_codec: 0,        // PCMU by default
             enable_transcoding: false, // Disabled by default
             max_complexity: 5,         // Medium complexity

--- a/crates/media/media-core/src/engine/media_engine.rs
+++ b/crates/media/media-core/src/engine/media_engine.rs
@@ -42,6 +42,33 @@ impl Default for PerformanceLevel {
     }
 }
 
+#[cfg(test)]
+mod codec_capability_tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_only_advertise_implemented_codecs() {
+        let mut config = MediaEngineConfig::default();
+        // Include every disputed payload explicitly. The capability builder
+        // must still reject codecs whose encoder/decoder is unavailable.
+        config.codecs.enabled_payload_types = vec![0, 8, 9, 111];
+        let capabilities = MediaEngine::build_capabilities(&config);
+        let names: Vec<&str> = capabilities
+            .audio_codecs
+            .iter()
+            .map(|codec| codec.name.as_str())
+            .collect();
+
+        assert!(names.contains(&"PCMU"));
+        assert!(names.contains(&"PCMA"));
+        assert!(!names.iter().any(|name| name.eq_ignore_ascii_case("G722")));
+        #[cfg(feature = "opus")]
+        assert!(names.iter().any(|name| name.eq_ignore_ascii_case("opus")));
+        #[cfg(not(feature = "opus"))]
+        assert!(!names.iter().any(|name| name.eq_ignore_ascii_case("opus")));
+    }
+}
+
 /// Parameters for creating a media session
 #[derive(Debug, Clone)]
 pub struct MediaSessionParams {
@@ -806,7 +833,7 @@ impl MediaEngine {
     fn build_capabilities(config: &MediaEngineConfig) -> EngineCapabilities {
         use crate::types::{payload_types, SampleRate};
 
-        let mut audio_codecs: Vec<AudioCodecCapability> = config
+        let audio_codecs: Vec<AudioCodecCapability> = config
             .codecs
             .enabled_payload_types
             .iter()
@@ -841,20 +868,24 @@ impl MediaEngine {
             })
             .collect();
 
-        // Add dynamic codec capabilities that are always supported
-
-        // Add Opus capability (dynamic payload type - will be set during SDP negotiation)
-        audio_codecs.push(AudioCodecCapability {
-            payload_type: 0, // Placeholder - will be set during SDP negotiation
-            name: "opus".to_string(),
-            sample_rates: vec![
-                SampleRate::Rate8000,
-                SampleRate::Rate16000,
-                SampleRate::Rate48000,
-            ],
-            channels: 1, // Mono for now
-            clock_rate: 48000,
-        });
+        #[cfg(feature = "opus")]
+        let audio_codecs = {
+            let mut audio_codecs = audio_codecs;
+            if config.codecs.enabled_payload_types.contains(&111) {
+                audio_codecs.push(AudioCodecCapability {
+                    payload_type: 111,
+                    name: "opus".to_string(),
+                    sample_rates: vec![
+                        SampleRate::Rate8000,
+                        SampleRate::Rate16000,
+                        SampleRate::Rate48000,
+                    ],
+                    channels: 2,
+                    clock_rate: 48000,
+                });
+            }
+            audio_codecs
+        };
 
         EngineCapabilities {
             audio_codecs,

--- a/crates/media/media-core/src/error.rs
+++ b/crates/media/media-core/src/error.rs
@@ -70,6 +70,12 @@ pub enum MediaSessionError {
 /// Codec-related errors
 #[derive(Debug, Error)]
 pub enum CodecError {
+    /// The requested codec is known but no usable encoder/decoder is
+    /// available in this build. This is deliberately distinct from an
+    /// unknown payload type so callers can fail negotiation explicitly.
+    #[error("Unsupported codec: {name}")]
+    UnsupportedCodec { name: String },
+
     #[error("Unsupported payload type: {payload_type}")]
     UnsupportedPayloadType { payload_type: u8 },
 
@@ -186,6 +192,11 @@ impl Error {
     /// Create a codec not found error
     pub fn codec_not_found(name: impl Into<String>) -> Self {
         Self::Codec(CodecError::NotFound { name: name.into() })
+    }
+
+    /// Create an unsupported-codec error.
+    pub fn unsupported_codec(name: impl Into<String>) -> Self {
+        Self::Codec(CodecError::UnsupportedCodec { name: name.into() })
     }
 
     /// Create an unsupported payload type error

--- a/crates/media/media-core/src/relay/controller/audio_generation.rs
+++ b/crates/media/media-core/src/relay/controller/audio_generation.rs
@@ -15,7 +15,11 @@ use tokio::time::Instant as TokioInstant;
 use tracing::{debug, error, info, warn};
 
 use crate::diagnostics;
+use crate::types::AudioFrame;
 use rvoip_rtp_core::{RtpSendHandle, RtpSession};
+
+use super::codec_runtime::DialogCodecRuntime;
+use super::types::NegotiatedAudioCodec;
 
 const AUDIO_TX_PHASE_MULTIPLIER: u64 = 0x9E37_79B9_7F4A_7C15;
 #[cfg(any(feature = "perf-diagnostics", test))]
@@ -89,12 +93,17 @@ pub enum AudioSource {
 pub struct AudioGenerator {
     /// Sample rate (Hz)
     sample_rate: u32,
+    /// Clock of legacy PCMU custom samples before resampling to `sample_rate`.
+    custom_source_rate: u32,
     /// Current phase for sine wave generation
     phase: f64,
     /// Audio source configuration
     source: AudioSource,
     /// Current position in custom samples (if using custom samples)
     sample_position: usize,
+    /// Output-frame cursor used for deterministic nearest-neighbour custom
+    /// sample-rate conversion.
+    custom_output_position: u64,
     /// One exact encoded period for integral-frequency tones.
     tone_waveform: Option<Vec<u8>>,
     /// Immutable packet payloads keyed by (packet length, waveform offset).
@@ -110,22 +119,34 @@ impl AudioGenerator {
         };
         Self {
             sample_rate,
+            custom_source_rate: sample_rate,
             phase: 0.0,
             tone_waveform: encoded_integral_tone_period(sample_rate, &source),
             source,
             sample_position: 0,
+            custom_output_position: 0,
             tone_payload_cache: HashMap::new(),
         }
     }
 
     /// Create a new audio generator with custom audio source
     pub fn new_with_source(sample_rate: u32, source: AudioSource) -> Self {
+        Self::new_with_source_rates(sample_rate, sample_rate, source)
+    }
+
+    fn new_with_source_rates(
+        sample_rate: u32,
+        custom_source_rate: u32,
+        source: AudioSource,
+    ) -> Self {
         Self {
             sample_rate,
+            custom_source_rate,
             phase: 0.0,
             tone_waveform: encoded_integral_tone_period(sample_rate, &source),
             source,
             sample_position: 0,
+            custom_output_position: 0,
             tone_payload_cache: HashMap::new(),
         }
     }
@@ -188,6 +209,55 @@ impl AudioGenerator {
                 vec![0x7F; num_samples] // μ-law silence
             }
         }
+    }
+
+    /// Generate codec-neutral signed PCM at this generator's sample rate.
+    ///
+    /// `CustomSamples` remains source-compatible with its historical wire
+    /// contract: the bytes are interpreted as PCMU. They are decoded to PCM
+    /// here so the negotiated codec, rather than the source container, owns
+    /// the RTP payload encoding.
+    pub fn generate_pcm_frame(&mut self, frames: usize, channels: u8) -> Vec<i16> {
+        let channels = usize::from(channels.max(1));
+        let mut output = Vec::with_capacity(frames.saturating_mul(channels));
+        match self.source.clone() {
+            AudioSource::Tone {
+                frequency,
+                amplitude,
+            } => {
+                let phase_increment =
+                    2.0 * std::f64::consts::PI * frequency / self.sample_rate.max(1) as f64;
+                for _ in 0..frames {
+                    let sample = (self.phase.sin() * amplitude * 32767.0) as i16;
+                    output.extend(std::iter::repeat_n(sample, channels));
+                    self.phase = (self.phase + phase_increment) % (2.0 * std::f64::consts::PI);
+                }
+            }
+            AudioSource::CustomSamples { samples, repeat } => {
+                for _ in 0..frames {
+                    let source_index = self
+                        .custom_output_position
+                        .saturating_mul(u64::from(self.custom_source_rate.max(1)))
+                        / u64::from(self.sample_rate.max(1));
+                    self.custom_output_position = self.custom_output_position.saturating_add(1);
+                    let encoded = if samples.is_empty() {
+                        0xff
+                    } else if repeat {
+                        let sample_count = u64::try_from(samples.len()).unwrap_or(u64::MAX);
+                        samples[usize::try_from(source_index % sample_count).unwrap_or(0)]
+                    } else {
+                        usize::try_from(source_index)
+                            .ok()
+                            .and_then(|index| samples.get(index).copied())
+                            .unwrap_or(0xff)
+                    };
+                    let sample = codec_core::utils::mulaw_to_linear_scalar(encoded);
+                    output.extend(std::iter::repeat_n(sample, channels));
+                }
+            }
+            AudioSource::PassThrough => output.resize(frames.saturating_mul(channels), 0),
+        }
+        output
     }
 
     /// Generate tone samples
@@ -290,6 +360,7 @@ impl AudioGenerator {
         self.source = source;
         self.phase = 0.0;
         self.sample_position = 0; // Reset position for custom samples
+        self.custom_output_position = 0;
     }
 }
 
@@ -383,6 +454,8 @@ pub struct AudioTransmitter {
     audio_generator: Arc<ParkingMutex<AudioGenerator>>,
     /// Transmission configuration
     config: AudioTransmitterConfig,
+    /// Exact codec generation used for both bytes and RTP payload identity.
+    codec_runtime: Arc<DialogCodecRuntime>,
     /// Whether transmission is active
     is_active: Arc<AtomicBool>,
     /// Background transmission task.
@@ -393,7 +466,7 @@ impl AudioTransmitter {
     /// Create a new audio transmitter with default configuration (pass-through mode)
     pub fn new(rtp_session: Arc<Mutex<RtpSession>>) -> Self {
         let config = AudioTransmitterConfig::default();
-        Self::new_with_config(rtp_session, config)
+        Self::new_with_config(rtp_session, config, default_pcmu_runtime())
     }
 
     /// Create a new audio transmitter with tone generation (for backward compatibility)
@@ -405,16 +478,20 @@ impl AudioTransmitter {
             },
             ..Default::default()
         };
-        Self::new_with_config(rtp_session, config)
+        Self::new_with_config(rtp_session, config, default_pcmu_runtime())
     }
 
     /// Create a new audio transmitter with custom configuration
-    pub fn new_with_config(
+    pub(super) fn new_with_config(
         rtp_session: Arc<Mutex<RtpSession>>,
         config: AudioTransmitterConfig,
+        codec_runtime: Arc<DialogCodecRuntime>,
     ) -> Self {
-        let audio_generator =
-            AudioGenerator::new_with_source(config.sample_rate, config.source.clone());
+        let audio_generator = AudioGenerator::new_with_source_rates(
+            codec_runtime.format.clock_rate,
+            config.sample_rate,
+            config.source.clone(),
+        );
 
         // Build the lock-free send handle once. This briefly locks the
         // session at construction time only; the TX hot path never
@@ -433,6 +510,7 @@ impl AudioTransmitter {
             send_handle,
             audio_generator: Arc::new(ParkingMutex::new(audio_generator)),
             config,
+            codec_runtime,
             is_active: Arc::new(AtomicBool::new(false)),
             tx_task: None,
         }
@@ -491,11 +569,24 @@ impl AudioTransmitter {
         let initial_delay = next_audio_tx_start_delay(self.config.interval);
         diagnostics::record_audio_tx_task_started(initial_delay);
         let pacing_config = audio_tx_pacing_config_from_env();
+        let codec_runtime = Arc::clone(&self.codec_runtime);
+        let payload_type = codec_runtime.format.payload_type;
+        let clock_rate = codec_runtime.format.clock_rate;
+        let channels = codec_runtime.format.channels;
 
         let collect_diagnostics = diagnostics::enabled();
         let mut next_tick_at = TokioInstant::now() + initial_delay;
         let base_packet_interval = self.config.interval;
-        let samples_per_packet = self.config.samples_per_packet;
+        let samples_per_packet = rescale_packet_frames(
+            self.config.samples_per_packet,
+            self.config.sample_rate,
+            clock_rate,
+        );
+        let max_packetization_divisor = if codec_runtime.format.name.eq_ignore_ascii_case("opus") {
+            max_divisor_for_duration(base_packet_interval, Duration::from_millis(60))
+        } else {
+            MAX_AUDIO_TX_PACKETIZATION_DIVISOR
+        };
         let pacing_sequence = pacing_config
             .map(|_| AUDIO_TX_PACING_SEQUENCE.fetch_add(1, Ordering::Relaxed))
             .unwrap_or(0);
@@ -560,63 +651,77 @@ impl AudioTransmitter {
                         pacing_consecutive_skip_count = 0;
                         samples_per_packet
                     } else {
-                        let divisor = adaptive_packetization_divisor(active_guard.active_count());
+                        let divisor = adaptive_packetization_divisor(active_guard.active_count())
+                            .min(max_packetization_divisor);
                         let packet_interval =
                             adaptive_packetization_interval(base_packet_interval, divisor);
                         next_tick_at = next_audio_tx_deadline(next_tick_at, packet_interval);
                         samples_per_packet.saturating_mul(divisor as usize)
                     };
 
-                    // Generate audio samples
-                    let audio_samples = {
+                    // Generate codec-neutral PCM and encode it with the exact
+                    // negotiated codec generation before assigning its PT.
+                    let pcm_samples = {
                         let mut generator = audio_generator.lock();
-                        generator.generate_pcmu_payload(effective_samples_per_packet)
+                        generator.generate_pcm_frame(effective_samples_per_packet, channels)
                     };
-
-                    // Send RTP packet (only if not in pass-through mode)
-                    if !matches!(audio_samples.as_ref(), [0x7F, ..] if audio_samples.iter().all(|&x| x == 0x7F))
-                    {
-                        let current_timestamp = next_timestamp;
-                        next_timestamp =
-                            next_timestamp.wrapping_add(effective_samples_per_packet as u32);
-
-                        // Fast path: send through the lock-free handle —
-                        // no `session.lock().await` per frame.
-                        let send_started = collect_diagnostics.then(Instant::now);
-                        let send_result = if let Some(handle) = &send_handle {
-                            handle
-                                .send_packet(current_timestamp, audio_samples, false)
-                                .await
-                        } else {
-                            // Fallback: session lock per frame. Only reached
-                            // if the session was missing a scheduler when
-                            // we tried to build the handle.
-                            let session = rtp_session.lock().await;
-                            session
-                                .send_packet(current_timestamp, audio_samples, false)
-                                .await
-                        };
-                        if let Some(send_started) = send_started {
-                            let send_elapsed = send_started.elapsed();
-                            send_count = send_count.saturating_add(1);
-                            if send_result.is_err() {
-                                send_failures = send_failures.saturating_add(1);
-                            }
-                            send_total = send_total.saturating_add(send_elapsed);
-                            send_max = send_max.max(send_elapsed);
-                        }
-
-                        if let Err(e) = send_result {
-                            error!("Failed to send RTP audio packet: {}", e);
+                    let frame = AudioFrame::new(pcm_samples, clock_rate, channels, next_timestamp);
+                    let audio_samples = match codec_runtime.encode(&frame).await {
+                        Ok(payload) => Bytes::from(payload),
+                        Err(error) => {
+                            error!("Failed to encode generated RTP audio: {}", error);
                             is_active.store(false, Ordering::Release);
                             break;
-                        } else {
-                            debug!(
-                                "📡 Sent RTP audio packet (timestamp: {}, {} samples)",
-                                current_timestamp, effective_samples_per_packet
-                            );
                         }
+                    };
+                    let current_timestamp = next_timestamp;
+                    next_timestamp = next_timestamp.wrapping_add(
+                        u32::try_from(effective_samples_per_packet).unwrap_or(u32::MAX),
+                    );
+
+                    // Fast path: send through the lock-free handle — no
+                    // `session.lock().await` per frame. PT and bytes come
+                    // from the same immutable codec generation.
+                    let send_started = collect_diagnostics.then(Instant::now);
+                    let send_result = if let Some(handle) = &send_handle {
+                        handle
+                            .send_packet_with_pt(
+                                current_timestamp,
+                                audio_samples,
+                                false,
+                                payload_type,
+                            )
+                            .await
+                    } else {
+                        let session = rtp_session.lock().await;
+                        session
+                            .send_packet_with_pt(
+                                current_timestamp,
+                                audio_samples,
+                                false,
+                                payload_type,
+                            )
+                            .await
+                    };
+                    if let Some(send_started) = send_started {
+                        let send_elapsed = send_started.elapsed();
+                        send_count = send_count.saturating_add(1);
+                        if send_result.is_err() {
+                            send_failures = send_failures.saturating_add(1);
+                        }
+                        send_total = send_total.saturating_add(send_elapsed);
+                        send_max = send_max.max(send_elapsed);
                     }
+
+                    if let Err(e) = send_result {
+                        error!("Failed to send RTP audio packet: {}", e);
+                        is_active.store(false, Ordering::Release);
+                        break;
+                    }
+                    debug!(
+                        "📡 Sent RTP audio packet (timestamp: {}, {} frames, PT {})",
+                        current_timestamp, effective_samples_per_packet, payload_type
+                    );
                 }
 
                 if collect_diagnostics {
@@ -668,6 +773,15 @@ impl AudioTransmitter {
         self.is_active.load(Ordering::Acquire)
     }
 
+    pub(super) fn config(&self) -> &AudioTransmitterConfig {
+        &self.config
+    }
+
+    #[cfg(test)]
+    pub(super) fn codec_format(&self) -> &NegotiatedAudioCodec {
+        &self.codec_runtime.format
+    }
+
     /// Update the audio source during transmission
     pub async fn set_audio_source(&self, source: AudioSource) {
         let mut generator = self.audio_generator.lock();
@@ -695,6 +809,33 @@ impl AudioTransmitter {
         let source = AudioSource::PassThrough;
         self.set_audio_source(source).await;
     }
+}
+
+fn default_pcmu_runtime() -> Arc<DialogCodecRuntime> {
+    Arc::new(
+        DialogCodecRuntime::new(NegotiatedAudioCodec {
+            name: "PCMU".to_string(),
+            payload_type: 0,
+            clock_rate: 8_000,
+            channels: 1,
+        })
+        .expect("the built-in PCMU transmitter format is valid"),
+    )
+}
+
+fn rescale_packet_frames(frames: usize, source_rate: u32, target_rate: u32) -> usize {
+    let source_rate = u64::from(source_rate.max(1));
+    let target_rate = u64::from(target_rate.max(1));
+    let frames = u64::try_from(frames).unwrap_or(u64::MAX);
+    usize::try_from(frames.saturating_mul(target_rate).div_ceil(source_rate))
+        .unwrap_or(usize::MAX)
+        .max(1)
+}
+
+fn max_divisor_for_duration(base: Duration, maximum: Duration) -> u64 {
+    let base_nanos = base.as_nanos().max(1);
+    let divisor = maximum.as_nanos() / base_nanos;
+    u64::try_from(divisor).unwrap_or(u64::MAX).max(1)
 }
 
 fn next_audio_tx_start_delay(interval: Duration) -> Duration {
@@ -800,8 +941,27 @@ mod tests {
     use super::{
         adaptive_packetization_divisor, adaptive_packetization_interval,
         audio_tx_start_delay_for_sequence, pacing_divisor, AudioGenerator, AudioSource,
+        DialogCodecRuntime, NegotiatedAudioCodec,
     };
+    use crate::types::AudioFrame;
+    use std::sync::Arc;
     use std::time::Duration;
+
+    async fn encode_generated(
+        format: NegotiatedAudioCodec,
+        source: AudioSource,
+        frames: usize,
+    ) -> (Vec<u8>, AudioFrame) {
+        let mut generator = AudioGenerator::new_with_source(format.clock_rate, source);
+        let pcm = generator.generate_pcm_frame(frames, format.channels);
+        let runtime = Arc::new(DialogCodecRuntime::new(format.clone()).unwrap());
+        let payload = runtime
+            .encode(&AudioFrame::new(pcm, format.clock_rate, format.channels, 0))
+            .await
+            .unwrap();
+        let decoded = runtime.decode(&payload, 0).await.unwrap();
+        (payload, decoded)
+    }
 
     #[test]
     fn generate_pcmu_samples_returns_requested_length() {
@@ -851,6 +1011,82 @@ mod tests {
         let output = generator.generate_pcmu_samples(5);
 
         assert_eq!(output, vec![1, 2, 3, 1, 2]);
+    }
+
+    #[test]
+    fn custom_pcmu_is_resampled_to_the_negotiated_clock() {
+        let mut generator = AudioGenerator::new_with_source_rates(
+            48_000,
+            8_000,
+            AudioSource::CustomSamples {
+                samples: vec![0xff, 0x7f],
+                repeat: false,
+            },
+        );
+        let output = generator.generate_pcm_frame(12, 1);
+        assert!(output[..6].iter().all(|sample| *sample == output[0]));
+        assert!(output[6..].iter().all(|sample| *sample == output[6]));
+        assert_ne!(output[0], output[6]);
+    }
+
+    #[tokio::test]
+    async fn generated_tone_and_custom_audio_use_pcma_encoding() {
+        let format = NegotiatedAudioCodec {
+            name: "PCMA".to_string(),
+            payload_type: 8,
+            clock_rate: 8_000,
+            channels: 1,
+        };
+        let (tone_payload, tone) = encode_generated(
+            format.clone(),
+            AudioSource::Tone {
+                frequency: 440.0,
+                amplitude: 0.4,
+            },
+            160,
+        )
+        .await;
+        let (custom_payload, custom) = encode_generated(
+            format,
+            AudioSource::CustomSamples {
+                samples: vec![0xff, 0xce, 0x4e],
+                repeat: true,
+            },
+            160,
+        )
+        .await;
+        assert_eq!(tone_payload.len(), 160);
+        assert_eq!(custom_payload.len(), 160);
+        assert_eq!(tone.sample_rate, 8_000);
+        assert_eq!(custom.channels, 1);
+    }
+
+    #[cfg(feature = "opus")]
+    #[tokio::test]
+    async fn generated_tone_and_custom_audio_use_opus_encoding() {
+        let format = NegotiatedAudioCodec {
+            name: "opus".to_string(),
+            payload_type: 96,
+            clock_rate: 48_000,
+            channels: 2,
+        };
+        for source in [
+            AudioSource::Tone {
+                frequency: 440.0,
+                amplitude: 0.4,
+            },
+            AudioSource::CustomSamples {
+                samples: vec![0xff, 0xce, 0x4e],
+                repeat: true,
+            },
+        ] {
+            let (payload, decoded) = encode_generated(format.clone(), source, 960).await;
+            assert!(!payload.is_empty());
+            assert!(payload.len() < decoded.samples.len() * std::mem::size_of::<i16>());
+            assert_eq!(decoded.sample_rate, 48_000);
+            assert_eq!(decoded.channels, 2);
+            assert_eq!(decoded.samples.len(), 1_920);
+        }
     }
 
     #[test]

--- a/crates/media/media-core/src/relay/controller/audio_generation.rs
+++ b/crates/media/media-core/src/relay/controller/audio_generation.rs
@@ -773,8 +773,10 @@ impl AudioTransmitter {
         self.is_active.load(Ordering::Acquire)
     }
 
-    pub(super) fn config(&self) -> &AudioTransmitterConfig {
-        &self.config
+    pub(super) fn replacement_config(&self) -> AudioTransmitterConfig {
+        let mut config = self.config.clone();
+        config.source = self.audio_generator.lock().source.clone();
+        config
     }
 
     #[cfg(test)]

--- a/crates/media/media-core/src/relay/controller/codec_detection.rs
+++ b/crates/media/media-core/src/relay/controller/codec_detection.rs
@@ -453,8 +453,6 @@ mod tests {
         }
     }
 
-    // Test removed - Opus codec is not supported
-
     #[tokio::test]
     async fn test_insufficient_data() {
         let mapper = Arc::new(CodecMapper::new());

--- a/crates/media/media-core/src/relay/controller/codec_runtime.rs
+++ b/crates/media/media-core/src/relay/controller/codec_runtime.rs
@@ -1,0 +1,334 @@
+//! Per-dialog codec selection and state.
+//!
+//! RTP payload numbers are negotiated per dialog.  Keeping the complete codec
+//! identity beside the encoder/decoder prevents dynamic payloads from silently
+//! falling back to PCMU and lets a re-INVITE replace codec state atomically.
+
+use tokio::sync::Mutex;
+
+use crate::codec::audio::common::AudioCodec;
+use crate::codec::audio::G711Codec;
+#[cfg(feature = "g729")]
+use crate::codec::audio::{G729Annexes, G729Codec, G729Config};
+#[cfg(feature = "opus")]
+use crate::codec::audio::{OpusCodec, OpusConfig};
+use crate::error::{CodecError, Error, Result};
+use crate::types::AudioFrame;
+#[cfg(any(feature = "g729", feature = "opus"))]
+use crate::types::SampleRate;
+
+use super::types::{
+    MediaConfig, NegotiatedAudioCodec, AUDIO_CHANNELS_PARAMETER, RTP_CLOCK_RATE_PARAMETER,
+    RTP_PAYLOAD_TYPE_PARAMETER,
+};
+
+fn parse_parameter<T>(config: &MediaConfig, key: &str) -> Result<Option<T>>
+where
+    T: std::str::FromStr,
+{
+    config
+        .parameters
+        .get(key)
+        .map(|value| {
+            value.parse::<T>().map_err(|_| {
+                Error::Codec(CodecError::InvalidParameters {
+                    details: format!("invalid {key} value: {value}"),
+                })
+            })
+        })
+        .transpose()
+}
+
+fn normalized_codec_name(name: &str) -> String {
+    name.chars()
+        .filter(|character| !matches!(character, '.' | '-' | '_' | ' '))
+        .map(|character| character.to_ascii_uppercase())
+        .collect()
+}
+
+/// Resolve and validate the exact codec identity before any media state is
+/// allocated or mutated.
+pub(super) fn resolve_codec(config: &MediaConfig) -> Result<NegotiatedAudioCodec> {
+    let requested = config.preferred_codec.as_deref().unwrap_or("PCMU");
+    let normalized = normalized_codec_name(requested);
+    let supplied_payload_type = parse_parameter::<u8>(config, RTP_PAYLOAD_TYPE_PARAMETER)?;
+    let supplied_clock_rate = parse_parameter::<u32>(config, RTP_CLOCK_RATE_PARAMETER)?;
+    let supplied_channels = parse_parameter::<u8>(config, AUDIO_CHANNELS_PARAMETER)?;
+
+    let (name, default_payload_type, default_clock_rate, default_channels) =
+        match normalized.as_str() {
+            "PCMU" | "G711MU" | "G711U" => ("PCMU", 0, 8_000, 1),
+            "PCMA" | "G711A" => ("PCMA", 8, 8_000, 1),
+            "G722" => {
+                return Err(Error::unsupported_codec(
+                    "G.722 (encoder/decoder is not implemented)",
+                ));
+            }
+            "G729" | "G729A" | "G729BA" | "G729AB" => {
+                #[cfg(not(feature = "g729"))]
+                return Err(Error::unsupported_codec(
+                    "G.729 (enable the `g729` feature)",
+                ));
+                #[cfg(feature = "g729")]
+                (requested, 18, 8_000, 1)
+            }
+            "OPUS" => {
+                #[cfg(not(feature = "opus"))]
+                return Err(Error::unsupported_codec("Opus (enable the `opus` feature)"));
+                #[cfg(feature = "opus")]
+                ("opus", 111, 48_000, 2)
+            }
+            _ => return Err(Error::unsupported_codec(requested)),
+        };
+
+    let codec = NegotiatedAudioCodec {
+        name: name.to_string(),
+        payload_type: supplied_payload_type.unwrap_or(default_payload_type),
+        clock_rate: supplied_clock_rate.unwrap_or(default_clock_rate),
+        channels: supplied_channels.unwrap_or(default_channels),
+    };
+    validate_codec_shape(&codec)?;
+    Ok(codec)
+}
+
+fn validate_codec_shape(codec: &NegotiatedAudioCodec) -> Result<()> {
+    if codec.payload_type > 127 {
+        return Err(CodecError::InvalidParameters {
+            details: format!("RTP payload type {} is outside 0..=127", codec.payload_type),
+        }
+        .into());
+    }
+    if codec.channels == 0 {
+        return Err(CodecError::InvalidParameters {
+            details: "audio channel count must be at least one".to_string(),
+        }
+        .into());
+    }
+
+    if codec.name.eq_ignore_ascii_case("opus") {
+        if codec.clock_rate != 48_000 || !matches!(codec.channels, 1 | 2) {
+            return Err(CodecError::InvalidParameters {
+                details: format!(
+                    "Opus RTP requires 48000Hz and one or two channels, got {}Hz/{}ch",
+                    codec.clock_rate, codec.channels
+                ),
+            }
+            .into());
+        }
+    } else if codec.clock_rate != 8_000 || codec.channels != 1 {
+        return Err(CodecError::InvalidParameters {
+            details: format!(
+                "{} RTP requires 8000Hz mono, got {}Hz/{}ch",
+                codec.name, codec.clock_rate, codec.channels
+            ),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+enum StatefulCodec {
+    Pcmu(G711Codec),
+    Pcma(G711Codec),
+    #[cfg(feature = "g729")]
+    G729(G729Codec),
+    #[cfg(feature = "opus")]
+    Opus(OpusCodec),
+}
+
+impl StatefulCodec {
+    fn new(codec: &NegotiatedAudioCodec) -> Result<Self> {
+        if codec.name.eq_ignore_ascii_case("PCMU") {
+            return Ok(Self::Pcmu(G711Codec::mu_law(
+                codec.clock_rate,
+                u16::from(codec.channels),
+            )?));
+        }
+        if codec.name.eq_ignore_ascii_case("PCMA") {
+            return Ok(Self::Pcma(G711Codec::a_law(
+                codec.clock_rate,
+                u16::from(codec.channels),
+            )?));
+        }
+
+        #[cfg(feature = "g729")]
+        if normalized_codec_name(&codec.name).starts_with("G729") {
+            let annex_b = !matches!(normalized_codec_name(&codec.name).as_str(), "G729A");
+            return Ok(Self::G729(G729Codec::new(
+                SampleRate::Rate8000,
+                1,
+                G729Config {
+                    annexes: G729Annexes {
+                        annex_a: true,
+                        annex_b,
+                    },
+                    frame_size_ms: 10.0,
+                    enable_vad: annex_b,
+                    enable_cng: annex_b,
+                },
+            )?));
+        }
+
+        #[cfg(feature = "opus")]
+        if codec.name.eq_ignore_ascii_case("opus") {
+            let sample_rate = SampleRate::from_hz(codec.clock_rate).ok_or_else(|| {
+                Error::Codec(CodecError::InvalidParameters {
+                    details: format!("invalid Opus sample rate: {}", codec.clock_rate),
+                })
+            })?;
+            return Ok(Self::Opus(OpusCodec::new(
+                sample_rate,
+                codec.channels,
+                OpusConfig::default(),
+            )?));
+        }
+
+        Err(Error::unsupported_codec(&codec.name))
+    }
+
+    fn encode(&mut self, frame: &AudioFrame) -> Result<Vec<u8>> {
+        match self {
+            Self::Pcmu(codec) | Self::Pcma(codec) => codec.encode(frame),
+            #[cfg(feature = "g729")]
+            Self::G729(codec) => encode_g729(codec, frame),
+            #[cfg(feature = "opus")]
+            Self::Opus(codec) => codec.encode(frame),
+        }
+    }
+
+    fn decode(&mut self, payload: &[u8]) -> Result<AudioFrame> {
+        match self {
+            Self::Pcmu(codec) | Self::Pcma(codec) => codec.decode(payload),
+            #[cfg(feature = "g729")]
+            Self::G729(codec) => decode_g729(codec, payload),
+            #[cfg(feature = "opus")]
+            Self::Opus(codec) => codec.decode(payload),
+        }
+    }
+}
+
+#[cfg(feature = "g729")]
+fn encode_g729(codec: &mut G729Codec, frame: &AudioFrame) -> Result<Vec<u8>> {
+    const SAMPLES_PER_FRAME: usize = 80;
+    if frame.samples.len() % SAMPLES_PER_FRAME != 0 {
+        return Err(CodecError::InvalidFrameSize {
+            expected: SAMPLES_PER_FRAME,
+            actual: frame.samples.len(),
+        }
+        .into());
+    }
+    let mut encoded = Vec::with_capacity(frame.samples.len() / SAMPLES_PER_FRAME * 10);
+    for samples in frame.samples.chunks_exact(SAMPLES_PER_FRAME) {
+        encoded.extend(codec.encode(&AudioFrame::new(
+            samples.to_vec(),
+            frame.sample_rate,
+            frame.channels,
+            frame.timestamp,
+        ))?);
+    }
+    Ok(encoded)
+}
+
+#[cfg(feature = "g729")]
+fn decode_g729(codec: &mut G729Codec, payload: &[u8]) -> Result<AudioFrame> {
+    const SPEECH_FRAME_BYTES: usize = 10;
+    if payload.is_empty() || payload.len() == 2 || payload.len() % SPEECH_FRAME_BYTES != 0 {
+        return codec.decode(payload);
+    }
+    let mut samples = Vec::with_capacity(payload.len() / SPEECH_FRAME_BYTES * 80);
+    for chunk in payload.chunks_exact(SPEECH_FRAME_BYTES) {
+        samples.extend(codec.decode(chunk)?.samples);
+    }
+    Ok(AudioFrame::new(samples, 8_000, 1, 0))
+}
+
+/// Encoder and decoder state for one exact negotiated codec generation.
+pub(super) struct DialogCodecRuntime {
+    pub(super) format: NegotiatedAudioCodec,
+    encoder: Mutex<StatefulCodec>,
+    decoder: Mutex<StatefulCodec>,
+}
+
+impl DialogCodecRuntime {
+    pub(super) fn new(format: NegotiatedAudioCodec) -> Result<Self> {
+        let encoder = StatefulCodec::new(&format)?;
+        let decoder = StatefulCodec::new(&format)?;
+        Ok(Self {
+            format,
+            encoder: Mutex::new(encoder),
+            decoder: Mutex::new(decoder),
+        })
+    }
+
+    pub(super) async fn encode(&self, frame: &AudioFrame) -> Result<Vec<u8>> {
+        if frame.sample_rate != self.format.clock_rate || frame.channels != self.format.channels {
+            return Err(CodecError::InvalidParameters {
+                details: format!(
+                    "{} frame is {}Hz/{}ch, negotiated format is {}Hz/{}ch",
+                    self.format.name,
+                    frame.sample_rate,
+                    frame.channels,
+                    self.format.clock_rate,
+                    self.format.channels
+                ),
+            }
+            .into());
+        }
+        self.encoder.lock().await.encode(frame)
+    }
+
+    pub(super) async fn decode(&self, payload: &[u8], timestamp: u32) -> Result<AudioFrame> {
+        let mut frame = self.decoder.lock().await.decode(payload)?;
+        frame.timestamp = timestamp;
+        Ok(frame)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+
+    fn config(codec: &str) -> MediaConfig {
+        MediaConfig {
+            local_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            remote_addr: None,
+            preferred_codec: Some(codec.to_string()),
+            parameters: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn unsupported_codecs_fail_with_typed_error() {
+        for name in ["G722", "not-a-codec"] {
+            assert!(matches!(
+                resolve_codec(&config(name)),
+                Err(Error::Codec(CodecError::UnsupportedCodec { .. }))
+            ));
+        }
+    }
+
+    #[cfg(not(feature = "opus"))]
+    #[test]
+    fn opus_fails_closed_without_backend() {
+        assert!(matches!(
+            resolve_codec(&config("OpUs")),
+            Err(Error::Codec(CodecError::UnsupportedCodec { .. }))
+        ));
+    }
+
+    #[cfg(feature = "opus")]
+    #[tokio::test]
+    async fn opus_runtime_preserves_negotiated_shape() {
+        let config = config("OPUS").with_negotiated_audio_codec("OPUS", 96, 48_000, 1);
+        let runtime = DialogCodecRuntime::new(resolve_codec(&config).unwrap()).unwrap();
+        let input = AudioFrame::new(vec![0; 960], 48_000, 1, 7);
+        let payload = runtime.encode(&input).await.unwrap();
+        let output = runtime.decode(&payload, 23).await.unwrap();
+        assert_eq!(runtime.format.payload_type, 96);
+        assert_eq!(output.sample_rate, 48_000);
+        assert_eq!(output.channels, 1);
+        assert_eq!(output.timestamp, 23);
+    }
+}

--- a/crates/media/media-core/src/relay/controller/codec_runtime.rs
+++ b/crates/media/media-core/src/relay/controller/codec_runtime.rs
@@ -106,6 +106,15 @@ fn validate_codec_shape(codec: &NegotiatedAudioCodec) -> Result<()> {
     }
 
     if codec.name.eq_ignore_ascii_case("opus") {
+        if codec.payload_type < 96 || codec.payload_type == 101 {
+            return Err(CodecError::InvalidParameters {
+                details: format!(
+                    "Opus requires a negotiated dynamic RTP payload type, got {}",
+                    codec.payload_type
+                ),
+            }
+            .into());
+        }
         if codec.clock_rate != 48_000 || !matches!(codec.channels, 1 | 2) {
             return Err(CodecError::InvalidParameters {
                 details: format!(
@@ -115,6 +124,30 @@ fn validate_codec_shape(codec: &NegotiatedAudioCodec) -> Result<()> {
             }
             .into());
         }
+    } else if codec.name.eq_ignore_ascii_case("PCMU") && codec.payload_type != 0 {
+        return Err(CodecError::InvalidParameters {
+            details: format!(
+                "PCMU requires static RTP payload type 0, got {}",
+                codec.payload_type
+            ),
+        }
+        .into());
+    } else if codec.name.eq_ignore_ascii_case("PCMA") && codec.payload_type != 8 {
+        return Err(CodecError::InvalidParameters {
+            details: format!(
+                "PCMA requires static RTP payload type 8, got {}",
+                codec.payload_type
+            ),
+        }
+        .into());
+    } else if normalized_codec_name(&codec.name).starts_with("G729") && codec.payload_type != 18 {
+        return Err(CodecError::InvalidParameters {
+            details: format!(
+                "G.729 requires static RTP payload type 18, got {}",
+                codec.payload_type
+            ),
+        }
+        .into());
     } else if codec.clock_rate != 8_000 || codec.channels != 1 {
         return Err(CodecError::InvalidParameters {
             details: format!(
@@ -305,6 +338,32 @@ mod tests {
             assert!(matches!(
                 resolve_codec(&config(name)),
                 Err(Error::Codec(CodecError::UnsupportedCodec { .. }))
+            ));
+        }
+    }
+
+    #[test]
+    fn static_codec_payload_identity_is_enforced() {
+        for invalid in [
+            config("PCMU").with_negotiated_audio_codec("PCMU", 8, 8_000, 1),
+            config("PCMA").with_negotiated_audio_codec("PCMA", 0, 8_000, 1),
+        ] {
+            assert!(matches!(
+                resolve_codec(&invalid),
+                Err(Error::Codec(CodecError::InvalidParameters { .. }))
+            ));
+        }
+    }
+
+    #[cfg(feature = "opus")]
+    #[test]
+    fn opus_requires_a_dynamic_non_dtmf_payload() {
+        for payload_type in [0, 8, 18, 101] {
+            let invalid =
+                config("opus").with_negotiated_audio_codec("opus", payload_type, 48_000, 2);
+            assert!(matches!(
+                resolve_codec(&invalid),
+                Err(Error::Codec(CodecError::InvalidParameters { .. }))
             ));
         }
     }

--- a/crates/media/media-core/src/relay/controller/mod.rs
+++ b/crates/media/media-core/src/relay/controller/mod.rs
@@ -930,6 +930,7 @@ impl MediaSessionController {
         // Wrap RTP session
         let rtp_wrapper = RtpSessionWrapper {
             session: Arc::new(tokio::sync::Mutex::new(rtp_session)),
+            update_lock: Arc::new(tokio::sync::Mutex::new(())),
             local_addr: local_rtp_addr,
             remote_addr: config.remote_addr,
             created_at: std::time::Instant::now(),
@@ -1163,6 +1164,13 @@ impl MediaSessionController {
     pub async fn update_media(&self, dialog_id: DialogId, config: MediaConfig) -> Result<()> {
         info!("Updating media session for dialog: {}", dialog_id);
 
+        let update_lock = self
+            .rtp_sessions
+            .get(&dialog_id)
+            .map(|entry| Arc::clone(&entry.value().update_lock))
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+        let _update_guard = update_lock.lock().await;
+
         let old_config = self
             .sessions
             .get(&dialog_id)
@@ -1194,6 +1202,30 @@ impl MediaSessionController {
             .map(|entry| entry.value().session.clone())
             .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
 
+        // A generated-audio task owns one codec generation. Stop it only
+        // after the replacement runtime has been validated, then rebuild it
+        // against the new generation before publishing the update.
+        let transmitter_to_replace = if codec_changed {
+            self.rtp_sessions.get_mut(&dialog_id).and_then(|mut entry| {
+                entry
+                    .value_mut()
+                    .audio_transmitter
+                    .take()
+                    .map(|transmitter| {
+                        let config = transmitter.config().clone();
+                        (transmitter, config)
+                    })
+            })
+        } else {
+            None
+        };
+        let replacement_transmitter_config = transmitter_to_replace
+            .as_ref()
+            .map(|(_, config)| config.clone());
+        if let Some((transmitter, _)) = transmitter_to_replace {
+            transmitter.stop().await;
+        }
+
         {
             let mut rtp_session = rtp_session_arc.lock().await;
             if let Some(remote_addr) = config.remote_addr.filter(|_| remote_changed) {
@@ -1207,8 +1239,9 @@ impl MediaSessionController {
 
         // Commit the externally visible generation only after all validation
         // and lower-layer application succeeds.
-        if let Some(runtime) = replacement_runtime {
-            self.codec_runtimes.insert(dialog_id.clone(), runtime);
+        if let Some(runtime) = replacement_runtime.as_ref() {
+            self.codec_runtimes
+                .insert(dialog_id.clone(), Arc::clone(runtime));
         }
         if let Some(mut entry) = self.rtp_sessions.get_mut(&dialog_id) {
             entry.value_mut().remote_addr = config.remote_addr;
@@ -1219,6 +1252,22 @@ impl MediaSessionController {
             entry.value_mut().config = config.clone();
         } else {
             return Err(Error::session_not_found(dialog_id.as_str()));
+        }
+
+        if let (Some(transmitter_config), Some(runtime)) =
+            (replacement_transmitter_config, replacement_runtime)
+        {
+            let mut replacement = audio_generation::AudioTransmitter::new_with_config(
+                Arc::clone(&rtp_session_arc),
+                transmitter_config,
+                runtime,
+            );
+            replacement.start().await;
+            if let Some(mut entry) = self.rtp_sessions.get_mut(&dialog_id) {
+                entry.value_mut().audio_transmitter = Some(replacement);
+            } else {
+                return Err(Error::session_not_found(dialog_id.as_str()));
+            }
         }
 
         if let Some(remote_addr) = config.remote_addr.filter(|_| remote_changed) {

--- a/crates/media/media-core/src/relay/controller/mod.rs
+++ b/crates/media/media-core/src/relay/controller/mod.rs
@@ -22,11 +22,6 @@ use std::time::Instant;
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, error, info, trace, warn};
 
-#[cfg(feature = "g729")]
-use crate::codec::audio::common::AudioCodec;
-use crate::codec::audio::G711Codec;
-#[cfg(feature = "g729")]
-use crate::codec::audio::G729Codec;
 use crate::codec::mapping::CodecMapper;
 use crate::diagnostics;
 use crate::error::{Error, Result};
@@ -50,6 +45,8 @@ use rvoip_rtp_core::transport::{
 use rvoip_rtp_core::{
     RtpSession, RtpSessionBufferConfig, RtpSessionConfig, RtpTransportBufferConfig,
 };
+
+mod codec_runtime;
 
 /// Releases a media-controller port reservation if `start_media` is cancelled
 /// before ownership is committed to the controller maps.
@@ -83,47 +80,6 @@ impl Drop for MediaPortReservationGuard {
             });
         }
     }
-}
-
-#[cfg(feature = "g729")]
-fn decode_g729_payload_to_buffer(
-    decoder: &mut G729Codec,
-    payload: &[u8],
-    output: &mut Vec<i16>,
-) -> Result<usize> {
-    const G729_SAMPLES_PER_FRAME: usize = 80;
-    const G729_SPEECH_FRAME_BYTES: usize = 10;
-    const G729_SID_FRAME_BYTES: usize = 2;
-
-    let frame_count = if payload.is_empty() || payload.len() == G729_SID_FRAME_BYTES {
-        1
-    } else if payload.len() % G729_SPEECH_FRAME_BYTES == 0 {
-        payload.len() / G729_SPEECH_FRAME_BYTES
-    } else {
-        1
-    };
-    let needed = frame_count * G729_SAMPLES_PER_FRAME;
-    if output.len() < needed {
-        output.resize(needed, 0);
-    }
-
-    if payload.is_empty()
-        || payload.len() == G729_SID_FRAME_BYTES
-        || payload.len() % G729_SPEECH_FRAME_BYTES != 0
-    {
-        let frame = decoder.decode(payload)?;
-        output[..frame.samples.len()].copy_from_slice(&frame.samples);
-        return Ok(frame.samples.len());
-    }
-
-    let mut written = 0;
-    for chunk in payload.chunks_exact(G729_SPEECH_FRAME_BYTES) {
-        let frame = decoder.decode(chunk)?;
-        let end = written + frame.samples.len();
-        output[written..end].copy_from_slice(&frame.samples);
-        written = end;
-    }
-    Ok(written)
 }
 
 /// Controller-level capacity and pool tuning.
@@ -374,10 +330,10 @@ pub struct MediaSessionController {
     /// point for SIP hold/resume and remote direction changes.
     pub(super) media_directions: Arc<DashMap<DialogId, MediaDirection>>,
 
-    /// Per-dialog G.729 encoder state. G.729 is stateful, so unlike G.711 it
-    /// cannot be safely recreated for each outbound RTP packet.
-    #[cfg(feature = "g729")]
-    pub(super) g729_tx_codecs: Arc<DashMap<DialogId, Arc<tokio::sync::Mutex<G729Codec>>>>,
+    /// Exact negotiated codec identity and state for each dialog. Replacing
+    /// the `Arc` commits a codec update atomically for both transmit and
+    /// receive paths.
+    codec_runtimes: Arc<DashMap<DialogId, Arc<codec_runtime::DialogCodecRuntime>>>,
 
     /// RTP session queue sizing for new sessions.
     rtp_session_buffer_config: RtpSessionBufferConfig,
@@ -493,8 +449,7 @@ impl MediaSessionController {
             cn_gate_state: Arc::new(DashMap::with_capacity(capacity_hint)),
             comfort_noise_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             media_directions: Arc::new(DashMap::with_capacity(capacity_hint)),
-            #[cfg(feature = "g729")]
-            g729_tx_codecs: Arc::new(DashMap::with_capacity(capacity_hint)),
+            codec_runtimes: Arc::new(DashMap::with_capacity(capacity_hint)),
             rtp_session_buffer_config,
             rtp_transport_buffer_config,
             symmetric_rtp_policy: SymmetricRtpPolicy::default(),
@@ -820,8 +775,7 @@ impl MediaSessionController {
             cn_gate_state: Arc::new(DashMap::new()),
             comfort_noise_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             media_directions: Arc::new(DashMap::new()),
-            #[cfg(feature = "g729")]
-            g729_tx_codecs: Arc::new(DashMap::new()),
+            codec_runtimes: Arc::new(DashMap::new()),
             rtp_session_buffer_config: RtpSessionBufferConfig::default(),
             rtp_transport_buffer_config: RtpTransportBufferConfig::default(),
             symmetric_rtp_policy: SymmetricRtpPolicy::default(),
@@ -841,6 +795,14 @@ impl MediaSessionController {
             )));
         }
 
+        // Resolve and construct the complete codec generation before
+        // allocating a port or mutating any controller state. Unsupported,
+        // disabled, or malformed codec requests therefore fail atomically.
+        let codec_format = codec_runtime::resolve_codec(&config)?;
+        let codec_runtime = Arc::new(codec_runtime::DialogCodecRuntime::new(
+            codec_format.clone(),
+        )?);
+
         // Allocate RTP port using either our local allocator or the global one
         let allocator = if let Some(ref port_alloc) = self.port_allocator {
             // Use our custom port allocator with configured range
@@ -850,19 +812,8 @@ impl MediaSessionController {
             GlobalPortAllocator::instance().await
         };
 
-        // Determine payload type from preferred codec
-        let payload_type = config
-            .preferred_codec
-            .as_ref()
-            .and_then(|codec| self.codec_mapper.codec_to_payload(codec))
-            .unwrap_or(0); // Default to PCMU
-
-        // Determine clock rate based on codec
-        let clock_rate = config
-            .preferred_codec
-            .as_ref()
-            .map(|codec| self.codec_mapper.get_clock_rate(codec))
-            .unwrap_or(8000);
+        let payload_type = codec_format.payload_type;
+        let clock_rate = codec_format.clock_rate;
 
         let dialog_session_id = format!("dialog_{}", dialog_id);
         let mut last_bind_error: Option<rtp_core::Error> = None;
@@ -1014,6 +965,7 @@ impl MediaSessionController {
         );
         self.sessions.insert(dialog_id.clone(), session_info);
         self.rtp_sessions.insert(dialog_id.clone(), rtp_wrapper);
+        self.codec_runtimes.insert(dialog_id.clone(), codec_runtime);
         // The controller maps now own the RTP session and stop_media owns the
         // matching allocator release.
         reservation_guard.disarm();
@@ -1096,8 +1048,7 @@ impl MediaSessionController {
         self.audio_frame_callbacks.remove(dialog_id);
         self.dtmf_callbacks.remove(dialog_id);
         self.cn_gate_state.remove(dialog_id);
-        #[cfg(feature = "g729")]
-        self.g729_tx_codecs.remove(dialog_id);
+        self.codec_runtimes.remove(dialog_id);
 
         let media_id = MediaSessionId::from_dialog(dialog_id);
         if let Some((_, session_id)) = self.media_to_session.remove(&media_id) {
@@ -1212,132 +1163,91 @@ impl MediaSessionController {
     pub async fn update_media(&self, dialog_id: DialogId, config: MediaConfig) -> Result<()> {
         info!("Updating media session for dialog: {}", dialog_id);
 
-        // Update the session config and snapshot the old values for
-        // change detection. The shard guard is dropped at the end of
-        // this block.
-        let (old_remote, old_codec) = {
-            let mut entry = self
-                .sessions
-                .get_mut(&dialog_id)
-                .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
-            let session_info = entry.value_mut();
-            let old_remote = session_info.config.remote_addr;
-            let old_codec = session_info.config.preferred_codec.clone();
-            session_info.config = config.clone();
-            (old_remote, old_codec)
+        let old_config = self
+            .sessions
+            .get(&dialog_id)
+            .map(|entry| entry.value().config.clone())
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+        let old_runtime = self
+            .codec_runtimes
+            .get(&dialog_id)
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+
+        // Build replacement codec state before changing the RTP session or
+        // published configuration. Any unsupported codec or invalid shape
+        // leaves the preceding stable generation untouched.
+        let new_format = codec_runtime::resolve_codec(&config)?;
+        let codec_changed = old_runtime.format != new_format;
+        let replacement_runtime = if codec_changed {
+            Some(Arc::new(codec_runtime::DialogCodecRuntime::new(
+                new_format.clone(),
+            )?))
+        } else {
+            None
         };
+        let remote_changed = config.remote_addr != old_config.remote_addr;
 
-        // Extract the per-session Arc + update the wrapper's remote
-        // address in the same shard-guard scope. Drop the shard
-        // guard before we touch the RTP session itself.
-        let rtp_session_arc = {
-            let Some(mut entry) = self.rtp_sessions.get_mut(&dialog_id) else {
-                warn!(
-                    "No RTP session found for dialog {} during update",
-                    dialog_id
-                );
-                return Ok(());
-            };
-            let wrapper = entry.value_mut();
-            if config.remote_addr != old_remote {
-                wrapper.remote_addr = config.remote_addr;
-            }
-            wrapper.session.clone()
-        };
+        let rtp_session_arc = self
+            .rtp_sessions
+            .get(&dialog_id)
+            .map(|entry| entry.value().session.clone())
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
 
-        let mut updates_made = false;
-
-        // Apply remote-address change.
-        if config.remote_addr != old_remote {
-            if let Some(remote_addr) = config.remote_addr {
-                let mut rtp_session = rtp_session_arc.lock().await;
+        {
+            let mut rtp_session = rtp_session_arc.lock().await;
+            if let Some(remote_addr) = config.remote_addr.filter(|_| remote_changed) {
                 rtp_session.set_remote_addr(remote_addr).await;
-                drop(rtp_session);
-
-                info!(
-                    "✅ Updated RTP session remote address for dialog {}: {}",
-                    dialog_id, remote_addr
-                );
-                updates_made = true;
-
-                let _ = self.event_tx.send(MediaSessionEvent::RemoteAddressUpdated {
-                    dialog_id: dialog_id.clone(),
-                    remote_addr,
-                });
+            }
+            if codec_changed {
+                rtp_session.set_payload_type(new_format.payload_type);
+                rtp_session.set_clock_rate(new_format.clock_rate);
             }
         }
 
-        // Apply codec change.
-        if config.preferred_codec != old_codec {
-            #[cfg(feature = "g729")]
-            self.g729_tx_codecs.remove(&dialog_id);
+        // Commit the externally visible generation only after all validation
+        // and lower-layer application succeeds.
+        if let Some(runtime) = replacement_runtime {
+            self.codec_runtimes.insert(dialog_id.clone(), runtime);
+        }
+        if let Some(mut entry) = self.rtp_sessions.get_mut(&dialog_id) {
+            entry.value_mut().remote_addr = config.remote_addr;
+        } else {
+            return Err(Error::session_not_found(dialog_id.as_str()));
+        }
+        if let Some(mut entry) = self.sessions.get_mut(&dialog_id) {
+            entry.value_mut().config = config.clone();
+        } else {
+            return Err(Error::session_not_found(dialog_id.as_str()));
+        }
 
-            let new_payload_type = config
-                .preferred_codec
-                .as_ref()
-                .and_then(|codec| self.codec_mapper.codec_to_payload(codec))
-                .unwrap_or(0);
-            let new_clock_rate = config
-                .preferred_codec
-                .as_ref()
-                .map(|codec| self.codec_mapper.get_clock_rate(codec))
-                .unwrap_or(8000);
-
-            {
-                let mut rtp_session = rtp_session_arc.lock().await;
-                rtp_session.set_payload_type(new_payload_type);
-
-                if rtp_session.get_payload_type() != new_payload_type {
-                    warn!("Failed to update payload type for dialog {}", dialog_id);
-                } else {
-                    debug!(
-                        "Successfully updated payload type to {} for dialog {}",
-                        new_payload_type, dialog_id
-                    );
-                }
-
-                // TODO: Implement clock rate updates in rtp-core session
-                debug!(
-                    "Clock rate change noted for dialog {} ({}Hz), but full update requires rtp-core enhancement",
-                    dialog_id, new_clock_rate
-                );
-            }
-
-            updates_made = true;
-
-            // Log codec change with detailed information
-            let old_codec_name = old_codec.as_deref().unwrap_or("PCMU");
-            let new_codec_name = config.preferred_codec.as_deref().unwrap_or("PCMU");
-            let old_payload_type = old_codec
-                .as_ref()
-                .and_then(|codec| self.codec_mapper.codec_to_payload(codec))
-                .unwrap_or(0);
-            let old_clock_rate = old_codec
-                .as_ref()
-                .map(|codec| self.codec_mapper.get_clock_rate(codec))
-                .unwrap_or(8000);
-
+        if let Some(remote_addr) = config.remote_addr.filter(|_| remote_changed) {
+            let _ = self.event_tx.send(MediaSessionEvent::RemoteAddressUpdated {
+                dialog_id: dialog_id.clone(),
+                remote_addr,
+            });
+        }
+        if codec_changed {
             info!(
-                "🔄 Codec changed for dialog {}: {} -> {} (PT: {} -> {}, Clock: {}Hz -> {}Hz)",
+                "🔄 Codec changed for dialog {}: {} (PT {}, {}Hz) -> {} (PT {}, {}Hz)",
                 dialog_id,
-                old_codec_name,
-                new_codec_name,
-                old_payload_type,
-                new_payload_type,
-                old_clock_rate,
-                new_clock_rate
+                old_runtime.format.name,
+                old_runtime.format.payload_type,
+                old_runtime.format.clock_rate,
+                new_format.name,
+                new_format.payload_type,
+                new_format.clock_rate
             );
-
             let _ = self.event_tx.send(MediaSessionEvent::CodecChanged {
                 dialog_id: dialog_id.clone(),
-                old_codec: old_codec.clone(),
+                old_codec: old_config.preferred_codec.clone(),
                 new_codec: config.preferred_codec.clone(),
-                new_payload_type,
-                new_clock_rate,
+                new_payload_type: new_format.payload_type,
+                new_clock_rate: new_format.clock_rate,
             });
         }
 
-        if updates_made {
+        if remote_changed || codec_changed || config != old_config {
             info!(
                 "✅ Media session successfully updated for dialog: {}",
                 dialog_id
@@ -1445,7 +1355,7 @@ impl MediaSessionController {
     ) {
         let audio_frame_callbacks = self.audio_frame_callbacks.clone();
         let dtmf_callbacks = self.dtmf_callbacks.clone();
-        let _codec_mapper = self.codec_mapper.clone();
+        let codec_runtimes = self.codec_runtimes.clone();
         let media_directions = self.media_directions.clone();
 
         // RFC 4733 §2.5.1.3 retransmit dedup formerly lived here as a
@@ -1456,25 +1366,8 @@ impl MediaSessionController {
         // three E=1 retransmits before they are even decoded into a
         // typed `DtmfEvent`.
 
-        // Create G.711 codecs outside the loop for efficiency
-        let mut g711_ulaw = G711Codec::mu_law(8000, 1).expect("Failed to create μ-law codec");
-        let mut g711_alaw = G711Codec::a_law(8000, 1).expect("Failed to create A-law codec");
-        #[cfg(feature = "g729")]
-        let mut g729_decoder = G729Codec::new(
-            crate::types::SampleRate::Rate8000,
-            1,
-            crate::codec::audio::G729Config::default(),
-        )
-        .expect("Failed to create G.729 decoder");
-        let mut decode_buffer = vec![0i16; 160];
         let skip_audio_frame_delivery = perf_skip_audio_frame_delivery();
         let collect_audio_quality = diagnostics::audio_quality_enabled();
-
-        #[cfg(feature = "memory-diagnostics")]
-        let _decode_buffer_guard = rvoip_infra_common::memory_diagnostics::ObjectGuard::new(
-            "media_core.audio.rx.decode_reusable_buffer",
-            decode_buffer.capacity() * std::mem::size_of::<i16>(),
-        );
 
         spawn_memory_tracked("media_core.rtp_event_handler_task", async move {
             info!("🎧 Started RTP event handler for dialog: {}", dialog_id);
@@ -1494,6 +1387,22 @@ impl MediaSessionController {
                             rtp_core::session::RtpSessionEvent::PacketReceived(packet) => {
                                 rtp_count += 1;
                                 let packet_arrival = collect_audio_quality.then(Instant::now);
+                                let Some(codec_runtime) = codec_runtimes
+                                    .get(&dialog_id)
+                                    .map(|entry| entry.value().clone())
+                                else {
+                                    debug!("No codec runtime for dialog {}", dialog_id);
+                                    continue;
+                                };
+                                if packet.header.payload_type != codec_runtime.format.payload_type {
+                                    debug!(
+                                        "Ignoring unnegotiated payload type {} for dialog {} (expected {})",
+                                        packet.header.payload_type,
+                                        dialog_id,
+                                        codec_runtime.format.payload_type
+                                    );
+                                    continue;
+                                }
 
                                 if rtp_count % 10 == 0
                                     || rtp_count == 100
@@ -1545,8 +1454,8 @@ impl MediaSessionController {
                                             .timestamp
                                             .wrapping_sub(previous_timestamp)
                                             as f64;
-                                        let rtp_delta_ns =
-                                            rtp_delta_samples * 1_000_000_000_f64 / 8_000_f64;
+                                        let rtp_delta_ns = rtp_delta_samples * 1_000_000_000_f64
+                                            / f64::from(codec_runtime.format.clock_rate);
                                         let transit_delta = (arrival_delta - rtp_delta_ns).abs();
                                         jitter_ns += (transit_delta - jitter_ns) / 16.0;
                                     }
@@ -1563,78 +1472,20 @@ impl MediaSessionController {
                                     last_rtp_arrival = Some(arrival);
                                 }
 
-                                if decode_buffer.len() < packet.payload.len() {
-                                    let old_capacity = decode_buffer.capacity();
-                                    decode_buffer.resize(packet.payload.len(), 0);
-                                    let new_capacity = decode_buffer.capacity();
-                                    if new_capacity > old_capacity {
-                                        record_transient_allocation(
-                                            "media_core.audio.rx.decode_reusable_buffer_grow",
-                                            (new_capacity - old_capacity)
-                                                * std::mem::size_of::<i16>(),
-                                        );
-                                    }
-                                }
-
-                                // Decode based on payload type into a reusable per-handler buffer.
-                                let decoded_len = match packet.header.payload_type {
-                                    0 => {
-                                        // PCMU (μ-law)
-                                        match g711_ulaw.decode_to_buffer(
-                                            &packet.payload,
-                                            &mut decode_buffer[..packet.payload.len()],
-                                        ) {
-                                            Ok(samples) => samples,
-                                            Err(e) => {
-                                                warn!(
-                                                    "Failed to decode PCMU for dialog {}: {}",
-                                                    dialog_id, e
-                                                );
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                    8 => {
-                                        // PCMA (A-law)
-                                        match g711_alaw.decode_to_buffer(
-                                            &packet.payload,
-                                            &mut decode_buffer[..packet.payload.len()],
-                                        ) {
-                                            Ok(samples) => samples,
-                                            Err(e) => {
-                                                warn!(
-                                                    "Failed to decode PCMA for dialog {}: {}",
-                                                    dialog_id, e
-                                                );
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                    #[cfg(feature = "g729")]
-                                    18 => {
-                                        match decode_g729_payload_to_buffer(
-                                            &mut g729_decoder,
-                                            &packet.payload,
-                                            &mut decode_buffer,
-                                        ) {
-                                            Ok(samples) => samples,
-                                            Err(e) => {
-                                                warn!(
-                                                    "Failed to decode G.729 for dialog {}: {}",
-                                                    dialog_id, e
-                                                );
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                    _ => {
-                                        debug!(
-                                            "Unsupported payload type {} for dialog {}",
-                                            packet.header.payload_type, dialog_id
+                                let audio_frame = match codec_runtime
+                                    .decode(&packet.payload, packet.header.timestamp)
+                                    .await
+                                {
+                                    Ok(frame) => frame,
+                                    Err(error) => {
+                                        warn!(
+                                            "Failed to decode {} for dialog {}: {}",
+                                            codec_runtime.format.name, dialog_id, error
                                         );
                                         continue;
                                     }
                                 };
+                                let decoded_len = audio_frame.samples.len();
 
                                 let receive_enabled = media_directions
                                     .get(&dialog_id)
@@ -1673,13 +1524,10 @@ impl MediaSessionController {
                                     .map(|r| r.value().clone());
                                 if let Some(sender) = sender {
                                     decoded_audio_frame_count += 1;
-                                    let samples = decode_buffer[..decoded_len].to_vec();
                                     record_transient_allocation(
                                         "media_core.audio.rx.audio_frame.samples_vec",
-                                        samples.capacity() * std::mem::size_of::<i16>(),
+                                        audio_frame.samples.capacity() * std::mem::size_of::<i16>(),
                                     );
-                                    let audio_frame =
-                                        AudioFrame::new(samples, 8000, 1, packet.header.timestamp);
 
                                     // Use try_send to avoid blocking the RTP event handler
                                     match sender.try_send(audio_frame) {

--- a/crates/media/media-core/src/relay/controller/mod.rs
+++ b/crates/media/media-core/src/relay/controller/mod.rs
@@ -1212,7 +1212,7 @@ impl MediaSessionController {
                     .audio_transmitter
                     .take()
                     .map(|transmitter| {
-                        let config = transmitter.config().clone();
+                        let config = transmitter.replacement_config();
                         (transmitter, config)
                     })
             })

--- a/crates/media/media-core/src/relay/controller/rtp_management.rs
+++ b/crates/media/media-core/src/relay/controller/rtp_management.rs
@@ -97,7 +97,13 @@ impl MediaSessionController {
                 } else {
                     // Replace with a freshly-started transmitter.
                     let config = AudioTransmitterConfig::default();
-                    let mut replacement = AudioTransmitter::new_with_config(session, config);
+                    let runtime = self
+                        .codec_runtimes
+                        .get(dialog_id)
+                        .map(|entry| Arc::clone(entry.value()))
+                        .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+                    let mut replacement =
+                        AudioTransmitter::new_with_config(session, config, runtime);
                     replacement.start().await;
                     if let Some(mut entry) = self.rtp_sessions.get_mut(dialog_id) {
                         entry.value_mut().audio_transmitter = Some(replacement);
@@ -380,7 +386,7 @@ impl MediaSessionController {
         // Snapshot the per-session Arc + check the already-started
         // guard inside the shard guard, drop the guard, then build &
         // start the transmitter outside the lock.
-        let session_arc = {
+        let (session_arc, codec_runtime) = {
             let entry = self
                 .rtp_sessions
                 .get(dialog_id)
@@ -389,10 +395,16 @@ impl MediaSessionController {
             if wrapper.transmission_enabled && wrapper.audio_transmitter.is_some() {
                 return Ok(()); // Already started
             }
-            wrapper.session.clone()
+            let runtime = self
+                .codec_runtimes
+                .get(dialog_id)
+                .map(|entry| Arc::clone(entry.value()))
+                .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+            (wrapper.session.clone(), runtime)
         };
 
-        let mut audio_transmitter = AudioTransmitter::new_with_config(session_arc, config);
+        let mut audio_transmitter =
+            AudioTransmitter::new_with_config(session_arc, config, codec_runtime);
         audio_transmitter.start().await;
 
         // Re-acquire the shard guard to install the transmitter.

--- a/crates/media/media-core/src/relay/controller/rtp_management.rs
+++ b/crates/media/media-core/src/relay/controller/rtp_management.rs
@@ -18,80 +18,16 @@
 use bytes::Bytes;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
-use crate::codec::audio::common::AudioCodec;
 use crate::error::{Error, Result};
-use crate::types::{DialogId, MediaDirection};
+use crate::types::{AudioFrame, DialogId, MediaDirection};
 use rvoip_rtp_core::RtpSession;
 
 use super::{
     audio_generation::{AudioSource, AudioTransmitter, AudioTransmitterConfig},
     MediaSessionController,
 };
-
-#[cfg(feature = "g729")]
-fn g729_annex_b_enabled(codec_name: Option<&str>) -> bool {
-    match codec_name {
-        Some(name)
-            if name.eq_ignore_ascii_case("G729A")
-                || name.eq_ignore_ascii_case("G.729A")
-                || name.eq_ignore_ascii_case("G729 annex A") =>
-        {
-            false
-        }
-        Some(name)
-            if name.eq_ignore_ascii_case("G729BA")
-                || name.eq_ignore_ascii_case("G729AB")
-                || name.eq_ignore_ascii_case("G.729AB")
-                || name.eq_ignore_ascii_case("G.729BA") =>
-        {
-            true
-        }
-        _ => true,
-    }
-}
-
-#[cfg(feature = "g729")]
-fn g729_config(annex_b: bool) -> crate::codec::audio::G729Config {
-    crate::codec::audio::G729Config {
-        annexes: crate::codec::audio::G729Annexes {
-            annex_a: true,
-            annex_b,
-        },
-        frame_size_ms: 10.0,
-        enable_vad: annex_b,
-        enable_cng: annex_b,
-    }
-}
-
-#[cfg(feature = "g729")]
-fn encode_g729_payload(
-    codec: &mut crate::codec::audio::G729Codec,
-    audio_frame: &crate::types::AudioFrame,
-) -> Result<Vec<u8>> {
-    const G729_SAMPLES_PER_FRAME: usize = 80;
-
-    if audio_frame.samples.len() % G729_SAMPLES_PER_FRAME != 0 {
-        return Err(crate::error::CodecError::InvalidFrameSize {
-            expected: G729_SAMPLES_PER_FRAME,
-            actual: audio_frame.samples.len(),
-        }
-        .into());
-    }
-
-    let mut encoded = Vec::with_capacity(audio_frame.samples.len() / G729_SAMPLES_PER_FRAME * 10);
-    for chunk in audio_frame.samples.chunks_exact(G729_SAMPLES_PER_FRAME) {
-        let frame = crate::types::AudioFrame::new(
-            chunk.to_vec(),
-            audio_frame.sample_rate,
-            audio_frame.channels,
-            audio_frame.timestamp,
-        );
-        encoded.extend(codec.encode(&frame)?);
-    }
-    Ok(encoded)
-}
 
 impl MediaSessionController {
     /// Apply RTP/audio direction for SIP offer/answer changes.
@@ -203,6 +139,34 @@ impl MediaSessionController {
         payload: Vec<u8>,
         timestamp: u32,
     ) -> Result<()> {
+        self.send_rtp_packet_inner(dialog_id, payload, timestamp, None)
+            .await
+    }
+
+    /// Send an RTP packet with an explicit payload type from the same codec
+    /// generation that produced the encoded bytes.
+    ///
+    /// This prevents an in-flight frame from being relabeled if a concurrent
+    /// renegotiation changes the session's default payload type between encode
+    /// and enqueue.
+    pub async fn send_rtp_packet_with_payload_type(
+        &self,
+        dialog_id: &DialogId,
+        payload: Vec<u8>,
+        timestamp: u32,
+        payload_type: u8,
+    ) -> Result<()> {
+        self.send_rtp_packet_inner(dialog_id, payload, timestamp, Some(payload_type))
+            .await
+    }
+
+    async fn send_rtp_packet_inner(
+        &self,
+        dialog_id: &DialogId,
+        payload: Vec<u8>,
+        timestamp: u32,
+        payload_type: Option<u8>,
+    ) -> Result<()> {
         let rtp_session = self
             .get_rtp_session(dialog_id)
             .await
@@ -216,19 +180,27 @@ impl MediaSessionController {
 
         let payload_bytes = Bytes::from(payload);
         if let Some(handle) = send_handle {
-            handle
-                .send_packet(timestamp, payload_bytes, false)
-                .await
-                .map_err(|e| Error::config(format!("Failed to send RTP packet: {}", e)))?;
+            let result = if let Some(payload_type) = payload_type {
+                handle
+                    .send_packet_with_pt(timestamp, payload_bytes, false, payload_type)
+                    .await
+            } else {
+                handle.send_packet(timestamp, payload_bytes, false).await
+            };
+            result.map_err(|e| Error::config(format!("Failed to send RTP packet: {}", e)))?;
         } else {
             // Fallback: session has no scheduler (shouldn't happen in
             // production; see RtpSession::new). Lock and call send_packet
             // through the legacy path.
             let session = rtp_session.lock().await;
-            session
-                .send_packet(timestamp, payload_bytes, false)
-                .await
-                .map_err(|e| Error::config(format!("Failed to send RTP packet: {}", e)))?;
+            let result = if let Some(payload_type) = payload_type {
+                session
+                    .send_packet_with_pt(timestamp, payload_bytes, false, payload_type)
+                    .await
+            } else {
+                session.send_packet(timestamp, payload_bytes, false).await
+            };
+            result.map_err(|e| Error::config(format!("Failed to send RTP packet: {}", e)))?;
         }
 
         info!(
@@ -740,10 +712,34 @@ impl MediaSessionController {
         pcm_samples: Vec<i16>,
         timestamp: u32,
     ) -> Result<()> {
+        let runtime = self
+            .codec_runtimes
+            .get(dialog_id)
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+        self.encode_and_send_audio(
+            dialog_id,
+            AudioFrame::new(
+                pcm_samples,
+                runtime.format.clock_rate,
+                runtime.format.channels,
+                timestamp,
+            ),
+        )
+        .await
+    }
+
+    /// Encode and send a PCM frame without discarding its negotiated sample
+    /// rate or channel shape.
+    pub async fn encode_and_send_audio(
+        &self,
+        dialog_id: &DialogId,
+        audio_frame: AudioFrame,
+    ) -> Result<()> {
         info!(
             "🎯 encode_and_send_audio_frame called for dialog: {} with {} samples",
             dialog_id,
-            pcm_samples.len()
+            audio_frame.samples.len()
         );
 
         // Check if transmission is enabled and if audio is muted.
@@ -778,12 +774,23 @@ impl MediaSessionController {
         }
 
         // Replace with silence if muted
-        let pcm_samples = if is_muted {
+        let audio_frame = if is_muted {
             debug!("🔇 Audio muted for dialog: {}, sending silence", dialog_id);
-            vec![0i16; pcm_samples.len()] // PCM silence is zero
+            AudioFrame::new(
+                vec![0i16; audio_frame.samples.len()],
+                audio_frame.sample_rate,
+                audio_frame.channels,
+                audio_frame.timestamp,
+            )
         } else {
-            pcm_samples
+            audio_frame
         };
+
+        let codec_runtime = self
+            .codec_runtimes
+            .get(dialog_id)
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
 
         // Sprint 3.6 C1 follow-up — RFC 3389 Comfort Noise gating.
         // When CN is enabled at the controller level, run the
@@ -791,9 +798,10 @@ impl MediaSessionController {
         // whether to send the audio normally, suppress it (a recent
         // CN packet already covers this silence run), or emit one PT
         // 13 CN packet now and then suppress.
-        if self
-            .comfort_noise_enabled
-            .load(std::sync::atomic::Ordering::Relaxed)
+        if codec_runtime.format.clock_rate == 8_000
+            && self
+                .comfort_noise_enabled
+                .load(std::sync::atomic::Ordering::Relaxed)
         {
             // Build (or retrieve) the per-dialog gate. The gate's
             // CnTransmitter shares this dialog's RtpSession arc so PT
@@ -813,10 +821,9 @@ impl MediaSessionController {
                 gate_arc
             };
 
-            let frame = crate::types::AudioFrame::new(pcm_samples.clone(), 8000, 1, timestamp);
             let decision = {
                 let mut gate = gate_arc.lock().await;
-                gate.process_frame(&frame)
+                gate.process_frame(&audio_frame)
             };
             use crate::relay::controller::cn_gate::CnGateDecision;
             match decision {
@@ -847,78 +854,9 @@ impl MediaSessionController {
             }
         }
 
-        // Get session info to determine codec. DashMap shard guard
-        // is held only for the synchronous codec-mapper lookup.
-        info!("🔍 Looking for session for dialog: {}", dialog_id);
-        let (codec_payload_type, _preferred_codec) = self
-            .sessions
-            .get(dialog_id)
-            .ok_or_else(|| {
-                error!("❌ Session not found for dialog: {}", dialog_id);
-                Error::session_not_found(dialog_id.as_str())
-            })
-            .map(|entry| {
-                info!("✅ Found session for dialog: {}", dialog_id);
-                let preferred_codec = entry.value().config.preferred_codec.clone();
-                let pt = preferred_codec
-                    .as_ref()
-                    .and_then(|codec| self.codec_mapper.codec_to_payload(codec))
-                    .unwrap_or(0); // Default to PCMU
-                info!("📝 Using payload type {} for dialog: {}", pt, dialog_id);
-                (pt, preferred_codec)
-            })?;
-
-        // Create AudioFrame for codec interface
-        let audio_frame = crate::types::AudioFrame::new(
-            pcm_samples,
-            8000, // Default for G.711
-            1,    // Default mono
-            timestamp,
-        );
-
-        // Encode based on payload type
-        let encoded_payload = match codec_payload_type {
-            0 => {
-                // PCMU encoding using media-core's G711Codec. Per
-                // Phase C5: G711Codec is stateless, so we instantiate
-                // per call instead of through a shared tokio::Mutex
-                // (which serialised every encode in every session).
-                use crate::codec::audio::G711Codec;
-                let mut codec = G711Codec::mu_law(8000, 1)?;
-                codec.encode(&audio_frame)?
-            }
-            8 => {
-                // PCMA encoding - create temporary codec
-                use crate::codec::audio::G711Codec;
-                let mut codec = G711Codec::a_law(8000, 1)?;
-                codec.encode(&audio_frame)?
-            }
-            #[cfg(feature = "g729")]
-            18 => {
-                let annex_b = g729_annex_b_enabled(_preferred_codec.as_deref());
-                let codec = if let Some(existing) = self.g729_tx_codecs.get(dialog_id) {
-                    existing.value().clone()
-                } else {
-                    let codec = crate::codec::audio::G729Codec::new(
-                        crate::types::SampleRate::Rate8000,
-                        1,
-                        g729_config(annex_b),
-                    )?;
-                    let codec = Arc::new(tokio::sync::Mutex::new(codec));
-                    self.g729_tx_codecs.insert(dialog_id.clone(), codec.clone());
-                    codec
-                };
-                let mut codec = codec.lock().await;
-                encode_g729_payload(&mut codec, &audio_frame)?
-            }
-            #[cfg(not(feature = "g729"))]
-            18 => return Err(Error::unsupported_payload_type(codec_payload_type)),
-            _ => {
-                // For other codecs, we would need to instantiate them here
-                // For now, return an error
-                return Err(Error::unsupported_payload_type(codec_payload_type));
-            }
-        };
+        let timestamp = audio_frame.timestamp;
+        let codec_payload_type = codec_runtime.format.payload_type;
+        let encoded_payload = codec_runtime.encode(&audio_frame).await?;
 
         // Send the encoded packet via RTP
         info!(
@@ -926,8 +864,13 @@ impl MediaSessionController {
             dialog_id,
             encoded_payload.len()
         );
-        self.send_rtp_packet(dialog_id, encoded_payload, timestamp)
-            .await?;
+        self.send_rtp_packet_with_payload_type(
+            dialog_id,
+            encoded_payload,
+            timestamp,
+            codec_payload_type,
+        )
+        .await?;
 
         info!(
             "✅ Encoded and sent audio frame for dialog: {} (codec PT: {}, timestamp: {})",

--- a/crates/media/media-core/src/relay/controller/statistics.rs
+++ b/crates/media/media-core/src/relay/controller/statistics.rs
@@ -315,6 +315,7 @@ mod tests {
         controller.stop_media(&dialog_id).await.unwrap();
     }
 
+    #[cfg(feature = "opus")]
     #[tokio::test]
     async fn test_codec_statistics_opus() {
         let controller = create_test_controller().await;
@@ -398,11 +399,11 @@ mod tests {
             Some("PCMU".to_string())
         );
 
-        // Update to Opus codec
+        // Update to another always-available codec.
         let updated_config = MediaConfig {
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
             remote_addr: None,
-            preferred_codec: Some("Opus".to_string()),
+            preferred_codec: Some("PCMA".to_string()),
             parameters: HashMap::new(),
         };
 
@@ -415,7 +416,7 @@ mod tests {
         let updated_stats = controller.get_media_statistics(&dialog_id).await.unwrap();
         assert_eq!(
             updated_stats.media_stats.current_codec,
-            Some("Opus".to_string())
+            Some("PCMA".to_string())
         );
 
         // Cleanup
@@ -436,11 +437,11 @@ mod tests {
             parameters: HashMap::new(),
         };
 
-        // Configure second session with Opus
+        // Configure second session with another always-available codec.
         let config_2 = MediaConfig {
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
             remote_addr: None,
-            preferred_codec: Some("Opus".to_string()),
+            preferred_codec: Some("PCMA".to_string()),
             parameters: HashMap::new(),
         };
 
@@ -460,7 +461,7 @@ mod tests {
 
         // Verify each session has the correct codec
         assert_eq!(stats_1.media_stats.current_codec, Some("PCMU".to_string()));
-        assert_eq!(stats_2.media_stats.current_codec, Some("Opus".to_string()));
+        assert_eq!(stats_2.media_stats.current_codec, Some("PCMA".to_string()));
 
         // Cleanup
         controller.stop_media(&dialog_id_1).await.unwrap();

--- a/crates/media/media-core/src/relay/controller/tests.rs
+++ b/crates/media/media-core/src/relay/controller/tests.rs
@@ -1145,6 +1145,16 @@ mod tests {
             .start_audio_transmission_with_tone(&dialog_id)
             .await
             .unwrap();
+        controller
+            .set_audio_source(
+                &dialog_id,
+                AudioSource::CustomSamples {
+                    samples: vec![0x7f, 0xff],
+                    repeat: true,
+                },
+            )
+            .await
+            .unwrap();
         assert_eq!(
             controller
                 .rtp_sessions
@@ -1174,6 +1184,13 @@ mod tests {
         let transmitter = wrapper.audio_transmitter.as_ref().unwrap();
         assert_eq!(transmitter.codec_format().name, "PCMA");
         assert_eq!(transmitter.codec_format().payload_type, 8);
+        match transmitter.replacement_config().source {
+            AudioSource::CustomSamples { samples, repeat } => {
+                assert_eq!(samples, vec![0x7f, 0xff]);
+                assert!(repeat);
+            }
+            source => panic!("codec update replaced the current generated source: {source:?}"),
+        }
         drop(wrapper);
 
         #[cfg(feature = "opus")]

--- a/crates/media/media-core/src/relay/controller/tests.rs
+++ b/crates/media/media-core/src/relay/controller/tests.rs
@@ -201,6 +201,18 @@ mod tests {
             .await
             .expect("set audio callback");
 
+        let codec = codec_runtime::resolve_codec(&MediaConfig {
+            local_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            remote_addr: None,
+            preferred_codec: Some("PCMU".to_string()),
+            parameters: HashMap::new(),
+        })
+        .expect("resolve PCMU");
+        controller.codec_runtimes.insert(
+            dialog_id.clone(),
+            Arc::new(codec_runtime::DialogCodecRuntime::new(codec).expect("create PCMU runtime")),
+        );
+
         let (rtp_tx, rtp_rx) = tokio::sync::broadcast::channel(1);
         controller.spawn_rtp_event_handler(dialog_id, rtp_rx, 0);
         let timestamp = 0xf123_4567;
@@ -560,6 +572,7 @@ mod tests {
             .unwrap();
     }
 
+    #[cfg(feature = "opus")]
     #[tokio::test]
     async fn test_codec_negotiation_opus() {
         println!("🧪 Testing Opus codec negotiation");
@@ -605,9 +618,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_codec_negotiation_fallback() {
-        println!("🧪 Testing codec negotiation fallback for unknown codec");
-
+    async fn test_unknown_codec_fails_without_state_mutation() {
         let controller = MediaSessionController::new();
 
         let config = MediaConfig {
@@ -617,35 +628,19 @@ mod tests {
             parameters: HashMap::new(),
         };
 
-        // Start session with unknown codec (should fallback to PCMU)
         let result = controller
             .start_media(DialogId::new("fallback_dialog"), config)
             .await;
-        assert!(
-            result.is_ok(),
-            "Should successfully start session even with unknown codec"
-        );
-
-        // Verify session was created and stored the original codec name
-        let session_info = controller
+        assert!(matches!(
+            result,
+            Err(Error::Codec(
+                crate::error::CodecError::UnsupportedCodec { .. }
+            ))
+        ));
+        assert!(controller
             .get_session_info(&DialogId::new("fallback_dialog"))
-            .await;
-        assert!(session_info.is_some());
-        let session_info = session_info.unwrap();
-
-        // Check that the original preferred codec is stored (even though it's unknown)
-        assert_eq!(
-            session_info.config.preferred_codec,
-            Some("unknown_codec".to_string())
-        );
-
-        println!("✅ Codec negotiation fallback test completed");
-
-        // Cleanup
-        controller
-            .stop_media(&DialogId::new("fallback_dialog"))
             .await
-            .unwrap();
+            .is_none());
     }
 
     #[tokio::test]
@@ -696,14 +691,13 @@ mod tests {
         let controller = MediaSessionController::new();
 
         // Test different case variations
-        let test_cases = vec![
-            ("pcmu", "pcmu"),
-            ("PCMU", "PCMU"),
-            ("PcMu", "PcMu"),
-            ("opus", "opus"),
-            ("Opus", "Opus"),
-            ("OPUS", "OPUS"),
-        ];
+        let test_cases = vec![("pcmu", "pcmu"), ("PCMU", "PCMU"), ("PcMu", "PcMu")];
+        #[cfg(feature = "opus")]
+        let test_cases = {
+            let mut test_cases = test_cases;
+            test_cases.extend([("opus", "opus"), ("Opus", "Opus"), ("OPUS", "OPUS")]);
+            test_cases
+        };
 
         for (i, (codec_name, expected_stored)) in test_cases.into_iter().enumerate() {
             let dialog_id = format!("case_test_{}", i);
@@ -908,6 +902,7 @@ mod tests {
             ("PCMA", 8, 8000, "G.711 A-law"),
             #[cfg(feature = "g729")]
             ("G729", 18, 8000, "G.729"),
+            #[cfg(feature = "opus")]
             ("opus", 111, 48000, "Opus"),
         ];
 
@@ -958,6 +953,7 @@ mod tests {
         println!("   All RFC 3551 static codecs and Opus tested successfully!");
     }
 
+    #[cfg(feature = "opus")]
     #[tokio::test]
     async fn test_update_media_codec_change() {
         println!("🧪 Testing codec change in update_media");
@@ -1038,7 +1034,7 @@ mod tests {
         let updated_config = MediaConfig {
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
             remote_addr: Some(remote_addr),
-            preferred_codec: Some("opus".to_string()),
+            preferred_codec: Some("PCMA".to_string()),
             parameters: HashMap::new(),
         };
 
@@ -1055,7 +1051,7 @@ mod tests {
         assert!(session_info.is_some());
         let info = session_info.unwrap();
         assert_eq!(info.config.remote_addr, Some(remote_addr));
-        assert_eq!(info.config.preferred_codec, Some("opus".to_string()));
+        assert_eq!(info.config.preferred_codec, Some("PCMA".to_string()));
 
         println!("✅ Combined change test completed successfully!");
     }
@@ -1091,5 +1087,136 @@ mod tests {
         );
 
         println!("✅ No-change update test completed successfully!");
+    }
+
+    #[cfg(not(feature = "opus"))]
+    #[tokio::test]
+    async fn disabled_opus_start_and_update_fail_atomically() {
+        let controller = MediaSessionController::new();
+        let dialog_id = DialogId::new("disabled-opus");
+        let base = MediaConfig {
+            local_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            remote_addr: None,
+            preferred_codec: Some("PCMU".to_string()),
+            parameters: HashMap::new(),
+        };
+        controller
+            .start_media(dialog_id.clone(), base.clone())
+            .await
+            .unwrap();
+
+        let mut unsupported = base;
+        unsupported.remote_addr = Some(SocketAddr::from(([203, 0, 113, 10], 9_999)));
+        unsupported.preferred_codec = Some("OpUs".to_string());
+        assert!(matches!(
+            controller
+                .update_media(dialog_id.clone(), unsupported)
+                .await,
+            Err(Error::Codec(
+                crate::error::CodecError::UnsupportedCodec { .. }
+            ))
+        ));
+        let stable = controller.get_session_info(&dialog_id).await.unwrap();
+        assert_eq!(stable.config.preferred_codec.as_deref(), Some("PCMU"));
+        assert_eq!(stable.config.remote_addr, None);
+    }
+
+    #[tokio::test]
+    async fn g722_is_explicitly_unsupported() {
+        let controller = MediaSessionController::new();
+        let dialog_id = DialogId::new("g722-unsupported");
+        let config = MediaConfig {
+            local_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            remote_addr: None,
+            preferred_codec: Some("G.722".to_string()),
+            parameters: HashMap::new(),
+        };
+        assert!(matches!(
+            controller.start_media(dialog_id.clone(), config).await,
+            Err(Error::Codec(
+                crate::error::CodecError::UnsupportedCodec { .. }
+            ))
+        ));
+        assert!(controller.get_session_info(&dialog_id).await.is_none());
+    }
+
+    #[cfg(feature = "opus")]
+    #[tokio::test]
+    async fn controller_opus_rtp_round_trip_uses_negotiated_payload_and_clock() {
+        let controller = MediaSessionController::with_port_range(31_000, 31_100);
+        let sender = DialogId::new("opus-wire-sender");
+        let receiver = DialogId::new("opus-wire-receiver");
+        let base = |codec: &str| {
+            MediaConfig {
+                local_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+                remote_addr: None,
+                preferred_codec: None,
+                parameters: HashMap::new(),
+            }
+            .with_negotiated_audio_codec(codec, 96, 48_000, 1)
+        };
+        controller
+            .start_media(sender.clone(), base("Opus"))
+            .await
+            .unwrap();
+        controller
+            .start_media(receiver.clone(), base("OPUS"))
+            .await
+            .unwrap();
+        let sender_port = controller
+            .get_session_info(&sender)
+            .await
+            .unwrap()
+            .rtp_port
+            .unwrap();
+        let receiver_port = controller
+            .get_session_info(&receiver)
+            .await
+            .unwrap()
+            .rtp_port
+            .unwrap();
+
+        let mut sender_config = base("opus");
+        sender_config.remote_addr = Some(SocketAddr::from(([127, 0, 0, 1], receiver_port)));
+        controller
+            .update_media(sender.clone(), sender_config)
+            .await
+            .unwrap();
+        let mut receiver_config = base("opus");
+        receiver_config.remote_addr = Some(SocketAddr::from(([127, 0, 0, 1], sender_port)));
+        controller
+            .update_media(receiver.clone(), receiver_config)
+            .await
+            .unwrap();
+
+        let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel(4);
+        controller
+            .set_audio_frame_callback(receiver.clone(), frame_tx)
+            .await
+            .unwrap();
+
+        for timestamp in [0, 960] {
+            let samples = (0..960)
+                .map(|index| (((index as f32 / 20.0).sin()) * 8_000.0) as i16)
+                .collect();
+            controller
+                .encode_and_send_audio(&sender, AudioFrame::new(samples, 48_000, 1, timestamp))
+                .await
+                .unwrap();
+        }
+
+        for expected_timestamp in [0, 960] {
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(2), frame_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(frame.sample_rate, 48_000);
+            assert_eq!(frame.channels, 1);
+            assert_eq!(frame.samples.len(), 960);
+            assert_eq!(frame.timestamp, expected_timestamp);
+        }
+
+        controller.stop_media(&sender).await.unwrap();
+        controller.stop_media(&receiver).await.unwrap();
     }
 }

--- a/crates/media/media-core/src/relay/controller/tests.rs
+++ b/crates/media/media-core/src/relay/controller/tests.rs
@@ -1057,6 +1057,150 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_media_waits_for_the_dialog_generation_lock() {
+        let controller = Arc::new(MediaSessionController::new());
+        let dialog_id = DialogId::new("serialized_codec_update");
+        controller
+            .start_media(
+                dialog_id.clone(),
+                MediaConfig {
+                    local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    remote_addr: None,
+                    preferred_codec: Some("PCMU".to_string()),
+                    parameters: HashMap::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let update_lock = controller
+            .rtp_sessions
+            .get(&dialog_id)
+            .map(|wrapper| Arc::clone(&wrapper.update_lock))
+            .unwrap();
+        let guard = update_lock.lock().await;
+        let updating = {
+            let controller = Arc::clone(&controller);
+            let dialog_id = dialog_id.clone();
+            tokio::spawn(async move {
+                controller
+                    .update_media(
+                        dialog_id,
+                        MediaConfig {
+                            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                            remote_addr: None,
+                            preferred_codec: Some("PCMA".to_string()),
+                            parameters: HashMap::new(),
+                        },
+                    )
+                    .await
+            })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !updating.is_finished(),
+            "a second codec generation must not pass the dialog update lock"
+        );
+        drop(guard);
+        updating.await.unwrap().unwrap();
+
+        let config = controller.sessions.get(&dialog_id).unwrap().config.clone();
+        let runtime_format = controller
+            .codec_runtimes
+            .get(&dialog_id)
+            .unwrap()
+            .format
+            .clone();
+        let session = controller
+            .rtp_sessions
+            .get(&dialog_id)
+            .unwrap()
+            .session
+            .clone();
+        assert_eq!(config.preferred_codec.as_deref(), Some("PCMA"));
+        assert_eq!(runtime_format.name, "PCMA");
+        assert_eq!(session.lock().await.get_payload_type(), 8);
+        controller.stop_media(&dialog_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn codec_update_rebuilds_generated_audio_transmitter() {
+        let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let remote_addr = peer.local_addr().unwrap();
+        let controller = MediaSessionController::new();
+        let dialog_id = DialogId::new("generated_audio_codec_update");
+        controller
+            .start_media(
+                dialog_id.clone(),
+                MediaConfig {
+                    local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    remote_addr: Some(remote_addr),
+                    preferred_codec: Some("PCMU".to_string()),
+                    parameters: HashMap::new(),
+                },
+            )
+            .await
+            .unwrap();
+        controller
+            .start_audio_transmission_with_tone(&dialog_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            controller
+                .rtp_sessions
+                .get(&dialog_id)
+                .unwrap()
+                .audio_transmitter
+                .as_ref()
+                .unwrap()
+                .codec_format()
+                .payload_type,
+            0
+        );
+
+        controller
+            .update_media(
+                dialog_id.clone(),
+                MediaConfig {
+                    local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    remote_addr: Some(remote_addr),
+                    preferred_codec: Some("PCMA".to_string()),
+                    parameters: HashMap::new(),
+                },
+            )
+            .await
+            .unwrap();
+        let wrapper = controller.rtp_sessions.get(&dialog_id).unwrap();
+        let transmitter = wrapper.audio_transmitter.as_ref().unwrap();
+        assert_eq!(transmitter.codec_format().name, "PCMA");
+        assert_eq!(transmitter.codec_format().payload_type, 8);
+        drop(wrapper);
+
+        #[cfg(feature = "opus")]
+        {
+            controller
+                .update_media(
+                    dialog_id.clone(),
+                    MediaConfig {
+                        local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                        remote_addr: Some(remote_addr),
+                        preferred_codec: Some("opus".to_string()),
+                        parameters: HashMap::new(),
+                    }
+                    .with_negotiated_audio_codec("opus", 96, 48_000, 2),
+                )
+                .await
+                .unwrap();
+            let wrapper = controller.rtp_sessions.get(&dialog_id).unwrap();
+            let transmitter = wrapper.audio_transmitter.as_ref().unwrap();
+            assert_eq!(transmitter.codec_format().name, "opus");
+            assert_eq!(transmitter.codec_format().payload_type, 96);
+            assert_eq!(transmitter.codec_format().clock_rate, 48_000);
+        }
+        controller.stop_media(&dialog_id).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_update_media_no_changes() {
         println!("🧪 Testing update_media with no actual changes");
 

--- a/crates/media/media-core/src/relay/controller/types.rs
+++ b/crates/media/media-core/src/relay/controller/types.rs
@@ -247,6 +247,9 @@ pub struct AdvancedProcessorSet {
 pub struct RtpSessionWrapper {
     /// The actual RTP session
     pub session: Arc<tokio::sync::Mutex<RtpSession>>,
+    /// Serializes media configuration generations for this dialog. The guard
+    /// is cloned out of the map before awaiting so no DashMap shard is held.
+    pub(super) update_lock: Arc<tokio::sync::Mutex<()>>,
     /// Local RTP address
     pub local_addr: SocketAddr,
     /// Remote RTP address (if known)

--- a/crates/media/media-core/src/relay/controller/types.rs
+++ b/crates/media/media-core/src/relay/controller/types.rs
@@ -16,8 +16,15 @@ use crate::processing::audio::{
 use crate::types::DialogId;
 use rvoip_rtp_core::{session::RtpSessionStats, RtpSession};
 
+/// `MediaConfig::parameters` key carrying the negotiated RTP payload type.
+pub const RTP_PAYLOAD_TYPE_PARAMETER: &str = "rtp_payload_type";
+/// `MediaConfig::parameters` key carrying the negotiated RTP clock rate.
+pub const RTP_CLOCK_RATE_PARAMETER: &str = "rtp_clock_rate";
+/// `MediaConfig::parameters` key carrying the negotiated audio channel count.
+pub const AUDIO_CHANNELS_PARAMETER: &str = "audio_channels";
+
 /// Media configuration for a session
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MediaConfig {
     /// Local RTP address
     pub local_addr: SocketAddr,
@@ -27,6 +34,46 @@ pub struct MediaConfig {
     pub preferred_codec: Option<String>,
     /// Additional media parameters
     pub parameters: HashMap<String, String>,
+}
+
+impl MediaConfig {
+    /// Attach the exact negotiated RTP identity to a media configuration.
+    ///
+    /// Keeping these values in the existing parameter map preserves source
+    /// compatibility for callers that construct `MediaConfig` with a struct
+    /// literal while allowing dynamic codecs such as Opus to use any payload
+    /// type selected by SDP.
+    pub fn with_negotiated_audio_codec(
+        mut self,
+        codec: impl Into<String>,
+        payload_type: u8,
+        clock_rate: u32,
+        channels: u8,
+    ) -> Self {
+        self.preferred_codec = Some(codec.into());
+        self.parameters.insert(
+            RTP_PAYLOAD_TYPE_PARAMETER.to_string(),
+            payload_type.to_string(),
+        );
+        self.parameters
+            .insert(RTP_CLOCK_RATE_PARAMETER.to_string(), clock_rate.to_string());
+        self.parameters
+            .insert(AUDIO_CHANNELS_PARAMETER.to_string(), channels.to_string());
+        self
+    }
+}
+
+/// Exact audio codec parameters used by one media dialog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NegotiatedAudioCodec {
+    /// Canonical codec name.
+    pub name: String,
+    /// Negotiated RTP payload type.
+    pub payload_type: u8,
+    /// RTP clock and PCM sample rate in hertz.
+    pub clock_rate: u32,
+    /// Number of interleaved PCM channels.
+    pub channels: u8,
 }
 
 /// Media session status

--- a/crates/media/media-core/src/rtp_processing/codec/negotiation.rs
+++ b/crates/media/media-core/src/rtp_processing/codec/negotiation.rs
@@ -74,7 +74,7 @@ impl CodecCapability {
     /// Check if this capability is compatible with another
     pub fn is_compatible_with(&self, other: &CodecCapability) -> bool {
         // Must be same codec
-        if self.codec.name != other.codec.name {
+        if !codec_names_equal(&self.codec.name, &other.codec.name) {
             return false;
         }
 
@@ -118,19 +118,25 @@ pub struct NegotiationPreferences {
 
 impl Default for NegotiationPreferences {
     fn default() -> Self {
+        let preferred_codecs = vec![
+            "PCMU".to_string(),
+            "PCMA".to_string(),
+            "H264".to_string(),
+            "VP8".to_string(),
+        ];
+        #[cfg(feature = "opus")]
+        let preferred_codecs = {
+            let mut codecs = preferred_codecs;
+            codecs.insert(0, "OPUS".to_string());
+            codecs
+        };
+
         Self {
             prefer_audio: true,
             max_codecs: 5,
             prefer_low_bandwidth: false,
             min_quality_factor: 0.3,
-            preferred_codecs: vec![
-                "OPUS".to_string(),
-                "G722".to_string(),
-                "PCMU".to_string(),
-                "PCMA".to_string(),
-                "H264".to_string(),
-                "VP8".to_string(),
-            ],
+            preferred_codecs,
         }
     }
 }
@@ -180,6 +186,9 @@ impl CodecNegotiator {
         let mut compatible_pairs = Vec::new();
 
         for local_cap in &self.local_capabilities {
+            if !codec_is_negotiable(&local_cap.codec.name) {
+                continue;
+            }
             for remote_cap in &self.remote_capabilities {
                 if local_cap.is_compatible_with(remote_cap) {
                     compatible_pairs.push((local_cap, remote_cap));
@@ -239,7 +248,7 @@ impl CodecNegotiator {
             .preferences
             .preferred_codecs
             .iter()
-            .position(|name| name == &local.codec.name)
+            .position(|name| codec_names_equal(name, &local.codec.name))
         {
             score += 1.0 - (pos as f32 / self.preferences.preferred_codecs.len() as f32);
         }
@@ -331,7 +340,8 @@ impl CodecNegotiator {
         let registry = get_global_registry();
         let mut capabilities = Vec::new();
 
-        // Add OPUS capability (high quality)
+        // Opus is negotiable only when the real backend is compiled in.
+        #[cfg(feature = "opus")]
         if let Some(opus_info) = registry.get_payload_info(111) {
             let codec = MediaCodec::new(opus_info.codec_name.clone(), 111, opus_info.clock_rate)
                 .with_channels(2);
@@ -339,17 +349,6 @@ impl CodecNegotiator {
                 CodecCapability::new(codec, MediaDirection::SendReceive)
                     .with_quality_factor(0.9)
                     .with_bitrate_range(32000, 128000),
-            );
-        }
-
-        // Add G.722 capability (good quality)
-        if let Some(g722_info) = registry.get_payload_info(9) {
-            let codec = MediaCodec::new(g722_info.codec_name.clone(), 9, g722_info.clock_rate)
-                .with_channels(1);
-            capabilities.push(
-                CodecCapability::new(codec, MediaDirection::SendReceive)
-                    .with_quality_factor(0.7)
-                    .with_bitrate_range(48000, 64000),
             );
         }
 
@@ -408,6 +407,26 @@ impl CodecNegotiator {
     }
 }
 
+fn codec_names_equal(left: &str, right: &str) -> bool {
+    left.chars()
+        .filter(|character| *character != '.')
+        .map(|character| character.to_ascii_uppercase())
+        .eq(right
+            .chars()
+            .filter(|character| *character != '.')
+            .map(|character| character.to_ascii_uppercase()))
+}
+
+fn codec_is_negotiable(name: &str) -> bool {
+    if codec_names_equal(name, "G722") {
+        return false;
+    }
+    if codec_names_equal(name, "OPUS") {
+        return cfg!(feature = "opus");
+    }
+    true
+}
+
 impl Default for CodecNegotiator {
     fn default() -> Self {
         Self::new()
@@ -435,6 +454,19 @@ mod tests {
     }
 
     #[test]
+    fn test_codec_capability_names_are_case_and_dot_insensitive() {
+        let local = CodecCapability::new(
+            MediaCodec::new("h.264".to_string(), 96, 90000),
+            MediaDirection::SendOnly,
+        );
+        let remote = CodecCapability::new(
+            MediaCodec::new("H264".to_string(), 96, 90000),
+            MediaDirection::ReceiveOnly,
+        );
+        assert!(local.is_compatible_with(&remote));
+    }
+
+    #[test]
     fn test_codec_capability_incompatibility() {
         let opus_cap = CodecCapability::new(
             MediaCodec::new("OPUS".to_string(), 111, 48000),
@@ -449,6 +481,7 @@ mod tests {
         assert!(!opus_cap.is_compatible_with(&pcmu_cap));
     }
 
+    #[cfg(feature = "opus")]
     #[test]
     fn test_negotiation() {
         let mut negotiator = CodecNegotiator::new();
@@ -503,5 +536,39 @@ mod tests {
         let codec_names: Vec<&str> = audio_caps.iter().map(|c| c.codec.name.as_str()).collect();
         assert!(codec_names.contains(&"PCMU"));
         assert!(codec_names.contains(&"PCMA"));
+        assert!(!codec_names.contains(&"G722"));
+        #[cfg(feature = "opus")]
+        assert!(codec_names.contains(&"OPUS"));
+        #[cfg(not(feature = "opus"))]
+        assert!(!codec_names.contains(&"OPUS"));
+    }
+
+    #[cfg(not(feature = "opus"))]
+    #[test]
+    fn test_opus_cannot_be_negotiated_without_backend() {
+        let mut negotiator = CodecNegotiator::new();
+        let capability = || {
+            CodecCapability::new(
+                MediaCodec::new("Opus".to_string(), 111, 48_000),
+                MediaDirection::SendReceive,
+            )
+        };
+        negotiator.add_local_capability(capability());
+        negotiator.add_remote_capability(capability());
+        assert!(negotiator.negotiate().is_err());
+    }
+
+    #[test]
+    fn test_g722_is_not_a_negotiable_codec() {
+        let capability = || {
+            CodecCapability::new(
+                MediaCodec::new("G.722".to_string(), 9, 8_000),
+                MediaDirection::SendReceive,
+            )
+        };
+        let mut negotiator = CodecNegotiator::new();
+        negotiator.add_local_capability(capability());
+        negotiator.add_remote_capability(capability());
+        assert!(negotiator.negotiate().is_err());
     }
 }

--- a/crates/media/media-core/src/rtp_processing/codec/negotiation.rs
+++ b/crates/media/media-core/src/rtp_processing/codec/negotiation.rs
@@ -78,6 +78,15 @@ impl CodecCapability {
             return false;
         }
 
+        // RTP clock rates and audio channel counts are part of a codec's
+        // encoding identity. Choosing the smaller value would describe a
+        // format neither endpoint actually advertised.
+        if self.codec.clock_rate != other.codec.clock_rate
+            || (self.codec.is_audio() && self.codec.channels != other.codec.channels)
+        {
+            return false;
+        }
+
         // Check direction compatibility
         match (self.direction, other.direction) {
             (MediaDirection::SendOnly, MediaDirection::ReceiveOnly) => true,
@@ -293,17 +302,19 @@ impl CodecNegotiator {
         remote: &CodecCapability,
     ) -> Result<NegotiationResult, MediaError> {
         // Create negotiated codec
-        let mut codec = local.codec.clone();
+        let codec = local.codec.clone();
 
-        // Negotiate clock rate (use minimum of both)
-        if local.codec.clock_rate != remote.codec.clock_rate {
-            codec.clock_rate = local.codec.clock_rate.min(remote.codec.clock_rate);
-            debug!("Negotiated clock rate: {} Hz", codec.clock_rate);
-        }
-
-        // Negotiate channels (use minimum for audio)
-        if let (Some(local_ch), Some(remote_ch)) = (local.codec.channels, remote.codec.channels) {
-            codec.channels = Some(local_ch.min(remote_ch));
+        if local.codec.clock_rate != remote.codec.clock_rate
+            || (local.codec.is_audio() && local.codec.channels != remote.codec.channels)
+        {
+            return Err(MediaError::ConfigError(format!(
+                "Codec shape mismatch for {}: local {}Hz/{:?}ch, remote {}Hz/{:?}ch",
+                codec.name,
+                local.codec.clock_rate,
+                local.codec.channels,
+                remote.codec.clock_rate,
+                remote.codec.channels
+            )));
         }
 
         // Negotiate parameters
@@ -489,6 +500,18 @@ mod tests {
         );
 
         assert!(!opus_cap.is_compatible_with(&pcmu_cap));
+    }
+
+    #[test]
+    fn matching_name_with_different_rate_or_channels_is_incompatible() {
+        let capability = |rate, channels| {
+            CodecCapability::new(
+                MediaCodec::new("Opus".to_string(), 111, rate).with_channels(channels),
+                MediaDirection::SendReceive,
+            )
+        };
+        assert!(!capability(48_000, 2).is_compatible_with(&capability(16_000, 2)));
+        assert!(!capability(48_000, 2).is_compatible_with(&capability(48_000, 1)));
     }
 
     #[cfg(feature = "opus")]

--- a/crates/media/media-core/src/rtp_processing/codec/negotiation.rs
+++ b/crates/media/media-core/src/rtp_processing/codec/negotiation.rs
@@ -159,7 +159,11 @@ impl CodecNegotiator {
 
     /// Add local codec capability
     pub fn add_local_capability(&mut self, capability: CodecCapability) {
-        self.local_capabilities.push(capability);
+        if !capability.codec.is_audio()
+            || crate::codec::audio_codec_available(&capability.codec.name)
+        {
+            self.local_capabilities.push(capability);
+        }
     }
 
     /// Add remote codec capability
@@ -169,7 +173,13 @@ impl CodecNegotiator {
 
     /// Set local capabilities from a list
     pub fn set_local_capabilities(&mut self, capabilities: Vec<CodecCapability>) {
-        self.local_capabilities = capabilities;
+        self.local_capabilities = capabilities
+            .into_iter()
+            .filter(|capability| {
+                !capability.codec.is_audio()
+                    || crate::codec::audio_codec_available(&capability.codec.name)
+            })
+            .collect();
     }
 
     /// Set remote capabilities from a list

--- a/crates/media/media-core/src/rtp_processing/codec/sdp.rs
+++ b/crates/media/media-core/src/rtp_processing/codec/sdp.rs
@@ -503,7 +503,7 @@ impl SdpMediaProcessor {
 
     /// Estimate codec quality factor
     fn estimate_codec_quality(&self, codec_name: &str) -> f32 {
-        match codec_name.to_uppercase().as_str() {
+        match codec_name.to_ascii_uppercase().replace('.', "").as_str() {
             "OPUS" => 0.9,
             "G722" => 0.7,
             "PCMU" | "PCMA" => 0.5,
@@ -604,5 +604,23 @@ mod tests {
         assert!(text.contains("m=audio 5004 RTP/AVP 0"));
         assert!(text.contains("a=sendrecv"));
         assert!(text.contains("a=rtpmap:0 PCMU/8000/1"));
+    }
+
+    #[test]
+    fn default_sdp_only_advertises_implemented_audio_codecs() {
+        let processor = SdpMediaProcessor::new();
+        let capabilities = CodecNegotiator::create_default_audio_capabilities();
+        let description = processor
+            .capabilities_to_sdp(&capabilities, "audio", 5004)
+            .unwrap();
+        let text = processor.generate_sdp_text(&description);
+
+        assert!(text.contains("PCMU"));
+        assert!(text.contains("PCMA"));
+        assert!(!text.to_ascii_uppercase().contains("G722"));
+        #[cfg(feature = "opus")]
+        assert!(text.to_ascii_uppercase().contains("OPUS"));
+        #[cfg(not(feature = "opus"))]
+        assert!(!text.to_ascii_uppercase().contains("OPUS"));
     }
 }

--- a/crates/media/media-core/src/rtp_processing/codec/sdp.rs
+++ b/crates/media/media-core/src/rtp_processing/codec/sdp.rs
@@ -359,6 +359,11 @@ impl SdpMediaProcessor {
                     || crate::codec::audio_codec_available(&capability.codec.name)
             })
             .collect();
+        if capabilities.is_empty() {
+            return Err(MediaError::ConfigError(format!(
+                "No available {media_type} codecs remain after capability filtering"
+            )));
+        }
         let payload_types: Vec<u8> = capabilities
             .iter()
             .map(|capability| capability.codec.payload_type)
@@ -660,5 +665,18 @@ mod tests {
         #[cfg(not(feature = "opus"))]
         assert!(!description.media_line.payload_types.contains(&111));
         assert!(description.media_line.payload_types.contains(&0));
+    }
+
+    #[test]
+    fn filtered_audio_capabilities_cannot_create_an_empty_media_line() {
+        let processor = SdpMediaProcessor::new();
+        let unsupported = [CodecCapability::new(
+            MediaCodec::new("G722".to_string(), 9, 8_000).with_channels(1),
+            MediaDirection::SendOnly,
+        )];
+        assert!(matches!(
+            processor.capabilities_to_sdp(&unsupported, "audio", 5_004),
+            Err(MediaError::ConfigError(_))
+        ));
     }
 }

--- a/crates/media/media-core/src/rtp_processing/codec/sdp.rs
+++ b/crates/media/media-core/src/rtp_processing/codec/sdp.rs
@@ -352,7 +352,17 @@ impl SdpMediaProcessor {
         media_type: &str,
         port: u16,
     ) -> Result<SdpMediaDescription, MediaError> {
-        let payload_types: Vec<u8> = capabilities.iter().map(|c| c.codec.payload_type).collect();
+        let capabilities: Vec<&CodecCapability> = capabilities
+            .iter()
+            .filter(|capability| {
+                !media_type.eq_ignore_ascii_case("audio")
+                    || crate::codec::audio_codec_available(&capability.codec.name)
+            })
+            .collect();
+        let payload_types: Vec<u8> = capabilities
+            .iter()
+            .map(|capability| capability.codec.payload_type)
+            .collect();
 
         let media_line = SdpMediaLine {
             media_type: media_type.to_string(),
@@ -622,5 +632,33 @@ mod tests {
         assert!(text.to_ascii_uppercase().contains("OPUS"));
         #[cfg(not(feature = "opus"))]
         assert!(!text.to_ascii_uppercase().contains("OPUS"));
+    }
+
+    #[test]
+    fn explicit_local_capabilities_cannot_advertise_unavailable_audio() {
+        let processor = SdpMediaProcessor::new();
+        let capabilities = [
+            CodecCapability::new(
+                MediaCodec::new("G722".to_string(), 9, 8_000).with_channels(1),
+                MediaDirection::SendReceive,
+            ),
+            CodecCapability::new(
+                MediaCodec::new("OpUs".to_string(), 111, 48_000).with_channels(2),
+                MediaDirection::SendReceive,
+            ),
+            CodecCapability::new(
+                MediaCodec::new("PCMU".to_string(), 0, 8_000).with_channels(1),
+                MediaDirection::SendReceive,
+            ),
+        ];
+        let description = processor
+            .capabilities_to_sdp(&capabilities, "audio", 5_004)
+            .unwrap();
+        assert!(!description.media_line.payload_types.contains(&9));
+        #[cfg(feature = "opus")]
+        assert!(description.media_line.payload_types.contains(&111));
+        #[cfg(not(feature = "opus"))]
+        assert!(!description.media_line.payload_types.contains(&111));
+        assert!(description.media_line.payload_types.contains(&0));
     }
 }

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -13,7 +13,7 @@ use bytes::{Bytes, BytesMut};
 use dashmap::DashMap;
 use rand::Rng;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::net::UdpSocket;
@@ -508,6 +508,10 @@ pub struct RtpSession {
     /// Session configuration
     config: RtpSessionConfig,
 
+    /// Live RTP clock used when receive streams are created after a codec
+    /// renegotiation.
+    clock_rate: Arc<AtomicU32>,
+
     /// SSRC for this session
     ssrc: RtpSsrc,
 
@@ -678,8 +682,10 @@ impl RtpSession {
         );
         let rtcp_generator = crate::stats::reports::RtcpReportGenerator::new(ssrc, cname);
 
+        let clock_rate = Arc::new(AtomicU32::new(config.clock_rate));
         let mut session = Self {
             config,
+            clock_rate,
             ssrc,
             transport,
             streams: Arc::new(DashMap::new()),
@@ -736,7 +742,7 @@ impl RtpSession {
         let stats_recv = self.stats.clone();
         let remote_addr = self.config.remote_addr;
         let event_tx_recv = self.event_tx.clone();
-        let clock_rate = self.config.clock_rate;
+        let clock_rate = self.clock_rate.clone();
         let _payload_type = self.config.payload_type;
         let ssrc = self.ssrc;
         let streams_map = self.streams.clone();
@@ -764,7 +770,8 @@ impl RtpSession {
         if let Some(scheduler) = &mut self.scheduler {
             // Set appropriate timestamp increment based on packet interval
             let interval_ms = 20; // Default 20ms packet interval
-            let samples_per_packet = (clock_rate as f64 * (interval_ms as f64 / 1000.0)) as u32;
+            let samples_per_packet = (f64::from(clock_rate.load(Ordering::Relaxed))
+                * (interval_ms as f64 / 1000.0)) as u32;
             scheduler.set_interval(interval_ms, samples_per_packet);
         }
 
@@ -978,7 +985,10 @@ impl RtpSession {
                             let mut entry = streams_map.entry(packet_ssrc).or_insert_with(|| {
                                 created = true;
                                 info!("New RTP stream detected with SSRC={:08x}", packet_ssrc);
-                                let mut stream = RtpStream::new(packet_ssrc, clock_rate);
+                                let mut stream = RtpStream::new(
+                                    packet_ssrc,
+                                    clock_rate.load(Ordering::Relaxed),
+                                );
                                 if let Some(sender_report) =
                                     received_sender_reports.get(&packet_ssrc)
                                 {
@@ -1439,6 +1449,18 @@ impl RtpSession {
     /// Set the payload type
     pub fn set_payload_type(&mut self, payload_type: u8) {
         self.config.payload_type = payload_type;
+    }
+
+    /// Set the RTP clock after a completed codec renegotiation.
+    /// Existing receive-stream timing state belongs to the preceding codec
+    /// generation and is discarded so the next packet starts a fresh stream.
+    pub fn set_clock_rate(&mut self, clock_rate: u32) {
+        self.config.clock_rate = clock_rate;
+        self.clock_rate.store(clock_rate, Ordering::Release);
+        self.streams.clear();
+        if let Some(scheduler) = &mut self.scheduler {
+            scheduler.set_clock_rate(clock_rate);
+        }
     }
 
     /// Get a stream by SSRC, if it exists

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -985,10 +985,8 @@ impl RtpSession {
                             let mut entry = streams_map.entry(packet_ssrc).or_insert_with(|| {
                                 created = true;
                                 info!("New RTP stream detected with SSRC={:08x}", packet_ssrc);
-                                let mut stream = RtpStream::new(
-                                    packet_ssrc,
-                                    clock_rate.load(Ordering::Relaxed),
-                                );
+                                let mut stream =
+                                    RtpStream::new(packet_ssrc, clock_rate.load(Ordering::Relaxed));
                                 if let Some(sender_report) =
                                     received_sender_reports.get(&packet_ssrc)
                                 {

--- a/crates/media/rtp-core/src/session/mod.rs
+++ b/crates/media/rtp-core/src/session/mod.rs
@@ -1458,6 +1458,7 @@ impl RtpSession {
         self.config.clock_rate = clock_rate;
         self.clock_rate.store(clock_rate, Ordering::Release);
         self.streams.clear();
+        self.stats.lock().jitter_ms = 0.0;
         if let Some(scheduler) = &mut self.scheduler {
             scheduler.set_clock_rate(clock_rate);
         }
@@ -2508,6 +2509,24 @@ mod tests {
             assert_eq!(packet.packet_type(), expected_type);
             assert_ne!(&wire[..length], plaintext.as_ref());
         }
+        session.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clock_change_resets_session_jitter_diagnostics() {
+        let mut session = RtpSession::new(RtpSessionConfig {
+            local_addr: "127.0.0.1:0".parse().unwrap(),
+            ..RtpSessionConfig::default()
+        })
+        .await
+        .unwrap();
+        session.stats.lock().jitter_ms = 37.5;
+
+        session.set_clock_rate(48_000);
+
+        assert_eq!(session.config.clock_rate, 48_000);
+        assert_eq!(session.clock_rate.load(Ordering::Acquire), 48_000);
+        assert_eq!(session.stats.lock().jitter_ms, 0.0);
         session.close().await.unwrap();
     }
 }

--- a/crates/media/rtp-core/src/session/scheduling.rs
+++ b/crates/media/rtp-core/src/session/scheduling.rs
@@ -99,6 +99,13 @@ impl RtpScheduler {
         self.clock_rate = clock_rate;
         let interval_ms = self.interval.as_millis() as u64;
         self.timestamp_increment = (f64::from(clock_rate) * (interval_ms as f64 / 1_000.0)) as u32;
+        // Timing diagnostics before and after a clock change are not in the
+        // same unit. Start a fresh timing generation while preserving the
+        // current RTP timestamp cursor and sequence continuity.
+        self.initial_timestamp = self.timestamp;
+        self.start_time = Some(Instant::now());
+        self.packets_scheduled = 0;
+        self.packets_sent = 0;
     }
 
     /// Set the output channel
@@ -373,5 +380,20 @@ mod tests {
 
         // Stop the scheduler
         scheduler.stop().await;
+    }
+
+    #[test]
+    fn clock_change_starts_a_fresh_timing_diagnostic_generation() {
+        let mut scheduler = RtpScheduler::new(8_000, 1_000, 42);
+        scheduler.packets_scheduled = 7;
+        scheduler.packets_sent = 6;
+        scheduler.set_interval(20, 160);
+        scheduler.set_clock_rate(48_000);
+
+        assert_eq!(scheduler.timestamp_increment, 960);
+        assert_eq!(scheduler.initial_timestamp, scheduler.timestamp);
+        assert_eq!(scheduler.packets_scheduled, 0);
+        assert_eq!(scheduler.packets_sent, 0);
+        assert!(scheduler.start_time.is_some());
     }
 }

--- a/crates/media/rtp-core/src/session/scheduling.rs
+++ b/crates/media/rtp-core/src/session/scheduling.rs
@@ -94,6 +94,13 @@ impl RtpScheduler {
         );
     }
 
+    /// Update the RTP clock used for subsequent packet scheduling.
+    pub fn set_clock_rate(&mut self, clock_rate: u32) {
+        self.clock_rate = clock_rate;
+        let interval_ms = self.interval.as_millis() as u64;
+        self.timestamp_increment = (f64::from(clock_rate) * (interval_ms as f64 / 1_000.0)) as u32;
+    }
+
     /// Set the output channel
     pub fn set_sender(&mut self, sender: mpsc::Sender<RtpPacket>) {
         self.sender = Some(sender);

--- a/crates/sip/rvoip-sip/Cargo.toml
+++ b/crates/sip/rvoip-sip/Cargo.toml
@@ -470,6 +470,9 @@ g729 = ["rvoip-media-core/g729"]
 # this so SIP Opus is represented as Opus codec payload in MediaFrame rather
 # than being mis-decoded as G.711.
 opus = ["rvoip-media-core/opus"]
+# Deprecated compatibility alias; this selects the same real backend.
+opus-sim = ["opus"]
+all-codecs = ["g729", "opus"]
 # Heap profiling for `examples/profiling/dhat_*.rs`. Pulls in the dhat
 # global allocator and turns the gated examples into compilable
 # binaries. Off by default so `cargo build` / `cargo test` never see

--- a/crates/sip/rvoip-sip/docs/COMPATIBILITY_MATRIX.md
+++ b/crates/sip/rvoip-sip/docs/COMPATIBILITY_MATRIX.md
@@ -95,10 +95,12 @@ Developer-facing auth API and crate-boundary guidance is in
 | SDP RFC 8866 | Supported | SDP parser/builder tests, generated validation, SDP fuzz target | WebRTC attributes are parser/carry-through only unless wired higher. |
 | SDP offer/answer RFC 3264 | Supported | Hold/resume, codec matching, glare tests | Advanced media changes are not beta-scoped. |
 | RTP/RTCP RFC 3550 | Supported | RTP steady-state perf, audio round-trip, bridge round-trip | Full RTCP feedback matrix is not a beta claim. |
-| PCMU/PCMA | Supported | Codec and RTP media tests | Only beta full-media audio codecs. |
+| PCMU/PCMA | Supported | Codec and RTP media tests | Available in the default build. |
 | telephone-event DTMF | Supported | DTMF tests and PBX interop | RFC 4733 behavior must stay covered. |
 | Comfort Noise PT 13 | Supported | Config validation and SDP/media tests | Requires `comfort_noise_enabled=true`. |
-| Opus/G.722/G.729 | Post-beta | Config validation rejects unsupported beta full-media advertising | No beta full-media claim. |
+| Opus | Feature-gated | Real codec round trips plus SIP/RTP dynamic-payload tests | Requires the `opus` feature. |
+| G.729 | Feature-gated | Codec, SDP, and media tests | Requires the `g729` feature. |
+| G.722 | Not supported | Construction/negotiation rejection tests | RTP payload parsing metadata remains available. |
 | SDES-SRTP | Partial | SRTP integration/negotiator tests and PBX rows where present | Limited to tested suites. |
 | DTLS-SRTP | Post-beta | Explicit non-claim | Do not claim. |
 | ICE/TURN/WebRTC browser | Post-beta | Explicit non-claim | STUN remains limited address discovery. |

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -352,21 +352,29 @@ fn payload_codec_available(payload_type: u8) -> bool {
 }
 
 fn sdp_payload_codec_available(session: &SdpSession, payload_type: u8) -> bool {
-    let mapping_name =
-        audio_rtpmap(session, payload_type).map(|mapping| mapping.encoding_name.as_str());
+    let mapping = audio_rtpmap(session, payload_type);
+    let mapping_matches = |name: &str, rate: u32, channels: &[u8]| {
+        mapping.is_some_and(|mapping| {
+            let mapped_channels = mapping
+                .encoding_params
+                .as_deref()
+                .unwrap_or("1")
+                .parse::<u8>()
+                .ok();
+            mapping.encoding_name.eq_ignore_ascii_case(name)
+                && mapping.clock_rate == rate
+                && mapped_channels.is_some_and(|value| channels.contains(&value))
+        })
+    };
     match payload_type {
-        0 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("PCMU")),
-        8 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("PCMA")),
-        13 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("CN")),
-        18 => {
-            cfg!(feature = "g729")
-                && mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("G729"))
-        }
-        101 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("telephone-event")),
-        96..=127 => {
-            cfg!(feature = "opus")
-                && mapping_name.is_some_and(|name| name.eq_ignore_ascii_case("opus"))
-        }
+        0 => mapping.is_none() || mapping_matches("PCMU", 8_000, &[1]),
+        8 => mapping.is_none() || mapping_matches("PCMA", 8_000, &[1]),
+        13 => mapping.is_none() || mapping_matches("CN", 8_000, &[1]),
+        18 => cfg!(feature = "g729") && (mapping.is_none() || mapping_matches("G729", 8_000, &[1])),
+        // Telephone-event uses a dynamic PT in this stack and therefore
+        // always requires an explicit RFC 4733 mapping.
+        101 => mapping_matches("telephone-event", 8_000, &[1]),
+        96..=127 => cfg!(feature = "opus") && mapping_matches("opus", 48_000, &[1, 2]),
         _ => false,
     }
 }
@@ -475,6 +483,7 @@ fn validate_uac_audio_answer(
         .find(|media| media.media.eq_ignore_ascii_case("audio"))
         .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-audio"))?;
 
+    let mut primary_payloads = Vec::new();
     for format in &answered_audio.formats {
         if !offered_audio
             .formats
@@ -489,9 +498,25 @@ fn validate_uac_audio_answer(
         if !sdp_payload_codec_available(answer, payload_type) {
             return Err(bounded_sdp_failure("remote-answer", "unsupported-payload"));
         }
+        if !matches!(payload_type, 13 | 101) {
+            primary_payloads.push(payload_type);
+        }
     }
-    let payload_type = select_primary_audio_payload(&answered_audio.formats)
-        .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-primary-payload"))?;
+    let payload_type = match primary_payloads.as_slice() {
+        [payload_type] => *payload_type,
+        [] => {
+            return Err(bounded_sdp_failure(
+                "remote-answer",
+                "missing-primary-payload",
+            ))
+        }
+        _ => {
+            return Err(bounded_sdp_failure(
+                "remote-answer",
+                "multiple-primary-payloads",
+            ))
+        }
+    };
     if !sdp_payload_codec_available(answer, payload_type) {
         return Err(bounded_sdp_failure("remote-answer", "unsupported-payload"));
     }
@@ -1524,7 +1549,8 @@ impl MediaAdapter {
         let result = self
             .negotiate_sdp_as_uac_lane_owned(&mut session, remote_sdp)
             .await;
-        let security_observation = (session.media_security != previous_security)
+        let security_changed = result.is_ok() && session.media_security != previous_security;
+        let security_observation = security_changed
             .then(|| {
                 session
                     .lifecycle_handle
@@ -1532,7 +1558,7 @@ impl MediaAdapter {
                     .zip(session.media_security.clone())
             })
             .flatten();
-        if session.media_security != previous_security {
+        if security_changed {
             // The public compatibility commit acquires the same non-reentrant
             // lane and revision-checks this snapshot. Release our exact guard
             // first; any intervening signaling event makes the commit fail
@@ -1732,12 +1758,13 @@ impl MediaAdapter {
         let result = self
             .negotiate_sdp_as_uas_lane_owned(&mut session, remote_sdp)
             .await;
-        let state_changed = previous_origin
-            != (
-                session.sdp_origin_session_id.clone(),
-                session.sdp_origin_version,
-            )
-            || session.media_security != previous_security;
+        let state_changed = result.is_ok()
+            && (previous_origin
+                != (
+                    session.sdp_origin_session_id.clone(),
+                    session.sdp_origin_version,
+                )
+                || session.media_security != previous_security);
         let security_observation = (session.media_security != previous_security)
             .then(|| {
                 session
@@ -1788,14 +1815,13 @@ impl MediaAdapter {
         let offered_transport = audio_transport(&parsed_offer)
             .unwrap_or("RTP/AVP")
             .to_string();
-        let (answer_attr, srtp_pair, reject_with_port_zero) =
+        let (answer_attr, pending_srtp_pair, reject_with_port_zero) =
             if !offered_crypto.is_empty() && self.offer_srtp {
                 // Both sides want SRTP — negotiate.
                 let answerer = SrtpNegotiator::new_answerer();
                 let (chosen, pair) = answerer.process_offer(&offered_crypto)?;
-                self.negotiated_srtp.insert(session_id.clone(), pair);
                 tracing::info!(
-                    "SDES offer accepted for session {}: tag {} suite {:?}",
+                    "SDES offer provisionally accepted for session {}: tag {} suite {:?}",
                     session_id.0,
                     chosen.tag,
                     chosen.suite
@@ -1806,7 +1832,7 @@ impl MediaAdapter {
                         session_id.0, chosen.suite
                     ));
                 }
-                (Some(chosen), true, false)
+                (Some(chosen), Some(pair), false)
             } else if offered_crypto.is_empty() && self.srtp_required {
                 return Err(SessionError::SDPNegotiationFailed(
                     "srtp_required is set but the SDP offer carries no a=crypto: line".into(),
@@ -1827,11 +1853,10 @@ impl MediaAdapter {
                         session_id.0
                     ));
                 }
-                (None, false, true)
+                (None, None, true)
             } else {
-                (None, false, false)
+                (None, None, false)
             };
-        let _ = srtp_pair; // suppress unused warning — value retained via DashMap insert
 
         // Port-zero rejection short-circuit: build a minimal RFC 3264
         // §6 declined m-line answer and return without setting up any
@@ -1913,7 +1938,7 @@ impl MediaAdapter {
             )
             .await?;
 
-            if let Some((_, pair)) = self.negotiated_srtp.remove(&session_id) {
+            let negotiated_suite = if let Some(pair) = pending_srtp_pair {
                 let suite = pair.suite;
                 self.controller
                     .install_srtp_contexts(dialog_id, pair.send_ctx, pair.recv_ctx)
@@ -1929,14 +1954,16 @@ impl MediaAdapter {
                     session_id.0,
                     suite
                 );
-                Self::record_media_security_negotiated_lane_owned(session, suite, true);
                 if srtp_diagnostics {
                     emit_srtp_diag(format!(
                         "srtp_contexts_installed session={} role=uas suite={:?}",
                         session_id.0, suite
                     ));
                 }
-            }
+                Some(suite)
+            } else {
+                None
+            };
 
             self.controller
                 .establish_media_flow(dialog_id, remote_addr)
@@ -1955,8 +1982,11 @@ impl MediaAdapter {
                     "media resource changed during UAS negotiation".to_string(),
                 ));
             }
+            if let Some(suite) = negotiated_suite {
+                Self::record_media_security_negotiated_lane_owned(session, suite, true);
+            }
         } else if signaling_only_port.is_some() {
-            if let Some((_, pair)) = self.negotiated_srtp.remove(&session_id) {
+            if let Some(pair) = pending_srtp_pair {
                 Self::record_media_security_negotiated_lane_owned(session, pair.suite, false);
             }
         }
@@ -1966,11 +1996,9 @@ impl MediaAdapter {
         // Sprint 3.5 — `negotiate_sdp_as_uas` now consumes the
         // generic RFC 3264 §6 matcher in
         // `rvoip_sip_dialog::sdp::match_offer`. The strict path
-        // (default) intersects offered formats with our supported
-        // set in offerer-preference order; the permissive path
-        // (`Config::strict_codec_matching = false`) preserves the
-        // pre-Sprint-3.5 "always answer with full set" behaviour
-        // for deployments that depend on it.
+        // (default) additionally applies transport policy; both modes
+        // intersect the offer with our implemented codecs and retain one
+        // primary codec plus auxiliary CN/telephone-event payloads.
         let (origin_session_id, origin_version) = advance_sdp_origin(session);
         let origin_version = origin_version.to_string();
         // Sprint 3 A6 — same public-address override as the offer
@@ -2015,9 +2043,8 @@ impl MediaAdapter {
             .time("0", "0")
             .media_audio(advertised_port, answer_transport)
             .formats(&formats_str);
-        // Emit rtpmap/fmtp ONLY for the formats we kept. In the
-        // permissive branch this is the full set; in the strict
-        // branch the matcher's intersection has already filtered.
+        // Emit rtpmap/fmtp ONLY for the one primary and any auxiliary
+        // formats retained by the validated intersection.
         // NEXT_STEPS C2 — routed through `rtpmap_for_pt` so adding a
         // new codec only requires extending the helper.
         for fmt in &formats {
@@ -4004,32 +4031,65 @@ pub(crate) fn compute_answer_formats(
         }
     }
 
-    if !strict {
-        // Permissive — answer with our full set regardless. Matches
-        // the pre-Sprint-3.5 shape.
-        return Ok(supported);
+    let candidates = if strict {
+        let caps = rvoip_sip_dialog::sdp::AnswerCapabilities {
+            supported_formats: supported.clone(),
+            accept_srtp: offer_srtp,
+            require_srtp: srtp_required,
+        };
+        let matched = rvoip_sip_dialog::sdp::match_offer(offer, &caps)
+            .map_err(|_| bounded_sdp_failure("format-match", "policy"))?;
+        let line = matched
+            .media_lines
+            .iter()
+            .find(|line| line.media == "audio")
+            .ok_or_else(|| {
+                SessionError::SDPNegotiationFailed("matcher returned no audio media line".into())
+            })?;
+        if !line.accepted {
+            return Err(SessionError::SDPNegotiationFailed(
+                "no codec overlap with offer".into(),
+            ));
+        }
+        line.negotiated_formats.clone()
+    } else {
+        // Even compatibility mode must obey RFC 3264: an answer cannot add
+        // payloads the offer did not contain. It only bypasses the stricter
+        // transport-policy matcher.
+        let audio = offer
+            .media_descriptions
+            .iter()
+            .find(|media| media.media.eq_ignore_ascii_case("audio"))
+            .ok_or_else(|| bounded_sdp_failure("format-match", "missing-audio"))?;
+        audio
+            .formats
+            .iter()
+            .filter(|format| supported.contains(format))
+            .cloned()
+            .collect()
+    };
+
+    let mut primary = None;
+    let mut auxiliary = Vec::new();
+    for format in candidates {
+        let payload_type = format
+            .parse::<u8>()
+            .map_err(|_| bounded_sdp_failure("format-match", "invalid-payload"))?;
+        if !sdp_payload_codec_available(offer, payload_type) {
+            continue;
+        }
+        if matches!(payload_type, 13 | 101) {
+            auxiliary.push(format);
+        } else if primary.is_none() {
+            primary = Some(format);
+        }
     }
 
-    let caps = rvoip_sip_dialog::sdp::AnswerCapabilities {
-        supported_formats: supported,
-        accept_srtp: offer_srtp,
-        require_srtp: srtp_required,
-    };
-    let m = rvoip_sip_dialog::sdp::match_offer(offer, &caps)
-        .map_err(|_| bounded_sdp_failure("format-match", "policy"))?;
-    let line = m
-        .media_lines
-        .iter()
-        .find(|l| l.media == "audio")
-        .ok_or_else(|| {
-            SessionError::SDPNegotiationFailed("matcher returned no audio media line".into())
-        })?;
-    if !line.accepted {
-        return Err(SessionError::SDPNegotiationFailed(
-            "no codec overlap with offer".into(),
-        ));
-    }
-    Ok(line.negotiated_formats.clone())
+    let primary = primary.ok_or_else(|| bounded_sdp_failure("format-match", "no-primary"))?;
+    let mut answer = Vec::with_capacity(1 + auxiliary.len());
+    answer.push(primary);
+    answer.extend(auxiliary);
+    Ok(answer)
 }
 
 #[cfg(test)]
@@ -4752,10 +4812,10 @@ a=fmtp:101 0-15\r\n";
         );
     }
 
-    /// Sprint 3.5 — permissive mode preserves the legacy
-    /// pre-Sprint-3.5 "always full set" answer shape.
+    /// Compatibility mode still obeys RFC 3264 and cannot add an unoffered
+    /// payload to the answer.
     #[test]
-    fn permissive_mode_answers_with_full_set() {
+    fn compatibility_mode_still_answers_with_the_offered_intersection() {
         let offer_sdp = SdpBuilder::new("Session")
             .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
             .connection("IN", "IP4", "127.0.0.1")
@@ -4779,12 +4839,161 @@ a=fmtp:101 0-15\r\n";
             false,        /*srtp_required*/
             false,
         )
-        .expect("permissive mode never errors on overlap");
+        .expect("compatibility mode accepts the offered overlap");
         assert_eq!(
             formats,
-            vec!["0".to_string(), "8".to_string(), "101".to_string()],
-            "permissive answer keeps the full legacy set"
+            vec!["0".to_string(), "101".to_string()],
+            "an answer must not add unoffered PCMA"
         );
+    }
+
+    #[test]
+    fn uas_selects_one_primary_codec_and_keeps_auxiliary_payloads() {
+        let offer = SdpBuilder::new("Session")
+            .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_000, "RTP/AVP")
+            .formats(&["8", "0", "13", "101"])
+            .rtpmap("8", "PCMA/8000")
+            .rtpmap("0", "PCMU/8000")
+            .rtpmap("13", "CN/8000")
+            .rtpmap("101", "telephone-event/8000")
+            .done()
+            .build()
+            .unwrap();
+
+        let formats = compute_answer_formats(&offer, &[0, 8, 13, 101], true, false, false)
+            .expect("valid mixed offer");
+        assert_eq!(formats, ["8", "13", "101"]);
+    }
+
+    #[test]
+    fn uas_skips_invalid_mappings_and_never_answers_unmapped_dynamic_payloads() {
+        let offer = SdpBuilder::new("Session")
+            .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_000, "RTP/AVP")
+            .formats(&["96", "0", "101"])
+            .rtpmap("0", "PCMU/16000")
+            .rtpmap("101", "telephone-event/8000")
+            .done()
+            .build()
+            .unwrap();
+
+        assert!(compute_answer_formats(&offer, &[0, 8, 111, 101], true, false, false).is_err());
+    }
+
+    #[test]
+    fn uac_answer_requires_one_primary_and_valid_dynamic_mappings() {
+        let offer = SdpBuilder::new("Session")
+            .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_000, "RTP/AVP")
+            .formats(&["0", "8", "101"])
+            .rtpmap("0", "PCMU/8000")
+            .rtpmap("8", "PCMA/8000")
+            .rtpmap("101", "telephone-event/8000")
+            .done()
+            .build()
+            .unwrap();
+        let multiple_primary = offer.clone();
+        assert!(validate_uac_audio_answer(&offer, &multiple_primary, true).is_err());
+
+        let missing_dynamic_map = SdpBuilder::new("Session")
+            .origin("-", "2", "0", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_002, "RTP/AVP")
+            .formats(&["0", "101"])
+            .rtpmap("0", "PCMU/8000")
+            .done()
+            .build()
+            .unwrap();
+        assert!(validate_uac_audio_answer(&offer, &missing_dynamic_map, true).is_err());
+    }
+
+    #[tokio::test]
+    async fn uas_answer_and_runtime_choose_the_same_single_primary_codec() {
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use std::net::Ipv4Addr;
+
+        let mut adapter = MediaAdapter::new(
+            Arc::new(MediaSessionController::new()),
+            Arc::new(SessionStore::new()),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_000,
+            16_100,
+        );
+        adapter.set_media_mode(MediaMode::SignalingOnly { sdp_rtp_port: 9 });
+        adapter.set_offered_codecs(vec![0, 8, 101]);
+        let mut session = SessionState::new(SessionId("single-primary".into()), Role::UAS);
+        let offer = SdpBuilder::new("Session")
+            .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(18_000, "RTP/AVP")
+            .formats(&["8", "0", "101"])
+            .rtpmap("8", "PCMA/8000")
+            .rtpmap("0", "PCMU/8000")
+            .rtpmap("101", "telephone-event/8000")
+            .done()
+            .build()
+            .unwrap()
+            .to_string();
+
+        let (answer, config) = adapter
+            .negotiate_sdp_as_uas_lane_owned(&mut session, &offer)
+            .await
+            .unwrap();
+        assert!(answer.contains("m=audio 9 RTP/AVP 8 101\r\n"));
+        assert!(!answer.contains("a=rtpmap:0 "));
+        assert_eq!(config.codec, "PCMA");
+        assert_eq!(config.payload_type, 8);
+    }
+
+    #[tokio::test]
+    async fn invalid_uas_codec_offer_does_not_commit_provisional_srtp_state() {
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use std::net::Ipv4Addr;
+
+        let mut adapter = MediaAdapter::new(
+            Arc::new(MediaSessionController::new()),
+            Arc::new(SessionStore::new()),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_000,
+            16_100,
+        );
+        adapter.set_media_mode(MediaMode::SignalingOnly { sdp_rtp_port: 9 });
+        adapter.set_srtp_policy(true, true, vec![CryptoSuite::AesCm128HmacSha1_80]);
+        let (_, attrs) =
+            SrtpNegotiator::new_offerer(&[CryptoSuite::AesCm128HmacSha1_80]).expect("offerer keys");
+        let mut media = SdpBuilder::new("Session")
+            .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(18_000, "RTP/SAVP")
+            .formats(&["0"])
+            .rtpmap("0", "PCMU/16000");
+        for attr in attrs {
+            media = media.crypto_attribute(attr);
+        }
+        let offer = media.done().build().unwrap().to_string();
+        let session_id = SessionId("srtp-codec-rollback".into());
+        let mut session = SessionState::new(session_id.clone(), Role::UAS);
+
+        assert!(adapter
+            .negotiate_sdp_as_uas_lane_owned(&mut session, &offer)
+            .await
+            .is_err());
+        assert!(session.media_security.is_none());
+        assert!(!adapter.negotiated_srtp.contains_key(&session_id));
     }
 
     /// Sprint 3.5 — strict mode + zero overlap returns

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -309,15 +309,13 @@ fn negotiated_g729_annex_b(session: &SdpSession, local_annex_b: bool) -> bool {
 }
 
 fn select_primary_audio_payload(formats: &[String]) -> Option<u8> {
-    let mut parsed = formats.iter().filter_map(|fmt| fmt.parse::<u8>().ok());
-    parsed.find(|pt| !matches!(*pt, 13 | 101)).or_else(|| {
-        formats
-            .iter()
-            .filter_map(|fmt| fmt.parse::<u8>().ok())
-            .next()
-    })
+    formats
+        .iter()
+        .filter_map(|format| format.parse::<u8>().ok())
+        .find(|payload_type| !matches!(*payload_type, 13 | 101))
 }
 
+#[cfg(test)]
 fn select_primary_audio_payload_from_session(session: &SdpSession) -> Option<u8> {
     session
         .media_descriptions
@@ -326,6 +324,7 @@ fn select_primary_audio_payload_from_session(session: &SdpSession) -> Option<u8>
         .and_then(|m| select_primary_audio_payload(&m.formats))
 }
 
+#[cfg(test)]
 fn codec_name_for_payload(payload_type: u8, g729_annex_b: bool) -> String {
     match payload_type {
         0 => "PCMU",
@@ -339,6 +338,187 @@ fn codec_name_for_payload(payload_type: u8, g729_annex_b: bool) -> String {
         _ => return format!("PT{}", payload_type),
     }
     .to_string()
+}
+
+fn payload_codec_available(payload_type: u8) -> bool {
+    match payload_type {
+        0 | 8 | 13 | 101 => true,
+        18 => cfg!(feature = "g729"),
+        111 => cfg!(feature = "opus"),
+        // G.722 remains wire-parseable but has no encoder/decoder.
+        9 => false,
+        _ => false,
+    }
+}
+
+fn sdp_payload_codec_available(session: &SdpSession, payload_type: u8) -> bool {
+    let mapping_name =
+        audio_rtpmap(session, payload_type).map(|mapping| mapping.encoding_name.as_str());
+    match payload_type {
+        0 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("PCMU")),
+        8 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("PCMA")),
+        13 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("CN")),
+        18 => {
+            cfg!(feature = "g729")
+                && mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("G729"))
+        }
+        101 => mapping_name.is_none_or(|name| name.eq_ignore_ascii_case("telephone-event")),
+        96..=127 => {
+            cfg!(feature = "opus")
+                && mapping_name.is_some_and(|name| name.eq_ignore_ascii_case("opus"))
+        }
+        _ => false,
+    }
+}
+
+fn audio_rtpmap(
+    session: &SdpSession,
+    payload_type: u8,
+) -> Option<&rvoip_sip_core::types::sdp::RtpMapAttribute> {
+    session
+        .media_descriptions
+        .iter()
+        .find(|media| media.media.eq_ignore_ascii_case("audio"))?
+        .generic_attributes
+        .iter()
+        .find_map(|attribute| match attribute {
+            ParsedAttribute::RtpMap(mapping) if mapping.payload_type == payload_type => {
+                Some(mapping)
+            }
+            _ => None,
+        })
+}
+
+fn negotiated_audio_shape_from_sdp(
+    session: &SdpSession,
+    payload_type: u8,
+    g729_annex_b: bool,
+) -> Result<(String, u32, u8)> {
+    let mapping = audio_rtpmap(session, payload_type);
+    let (wire_name, clock_rate, channels) = if let Some(mapping) = mapping {
+        let channels = mapping
+            .encoding_params
+            .as_deref()
+            .unwrap_or("1")
+            .parse::<u8>()
+            .map_err(|_| bounded_sdp_failure("codec", "invalid-channels"))?;
+        (mapping.encoding_name.as_str(), mapping.clock_rate, channels)
+    } else {
+        match payload_type {
+            0 => ("PCMU", 8_000, 1),
+            8 => ("PCMA", 8_000, 1),
+            9 => ("G722", 8_000, 1),
+            18 => ("G729", 8_000, 1),
+            _ => return Err(bounded_sdp_failure("codec", "missing-rtpmap")),
+        }
+    };
+
+    let canonical = if wire_name.eq_ignore_ascii_case("PCMU") {
+        "PCMU"
+    } else if wire_name.eq_ignore_ascii_case("PCMA") {
+        "PCMA"
+    } else if wire_name.eq_ignore_ascii_case("G729") {
+        if !cfg!(feature = "g729") {
+            return Err(bounded_sdp_failure("codec", "g729-disabled"));
+        }
+        if g729_annex_b {
+            "G729BA"
+        } else {
+            "G729A"
+        }
+    } else if wire_name.eq_ignore_ascii_case("opus") {
+        if !cfg!(feature = "opus") {
+            return Err(bounded_sdp_failure("codec", "opus-disabled"));
+        }
+        "opus"
+    } else if wire_name.eq_ignore_ascii_case("G722") {
+        return Err(bounded_sdp_failure("codec", "g722-unsupported"));
+    } else {
+        return Err(bounded_sdp_failure("codec", "unsupported"));
+    };
+
+    let valid_shape = if canonical.eq_ignore_ascii_case("opus") {
+        clock_rate == 48_000 && matches!(channels, 1 | 2)
+    } else {
+        clock_rate == 8_000 && channels == 1
+    };
+    if !valid_shape {
+        return Err(bounded_sdp_failure("codec", "invalid-shape"));
+    }
+    let valid_payload_identity = match payload_type {
+        0 => canonical == "PCMU",
+        8 => canonical == "PCMA",
+        18 => canonical.starts_with("G729"),
+        96..=127 if payload_type != 101 => canonical.eq_ignore_ascii_case("opus"),
+        _ => false,
+    };
+    if !valid_payload_identity {
+        return Err(bounded_sdp_failure("codec", "payload-identity"));
+    }
+
+    Ok((canonical.to_string(), clock_rate, channels))
+}
+
+fn validate_uac_audio_answer(
+    offer: &SdpSession,
+    answer: &SdpSession,
+    g729_annex_b: bool,
+) -> Result<(u8, String, u32, u8)> {
+    let offered_audio = offer
+        .media_descriptions
+        .iter()
+        .find(|media| media.media.eq_ignore_ascii_case("audio"))
+        .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-local-audio-offer"))?;
+    let answered_audio = answer
+        .media_descriptions
+        .iter()
+        .find(|media| media.media.eq_ignore_ascii_case("audio"))
+        .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-audio"))?;
+
+    for format in &answered_audio.formats {
+        if !offered_audio
+            .formats
+            .iter()
+            .any(|offered| offered == format)
+        {
+            return Err(bounded_sdp_failure("remote-answer", "unoffered-payload"));
+        }
+        let payload_type = format
+            .parse::<u8>()
+            .map_err(|_| bounded_sdp_failure("remote-answer", "invalid-payload"))?;
+        if !sdp_payload_codec_available(answer, payload_type) {
+            return Err(bounded_sdp_failure("remote-answer", "unsupported-payload"));
+        }
+    }
+    let payload_type = select_primary_audio_payload(&answered_audio.formats)
+        .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-primary-payload"))?;
+    if !sdp_payload_codec_available(answer, payload_type) {
+        return Err(bounded_sdp_failure("remote-answer", "unsupported-payload"));
+    }
+    let negotiated_annex_b = payload_type == 18 && negotiated_g729_annex_b(answer, g729_annex_b);
+    let (codec, clock_rate, channels) =
+        negotiated_audio_shape_from_sdp(answer, payload_type, negotiated_annex_b)?;
+
+    // For dynamic payloads the answer must retain the offered codec identity.
+    if payload_type >= 96 {
+        let offer_map = audio_rtpmap(offer, payload_type)
+            .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-offer-rtpmap"))?;
+        let answer_map = audio_rtpmap(answer, payload_type)
+            .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-answer-rtpmap"))?;
+        if !offer_map
+            .encoding_name
+            .eq_ignore_ascii_case(&answer_map.encoding_name)
+            || offer_map.clock_rate != answer_map.clock_rate
+            || offer_map.encoding_params != answer_map.encoding_params
+        {
+            return Err(bounded_sdp_failure(
+                "remote-answer",
+                "changed-dynamic-payload",
+            ));
+        }
+    }
+
+    Ok((payload_type, codec, clock_rate, channels))
 }
 
 /// Build the SDP answer that declines an offered audio m-line per
@@ -425,12 +605,25 @@ pub struct RecordingStatus {
 }
 
 /// Negotiated media configuration
+const fn default_negotiated_clock_rate() -> u32 {
+    8_000
+}
+
+const fn default_negotiated_channels() -> u8 {
+    1
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NegotiatedConfig {
     pub local_addr: SocketAddr,
     pub remote_addr: SocketAddr,
     pub codec: String,
+    #[serde(default)]
     pub payload_type: u8,
+    #[serde(default = "default_negotiated_clock_rate")]
+    pub clock_rate: u32,
+    #[serde(default = "default_negotiated_channels")]
+    pub channels: u8,
     pub local_direction: crate::types::MediaDirection,
     pub remote_direction: crate::types::MediaDirection,
 }
@@ -1074,11 +1267,17 @@ impl MediaAdapter {
     /// of DTMF (PT 101) when enabled, preserving the legacy ordering
     /// the byte-fixture tests pin.
     fn effective_offered_formats(&self) -> Vec<u8> {
+        let offered: Vec<u8> = self
+            .offered_codecs
+            .iter()
+            .copied()
+            .filter(|payload_type| payload_codec_available(*payload_type))
+            .collect();
         if !self.comfort_noise_enabled {
-            return self.offered_codecs.clone();
+            return offered;
         }
-        let mut out = Vec::with_capacity(self.offered_codecs.len() + 1);
-        for pt in &self.offered_codecs {
+        let mut out = Vec::with_capacity(offered.len() + 1);
+        for pt in &offered {
             if *pt == 101 {
                 out.push(13);
             }
@@ -1096,6 +1295,9 @@ impl MediaAdapter {
         dialog_id: &DialogId,
         remote_addr: SocketAddr,
         codec: &str,
+        payload_type: u8,
+        clock_rate: u32,
+        channels: u8,
     ) -> Result<()> {
         let mut config = self
             .controller
@@ -1106,7 +1308,12 @@ impl MediaAdapter {
             })?
             .config;
         config.remote_addr = Some(remote_addr);
-        config.preferred_codec = Some(codec.to_string());
+        config = config.with_negotiated_audio_codec(
+            codec.to_string(),
+            payload_type,
+            clock_rate,
+            channels,
+        );
 
         self.controller
             .update_media(dialog_id.clone(), config)
@@ -1347,18 +1554,29 @@ impl MediaAdapter {
         let session_id = session.session_id.clone();
         // Parse remote SDP to extract IP and port
         let (remote_ip, remote_port) = self.parse_sdp_connection(remote_sdp)?;
+        let parsed_answer = SdpSession::from_str(remote_sdp)
+            .map_err(|_| bounded_sdp_failure("remote-answer", "syntax"))?;
+        let parsed_offer = session
+            .local_sdp
+            .as_deref()
+            .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-local-offer"))
+            .and_then(|offer| {
+                SdpSession::from_str(offer)
+                    .map_err(|_| bounded_sdp_failure("remote-answer", "invalid-local-offer"))
+            })?;
+        let (payload_type, negotiated_codec, clock_rate, channels) =
+            validate_uac_audio_answer(&parsed_offer, &parsed_answer, self.g729_annex_b)?;
+        let answer_direction = audio_direction(&parsed_answer);
         let srtp_diagnostics = srtp_diagnostics_enabled();
         if sdp_diagnostics_enabled() {
-            if let Ok(parsed) = SdpSession::from_str(remote_sdp) {
-                emit_sdp_diag(format!(
-                    "remote_sdp_answer session={} media={}:{} transport={} {}",
-                    session_id.0,
-                    remote_ip,
-                    remote_port,
-                    audio_transport(&parsed).unwrap_or("unknown"),
-                    crypto_attribute_diag(Self::extract_audio_crypto(&parsed).len())
-                ));
-            }
+            emit_sdp_diag(format!(
+                "remote_sdp_answer session={} media={}:{} transport={} {}",
+                session_id.0,
+                remote_ip,
+                remote_port,
+                audio_transport(&parsed_answer).unwrap_or("unknown"),
+                crypto_attribute_diag(Self::extract_audio_crypto(&parsed_answer).len())
+            ));
         }
 
         // SDES answer-side handling (RFC 4568 §7.5).
@@ -1368,9 +1586,7 @@ impl MediaAdapter {
         // which the executor turns into terminal `CallFailed`.
         if let Some((_, offerer_state)) = self.pending_srtp_offerers.remove(&session_id) {
             // We did offer SRTP. Look for a matching `a=crypto:` in the answer.
-            let parsed = SdpSession::from_str(remote_sdp)
-                .map_err(|_| bounded_sdp_failure("remote-answer", "syntax"))?;
-            let attrs = Self::extract_audio_crypto(&parsed);
+            let attrs = Self::extract_audio_crypto(&parsed_answer);
             if let Some(chosen) = attrs.first() {
                 let pair = offerer_state.accept_answer(chosen)?;
                 self.negotiated_srtp.insert(session_id.clone(), pair);
@@ -1400,19 +1616,6 @@ impl MediaAdapter {
             }
         }
 
-        let parsed_answer = SdpSession::from_str(remote_sdp).ok();
-        let answer_direction = parsed_answer.as_ref().and_then(audio_direction);
-        let payload_type = parsed_answer
-            .as_ref()
-            .and_then(select_primary_audio_payload_from_session)
-            .unwrap_or(0);
-        let negotiated_annex_b = parsed_answer
-            .as_ref()
-            .filter(|_| payload_type == 18)
-            .map(|answer| negotiated_g729_annex_b(answer, self.g729_annex_b))
-            .unwrap_or(false);
-        let negotiated_codec = codec_name_for_payload(payload_type, negotiated_annex_b);
-
         // Update media session with remote address. SRTP contexts (if
         // negotiated in 2B.1) must be installed *between* updating the
         // remote address and starting the audio transmitter — the
@@ -1429,8 +1632,15 @@ impl MediaAdapter {
             let dialog_id = &exact_media.dialog_id;
             let remote_addr = SocketAddr::new(remote_ip, remote_port);
 
-            self.apply_negotiated_media_config(dialog_id, remote_addr, &negotiated_codec)
-                .await?;
+            self.apply_negotiated_media_config(
+                dialog_id,
+                remote_addr,
+                &negotiated_codec,
+                payload_type,
+                clock_rate,
+                channels,
+            )
+            .await?;
 
             // RFC 4568 SDES: install per-direction contexts before the
             // first wire packet flows.
@@ -1489,6 +1699,8 @@ impl MediaAdapter {
             remote_addr: SocketAddr::new(remote_ip, remote_port),
             codec: negotiated_codec,
             payload_type,
+            clock_rate,
+            channels,
             local_direction: local_direction_from_remote_answer(&answer_direction),
             remote_direction: answer_direction
                 .map(sip_direction_to_session)
@@ -1642,6 +1854,8 @@ impl MediaAdapter {
                 remote_addr: SocketAddr::new(remote_ip, remote_port),
                 codec: "PCMU".to_string(),
                 payload_type: 0,
+                clock_rate: 8_000,
+                channels: 1,
                 local_direction: crate::types::MediaDirection::Inactive,
                 remote_direction: crate::types::MediaDirection::Inactive,
             };
@@ -1661,13 +1875,18 @@ impl MediaAdapter {
             self.offer_srtp,
             self.srtp_required,
         )?;
-        let negotiated_payload_type = select_primary_audio_payload(&formats).unwrap_or(0);
+        let negotiated_payload_type = select_primary_audio_payload(&formats)
+            .ok_or_else(|| bounded_sdp_failure("remote-offer", "missing-primary-payload"))?;
         let negotiated_annex_b = if negotiated_payload_type == 18 {
             negotiated_g729_annex_b(&parsed_offer, self.g729_annex_b)
         } else {
             false
         };
-        let negotiated_codec = codec_name_for_payload(negotiated_payload_type, negotiated_annex_b);
+        let (negotiated_codec, clock_rate, channels) = negotiated_audio_shape_from_sdp(
+            &parsed_offer,
+            negotiated_payload_type,
+            negotiated_annex_b,
+        )?;
         let offered_direction = audio_direction(&parsed_offer);
         let answer_direction = answer_direction_for_offer(&offered_direction);
 
@@ -1684,8 +1903,15 @@ impl MediaAdapter {
             let dialog_id = &exact_media.dialog_id;
             let remote_addr = SocketAddr::new(remote_ip, remote_port);
 
-            self.apply_negotiated_media_config(dialog_id, remote_addr, &negotiated_codec)
-                .await?;
+            self.apply_negotiated_media_config(
+                dialog_id,
+                remote_addr,
+                &negotiated_codec,
+                negotiated_payload_type,
+                clock_rate,
+                channels,
+            )
+            .await?;
 
             if let Some((_, pair)) = self.negotiated_srtp.remove(&session_id) {
                 let suite = pair.suite;
@@ -1798,7 +2024,10 @@ impl MediaAdapter {
             let Ok(pt) = fmt.parse::<u8>() else {
                 continue;
             };
-            if let Some(rtpmap) = rtpmap_for_pt(pt) {
+            if pt == negotiated_payload_type && negotiated_codec.eq_ignore_ascii_case("opus") {
+                let rtpmap = format!("opus/{clock_rate}/{channels}");
+                media_builder = media_builder.rtpmap(fmt.as_str(), rtpmap.as_str());
+            } else if let Some(rtpmap) = rtpmap_for_pt(pt) {
                 media_builder = media_builder.rtpmap(fmt.as_str(), rtpmap);
             }
             if let Some(fmtp) = fmtp_for_pt_with_g729_annex_b(pt, negotiated_annex_b) {
@@ -1820,6 +2049,8 @@ impl MediaAdapter {
             remote_addr: SocketAddr::new(remote_ip, remote_port),
             codec: negotiated_codec,
             payload_type: negotiated_payload_type,
+            clock_rate,
+            channels,
             local_direction: answer_direction,
             remote_direction: offered_direction
                 .map(sip_direction_to_session)
@@ -2086,20 +2317,12 @@ impl MediaAdapter {
             audio_frame.samples.len()
         );
 
-        // Move the PCM buffer into media-core instead of cloning it. At soak
-        // scale, the old clone created one extra Vec allocation per outbound
-        // frame and showed up as sustained RSS/CPU pressure.
-        let AudioFrame {
-            samples: pcm_samples,
-            timestamp,
-            ..
-        } = audio_frame;
         self.audio_send_frames_total.fetch_add(1, Ordering::Relaxed);
         self.audio_send_samples_total
-            .fetch_add(pcm_samples.len() as u64, Ordering::Relaxed);
+            .fetch_add(audio_frame.samples.len() as u64, Ordering::Relaxed);
 
         self.controller
-            .encode_and_send_audio_frame(&exact.dialog_id, pcm_samples, timestamp)
+            .encode_and_send_audio(&exact.dialog_id, audio_frame)
             .await
             .map_err(|e| {
                 SessionError::MediaError(format!("Failed to send audio frame via RTP: {}", e))
@@ -2132,14 +2355,9 @@ impl MediaAdapter {
                 handle.session_id().0
             ))
         })?;
-        let AudioFrame {
-            samples: pcm_samples,
-            timestamp,
-            ..
-        } = audio_frame;
         self.audio_send_frames_total.fetch_add(1, Ordering::Relaxed);
         self.audio_send_samples_total
-            .fetch_add(pcm_samples.len() as u64, Ordering::Relaxed);
+            .fetch_add(audio_frame.samples.len() as u64, Ordering::Relaxed);
 
         // `dialog_id` is generation-qualified and the retained resource is a
         // strong exact-lifetime binding. Teardown may make this A operation
@@ -2147,7 +2365,7 @@ impl MediaAdapter {
         // this hot path allocation-free avoids one supervisor task per 20 ms
         // audio frame.
         self.controller
-            .encode_and_send_audio_frame(&exact.dialog_id, pcm_samples, timestamp)
+            .encode_and_send_audio(&exact.dialog_id, audio_frame)
             .await
             .map_err(|error| {
                 SessionError::MediaError(format!("Failed to send audio frame via RTP: {error}"))
@@ -3759,7 +3977,32 @@ pub(crate) fn compute_answer_formats(
     offer_srtp: bool,
     srtp_required: bool,
 ) -> Result<Vec<String>> {
-    let supported: Vec<String> = offered_codecs.iter().map(|pt| pt.to_string()).collect();
+    let mut supported: Vec<String> = offered_codecs.iter().map(|pt| pt.to_string()).collect();
+
+    // Dynamic payload numbers belong to the offer, not to a codec. PT 111 in
+    // the local capability list represents Opus support; when the peer maps
+    // Opus to another dynamic PT, match and answer using that exact number.
+    if cfg!(feature = "opus") && offered_codecs.contains(&111) {
+        if let Some(audio) = offer
+            .media_descriptions
+            .iter()
+            .find(|media| media.media.eq_ignore_ascii_case("audio"))
+        {
+            for format in &audio.formats {
+                let Ok(payload_type) = format.parse::<u8>() else {
+                    continue;
+                };
+                if (96..=127).contains(&payload_type)
+                    && payload_type != 101
+                    && audio_rtpmap(offer, payload_type)
+                        .is_some_and(|mapping| mapping.encoding_name.eq_ignore_ascii_case("opus"))
+                    && !supported.contains(format)
+                {
+                    supported.push(format.clone());
+                }
+            }
+        }
+    }
 
     if !strict {
         // Permissive — answer with our full set regardless. Matches
@@ -4633,6 +4876,7 @@ a=fmtp:101 0-15\r\n";
         );
     }
 
+    #[cfg(feature = "opus")]
     #[tokio::test]
     async fn opus_offered_codec_appears_in_generated_offer() {
         // NEXT_STEPS C2 — when Opus (PT 111) is in the configured
@@ -4688,6 +4932,7 @@ a=fmtp:101 0-15\r\n";
         );
     }
 
+    #[cfg(feature = "g729")]
     #[tokio::test]
     async fn g729_offer_advertises_annex_b_yes() {
         use crate::session_store::SessionStore;
@@ -4739,6 +4984,7 @@ a=fmtp:101 0-15\r\n";
         );
     }
 
+    #[cfg(feature = "g729")]
     #[tokio::test]
     async fn g729_offer_advertises_annex_b_no() {
         use crate::session_store::SessionStore;
@@ -4900,6 +5146,118 @@ a=fmtp:101 0-15\r\n";
             "default offer must not advertise Opus:\n{}",
             sdp
         );
+    }
+
+    #[test]
+    fn configured_formats_filter_unavailable_codecs() {
+        use crate::session_store::SessionStore;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use std::net::Ipv4Addr;
+
+        let mut adapter = MediaAdapter::new(
+            Arc::new(MediaSessionController::new()),
+            Arc::new(SessionStore::new()),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_000,
+            16_100,
+        );
+        adapter.set_offered_codecs(vec![9, 111, 0, 8, 101]);
+        let formats = adapter.effective_offered_formats();
+        assert!(!formats.contains(&9), "G.722 must never be advertised");
+        #[cfg(feature = "opus")]
+        assert!(formats.contains(&111));
+        #[cfg(not(feature = "opus"))]
+        assert!(!formats.contains(&111));
+        assert!(formats.contains(&0));
+        assert!(formats.contains(&8));
+    }
+
+    #[test]
+    fn auxiliary_only_audio_formats_do_not_fall_back_to_pcmu() {
+        let formats = vec!["13".to_string(), "101".to_string()];
+        assert_eq!(select_primary_audio_payload(&formats), None);
+    }
+
+    #[test]
+    fn uac_answer_rejects_unoffered_unsupported_and_changed_payloads() {
+        let offer = SdpBuilder::new("Session")
+            .origin("-", "1", "1", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_000, "RTP/AVP")
+            .formats(&["0", "111"])
+            .rtpmap("0", "PCMU/8000")
+            .rtpmap("111", "opus/48000/2")
+            .done()
+            .build()
+            .unwrap();
+        let unoffered = SdpBuilder::new("Session")
+            .origin("-", "2", "2", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_002, "RTP/AVP")
+            .formats(&["96"])
+            .rtpmap("96", "opus/48000/2")
+            .done()
+            .build()
+            .unwrap();
+        assert!(validate_uac_audio_answer(&offer, &unoffered, true).is_err());
+
+        let changed = SdpBuilder::new("Session")
+            .origin("-", "3", "3", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_002, "RTP/AVP")
+            .formats(&["111"])
+            .rtpmap("111", "PCMU/8000")
+            .done()
+            .build()
+            .unwrap();
+        assert!(validate_uac_audio_answer(&offer, &changed, true).is_err());
+
+        let unsupported_offer = SdpBuilder::new("Session")
+            .origin("-", "4", "4", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_000, "RTP/AVP")
+            .formats(&["9"])
+            .rtpmap("9", "G722/8000")
+            .done()
+            .build()
+            .unwrap();
+        let unsupported_answer = SdpBuilder::new("Session")
+            .origin("-", "5", "5", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_002, "RTP/AVP")
+            .formats(&["9"])
+            .rtpmap("9", "G722/8000")
+            .done()
+            .build()
+            .unwrap();
+        assert!(validate_uac_audio_answer(&unsupported_offer, &unsupported_answer, true).is_err());
+    }
+
+    #[cfg(feature = "opus")]
+    #[test]
+    fn dynamic_opus_payload_is_matched_and_preserved() {
+        let offer = SdpBuilder::new("Session")
+            .origin("-", "1", "1", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(16_000, "RTP/AVP")
+            .formats(&["96"])
+            .rtpmap("96", "OpUs/48000/1")
+            .done()
+            .build()
+            .unwrap();
+        let formats = compute_answer_formats(&offer, &[0, 8, 111], true, false, false).unwrap();
+        assert_eq!(formats, vec!["96"]);
+        let (codec, clock_rate, channels) =
+            negotiated_audio_shape_from_sdp(&offer, 96, false).unwrap();
+        assert_eq!(codec, "opus");
+        assert_eq!(clock_rate, 48_000);
+        assert_eq!(channels, 1);
     }
 
     #[test]

--- a/crates/sip/rvoip-sip/src/api/unified.rs
+++ b/crates/sip/rvoip-sip/src/api/unified.rs
@@ -2264,10 +2264,10 @@ pub struct Config {
     /// Beta validation intentionally rejects audio payload types that
     /// media-core cannot encode/decode end to end. The advertised full-media
     /// set is limited to PCMU (`0`), PCMA (`8`), telephone-event (`101`),
-    /// comfort noise (`13`) when `comfort_noise_enabled = true`, and G.729
-    /// (`18`) when the `g729` feature is enabled. Opus (`111`) and G.722 (`9`)
-    /// remain post-beta or signaling-only experiments until media-core support
-    /// is wired through and covered by interop/perf tests.
+    /// comfort noise (`13`) when `comfort_noise_enabled = true`, G.729 (`18`)
+    /// when the `g729` feature is enabled, and Opus (`111`) when the `opus`
+    /// feature is enabled. G.722 (`9`) retains wire metadata support but is
+    /// rejected because no working encoder/decoder is implemented.
     ///
     /// Default: `vec![0, 8, 101]`.
     pub offered_codecs: Vec<u8>,

--- a/crates/sip/rvoip-sip/src/media_stream.rs
+++ b/crates/sip/rvoip-sip/src/media_stream.rs
@@ -115,18 +115,30 @@ impl SipPayloadCodec {
 fn codec_descriptor(
     config: &crate::session_store::state::NegotiatedConfig,
 ) -> Result<(CodecInfo, u8), &'static str> {
-    let (name, payload_type) = if matches!(
+    let name = if matches!(
         config.codec.to_ascii_lowercase().as_str(),
         "pcmu" | "g.711-mu" | "g711-mu" | "g711-u"
     ) {
-        ("g.711-mu", 0)
+        if config.sample_rate != 8_000 || config.channels != 1 {
+            return Err("invalid-pcmu-shape");
+        }
+        "g.711-mu"
     } else if matches!(
         config.codec.to_ascii_lowercase().as_str(),
         "pcma" | "g.711-a" | "g711-a"
     ) {
-        ("g.711-a", 8)
+        if config.sample_rate != 8_000 || config.channels != 1 {
+            return Err("invalid-pcma-shape");
+        }
+        "g.711-a"
     } else if config.codec.eq_ignore_ascii_case("opus") {
-        ("opus", 111)
+        if !cfg!(feature = "opus") {
+            return Err("opus-feature-disabled");
+        }
+        if config.sample_rate != 48_000 || !matches!(config.channels, 1 | 2) {
+            return Err("invalid-opus-shape");
+        }
+        "opus"
     } else {
         return Err("unsupported-negotiated-codec");
     };
@@ -137,7 +149,7 @@ fn codec_descriptor(
             channels: config.channels,
             fmtp: None,
         },
-        payload_type,
+        config.payload_type,
     ))
 }
 
@@ -845,6 +857,7 @@ async fn run_media_driver(
         Arc::clone(&coordinator),
         session_id.clone(),
         decoder,
+        payload_type,
         channels,
         frames_out_rx,
     );
@@ -896,6 +909,7 @@ async fn run_outbound_pump(
     coordinator: Arc<UnifiedCoordinator>,
     session_id: SessionId,
     mut decoder: SipPayloadCodec,
+    payload_type: u8,
     channels: u8,
     mut frames_out_rx: mpsc::Receiver<MediaFrame>,
 ) -> &'static str {
@@ -908,6 +922,18 @@ async fn run_outbound_pump(
                     return "sip-dtmf-send-failed";
                 }
             }
+            continue;
+        }
+        if media_frame
+            .payload_type
+            .is_some_and(|actual| actual != payload_type)
+        {
+            tracing::trace!(
+                target: "rvoip_sip",
+                actual = ?media_frame.payload_type,
+                expected = payload_type,
+                "SipMediaStream: dropping unnegotiated payload type"
+            );
             continue;
         }
         let mut audio_frame = match decoder.decode(&media_frame.payload) {
@@ -1171,6 +1197,13 @@ mod negotiated_codec_tests {
             local_addr: SocketAddr::from(([127, 0, 0, 1], 10_000)),
             remote_addr: SocketAddr::from(([127, 0, 0, 1], 20_000)),
             codec: codec.to_string(),
+            payload_type: if codec.eq_ignore_ascii_case("opus") {
+                111
+            } else if codec.eq_ignore_ascii_case("PCMA") {
+                8
+            } else {
+                0
+            },
             sample_rate,
             channels,
         }
@@ -1204,16 +1237,26 @@ mod negotiated_codec_tests {
     #[cfg(feature = "opus")]
     #[test]
     fn opus_descriptor_and_codec_follow_sdp_clock_and_channels() {
-        let config = negotiated("opus", 48_000, 2);
+        let mut config = negotiated("opus", 48_000, 2);
+        config.payload_type = 96;
         let (descriptor, payload_type) = codec_descriptor(&config).unwrap();
         assert_eq!(descriptor.name, "opus");
         assert_eq!(descriptor.clock_rate_hz, 48_000);
         assert_eq!(descriptor.channels, 2);
-        assert_eq!(payload_type, 111);
+        assert_eq!(payload_type, 96);
         assert!(matches!(
             SipPayloadCodec::from_negotiated(&config),
             Ok(SipPayloadCodec::Opus(_))
         ));
+
+        let mut encoder = SipPayloadCodec::from_negotiated(&config).unwrap();
+        let mut decoder = SipPayloadCodec::from_negotiated(&config).unwrap();
+        let frame = rvoip_media_core::types::AudioFrame::new(vec![0; 960 * 2], 48_000, 2, 960);
+        let payload = encoder.encode(&frame).unwrap();
+        let decoded = decoder.decode(&payload).unwrap();
+        assert_eq!(decoded.sample_rate, 48_000);
+        assert_eq!(decoded.channels, 2);
+        assert_eq!(decoded.samples.len(), 960 * 2);
     }
 
     #[test]

--- a/crates/sip/rvoip-sip/src/session_store/state.rs
+++ b/crates/sip/rvoip-sip/src/session_store/state.rs
@@ -22,6 +22,8 @@ pub struct NegotiatedConfig {
     pub local_addr: SocketAddr,
     pub remote_addr: SocketAddr,
     pub codec: String,
+    #[serde(default)]
+    pub payload_type: u8,
     pub sample_rate: u32,
     pub channels: u8,
 }
@@ -33,6 +35,7 @@ impl fmt::Debug for NegotiatedConfig {
             .field("local_address_present", &true)
             .field("remote_address_present", &true)
             .field("codec_bytes", &self.codec.len())
+            .field("payload_type", &self.payload_type)
             .field("sample_rate", &self.sample_rate)
             .field("channels", &self.channels)
             .finish()

--- a/crates/sip/rvoip-sip/src/state_machine/actions.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/actions.rs
@@ -214,6 +214,7 @@ async fn release_lane_owned_resources(
     cleanup_lane_owned_media(session, media_adapter).await
 }
 
+#[cfg(test)]
 fn negotiated_audio_shape(codec: &str) -> (u32, u8) {
     if codec.eq_ignore_ascii_case("opus") {
         // The SIP SDP profile advertises `opus/48000/2`; preserve that exact
@@ -2325,13 +2326,13 @@ pub(crate) async fn execute_action(
                     .await?;
 
                 // Convert to session_store NegotiatedConfig
-                let (sample_rate, channels) = negotiated_audio_shape(&config.codec);
                 let session_config = crate::session_store::state::NegotiatedConfig {
                     local_addr: config.local_addr,
                     remote_addr: config.remote_addr,
                     codec: config.codec,
-                    sample_rate,
-                    channels,
+                    payload_type: config.payload_type,
+                    sample_rate: config.clock_rate,
+                    channels: config.channels,
                 };
                 session.negotiated_config = Some(session_config);
                 session.local_media_direction = config.local_direction;
@@ -2359,13 +2360,13 @@ pub(crate) async fn execute_action(
                     .await?;
 
                 // Convert to session_store NegotiatedConfig
-                let (sample_rate, channels) = negotiated_audio_shape(&config.codec);
                 let session_config = crate::session_store::state::NegotiatedConfig {
                     local_addr: config.local_addr,
                     remote_addr: config.remote_addr,
                     codec: config.codec,
-                    sample_rate,
-                    channels,
+                    payload_type: config.payload_type,
+                    sample_rate: config.clock_rate,
+                    channels: config.channels,
                 };
                 session.local_sdp = Some(local_sdp);
                 session.negotiated_config = Some(session_config);
@@ -2388,13 +2389,13 @@ pub(crate) async fn execute_action(
                 let (local_sdp, config) = media_adapter
                     .negotiate_sdp_as_uas_lane_owned(session, &remote_sdp)
                     .await?;
-                let (sample_rate, channels) = negotiated_audio_shape(&config.codec);
                 let session_config = crate::session_store::state::NegotiatedConfig {
                     local_addr: config.local_addr,
                     remote_addr: config.remote_addr,
                     codec: config.codec,
-                    sample_rate,
-                    channels,
+                    payload_type: config.payload_type,
+                    sample_rate: config.clock_rate,
+                    channels: config.channels,
                 };
                 session.local_sdp = Some(local_sdp);
                 session.negotiated_config = Some(session_config);
@@ -5123,6 +5124,7 @@ mod lane_owned_action_state_tests {
             local_addr: "127.0.0.1:16000".parse().expect("local address"),
             remote_addr: "127.0.0.1:16002".parse().expect("remote address"),
             codec: "PCMU".to_string(),
+            payload_type: 0,
             sample_rate: 8_000,
             channels: 1,
         });

--- a/crates/sip/rvoip-sip/tests/guard_tests.rs
+++ b/crates/sip/rvoip-sip/tests/guard_tests.rs
@@ -47,6 +47,7 @@ async fn test_has_negotiated_config_true() {
         local_addr: "127.0.0.1:5000".parse::<SocketAddr>().unwrap(),
         remote_addr: "127.0.0.1:5002".parse::<SocketAddr>().unwrap(),
         codec: "PCMU".into(),
+        payload_type: 0,
         sample_rate: 8000,
         channels: 1,
     });

--- a/crates/sip/rvoip-sip/tests/single_authority_architecture.rs
+++ b/crates/sip/rvoip-sip/tests/single_authority_architecture.rs
@@ -1411,7 +1411,7 @@ fn session_handle_audio_keeps_exact_generation_authority_off_the_raw_hot_path() 
         "pub(crate) async fn send_audio_frame_exact",
     ));
     assert!(send.contains("media_for_handle_exact(handle)"));
-    assert!(send.contains("encode_and_send_audio_frame(&exact.dialog_id"));
+    assert!(send.contains("encode_and_send_audio(&exact.dialog_id,audio_frame)"));
     assert!(!send.contains("current_media("));
     assert!(!send.contains("media_is_still_exact("));
     assert!(!send.contains("session_id:&SessionId"));


### PR DESCRIPTION
## What changed

- make audio and video codec-name classification ASCII case-insensitive
- use codec-core's real `opus` backend as the canonical Opus implementation
- map the Opus feature through media-core and keep `opus-sim` only as a deprecated compatibility alias to the real backend
- stop advertising or constructing Opus when its feature is disabled
- retain low-level G.722 RTP payload handling while excluding G.722 from working-codec and negotiation lists
- return explicit unsupported-codec errors instead of accepting inconsistent codec contracts
- keep media-session codec/source updates coherent and preserve generated sources across updates
- align SIP SDP negotiation with the codec and security configuration actually applied to media

## Regression proof

The first behavior commit replaces simulated Opus payloads, case-sensitive support checks, and misleading G.722 availability with honest capability and construction behavior. Dedicated feature-disabled coverage verifies that Opus cannot be advertised or built without the backend.

## Validation

- codec-core feature matrix:
  - no default features: 39 tests
  - default: 104 tests
  - `opus`: 114 tests
  - deprecated `opus-sim`: 115 tests
  - `all-codecs`: 153 tests
- media-core default and Opus suites, including both RTP soak tests
- SIP library default: 754 tests
- SIP library with Opus: 757 tests
- strict all-target Clippy for codec-core, media-core, and all-feature rtp-core
- formatting and diff checks

The prerequisite SRTP and SDES repairs merged in #42 and #43.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opus behavior and SDP/capability advertisement change materially (real audio vs prior simulation), which can affect negotiated calls and transcoding paths; G.722 can no longer be selected as a working codec despite payload metadata remaining.
> 
> **Overview**
> **Opus** moves from a simulated encoder/decoder in `codec-core` to **libopus** (`opus` optional dep; `opus-sim` is only a deprecated alias to the same backend). Encode/decode, buffer sizing (up to 4 KB packets, 120 ms decode buffers), config validation, and `CodecConfig::with_bitrate` sync for Opus are updated accordingly, with expanded tests.
> 
> **media-core** drops its direct `opus` crate usage and **delegates to `rvoip-codec-core`** via a thin frame adapter. Factory, transcoding, and engine defaults only expose Opus when the `opus` feature is on. A new **`UnsupportedCodec`** error distinguishes “known but not built” from unknown payload types.
> 
> **G.722** stays available for RTP payload plumbing but **`audio_codec_available` returns false**, factory/negotiation reject construction, and capabilities no longer advertise a working G.722 codec.
> 
> Negotiation, SDP capability export, and `CodecMapper` gate local audio offers on **`audio_codec_available`**. Codec-name checks (audio/video, Opus SDP strings) are **ASCII case-insensitive**. Docs/README reflect real Opus and explicit G.722 limits.
> 
> Smaller follow-ons: G.711 lint/doc polish, feature-gated factory/capability tests, and `opus` moved off `media-core`’s dependency list into codec-core.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7497bd9400953bf870bf72d670a12f73e48e40bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->