### PR TITLE
fix(sip): support signaling-only hold and resume

### DIFF
--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -4188,6 +4188,46 @@ mod sdp_format_tests {
         }
     }
 
+    #[tokio::test]
+    async fn signaling_only_hold_and_resume_sdp_need_no_media_allocation() {
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let store = Arc::new(SessionStore::new());
+        let session_id = SessionId("signaling-only-hold-resume".to_string());
+        store
+            .create_session(session_id.clone(), Role::UAC, false)
+            .await
+            .expect("create signaling-only session");
+
+        let mut adapter = MediaAdapter::new(
+            Arc::new(MediaSessionController::new()),
+            store,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_000,
+            16_100,
+        );
+        adapter.set_media_mode(MediaMode::SignalingOnly { sdp_rtp_port: 9 });
+
+        let hold = adapter
+            .create_hold_sdp_for_session(&session_id)
+            .await
+            .expect("signaling-only hold SDP");
+        let resume = adapter
+            .create_active_sdp_for_session(&session_id)
+            .await
+            .expect("signaling-only resume SDP");
+
+        assert!(hold.contains("m=audio 9 RTP/AVP"), "{hold}");
+        assert!(hold.contains("a=sendonly"), "{hold}");
+        assert!(resume.contains("m=audio 9 RTP/AVP"), "{resume}");
+        assert!(resume.contains("a=sendrecv"), "{resume}");
+        assert!(adapter.media_sessions.is_empty());
+        assert!(adapter.media_resources.is_empty());
+    }
+
     #[cfg(feature = "perf-tests")]
     #[test]
     fn deleted_adapter_mappings_keep_zero_compatibility_diagnostics() {

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -2811,15 +2811,15 @@ impl MediaAdapter {
         direction: crate::types::MediaDirection,
     ) -> Result<String> {
         let session_id = session.session_id.clone();
-        // Resolve the exact managed resource once and prime the cached session
-        // info. Both SRTP and plaintext paths share this canonical owner.
-        let exact_media = self.lane_owned_media(session)?;
-        let dialog_id = &exact_media.dialog_id;
         if self.signaling_only_local_port().is_some() {
             return self
                 .generate_signaling_only_sdp_offer_lane_owned(session, direction)
                 .await;
         }
+        // Resolve the exact managed resource once and prime the cached session
+        // info. Both SRTP and plaintext paths share this canonical owner.
+        let exact_media = self.lane_owned_media(session)?;
+        let dialog_id = &exact_media.dialog_id;
         let info = self
             .controller
             .get_session_info(dialog_id)

--- a/crates/sip/rvoip-sip/src/session_store/state.rs
+++ b/crates/sip/rvoip-sip/src/session_store/state.rs
@@ -168,6 +168,10 @@ pub struct SessionStateCold {
     pub redirect_targets: Vec<String>,
     pub redirect_attempts: u8,
     pub pending_reinvite: Option<PendingReinvite>,
+    /// Stable local SDP captured before an outbound re-INVITE replaces the
+    /// working offer. The outer option marks an in-flight snapshot; the inner
+    /// option preserves whether the stable dialog had local SDP at all.
+    pub(crate) stable_local_sdp_before_reinvite: Option<Option<String>>,
     pub reinvite_retry_attempts: u8,
     pub session_timer_min_se: Option<u32>,
     pub session_timer_retry_count: u8,
@@ -282,10 +286,6 @@ pub struct SessionState {
     // SDP data
     pub local_sdp: Option<String>,
     pub remote_sdp: Option<String>,
-    /// Stable local SDP captured before an outbound re-INVITE replaces the
-    /// working offer. The outer option marks an in-flight snapshot; the inner
-    /// option preserves whether the stable dialog had local SDP at all.
-    pub(crate) stable_local_sdp_before_reinvite: Option<Option<String>>,
     pub negotiated_config: Option<NegotiatedConfig>,
     /// Negotiated media security, populated after SRTP contexts install.
     pub media_security: Option<MediaSecurityState>,
@@ -860,7 +860,6 @@ impl SessionState {
             call_established_triggered: false,
             local_sdp: None,
             remote_sdp: None,
-            stable_local_sdp_before_reinvite: None,
             negotiated_config: None,
             media_security: None,
             sdp_origin_session_id,
@@ -898,6 +897,7 @@ impl SessionState {
                 redirect_targets: Vec::new(),
                 redirect_attempts: 0,
                 pending_reinvite: None,
+                stable_local_sdp_before_reinvite: None,
                 reinvite_retry_attempts: 0,
                 session_timer_min_se: None,
                 session_timer_retry_count: 0,

--- a/crates/sip/rvoip-sip/src/session_store/state.rs
+++ b/crates/sip/rvoip-sip/src/session_store/state.rs
@@ -282,6 +282,10 @@ pub struct SessionState {
     // SDP data
     pub local_sdp: Option<String>,
     pub remote_sdp: Option<String>,
+    /// Stable local SDP captured before an outbound re-INVITE replaces the
+    /// working offer. The outer option marks an in-flight snapshot; the inner
+    /// option preserves whether the stable dialog had local SDP at all.
+    pub(crate) stable_local_sdp_before_reinvite: Option<Option<String>>,
     pub negotiated_config: Option<NegotiatedConfig>,
     /// Negotiated media security, populated after SRTP contexts install.
     pub media_security: Option<MediaSecurityState>,
@@ -417,6 +421,10 @@ impl fmt::Debug for SessionState {
             )
             .field("local_sdp_present", &self.local_sdp.is_some())
             .field("remote_sdp_present", &self.remote_sdp.is_some())
+            .field(
+                "stable_local_sdp_before_reinvite_present",
+                &self.stable_local_sdp_before_reinvite.is_some(),
+            )
             .field(
                 "negotiated_config_present",
                 &self.negotiated_config.is_some(),
@@ -852,6 +860,7 @@ impl SessionState {
             call_established_triggered: false,
             local_sdp: None,
             remote_sdp: None,
+            stable_local_sdp_before_reinvite: None,
             negotiated_config: None,
             media_security: None,
             sdp_origin_session_id,

--- a/crates/sip/rvoip-sip/src/state_machine/actions.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/actions.rs
@@ -2813,22 +2813,22 @@ pub(crate) async fn execute_action(
                         Some(("SIP".to_string(), 408, Some("Session expired".to_string())));
                 }
                 "SuspendMedia" => {
+                    let direction = crate::types::MediaDirection::SendOnly;
                     if let Some(media_id) = &session.media_session_id {
-                        let direction = crate::types::MediaDirection::SendOnly;
                         media_adapter
                             .set_media_direction(media_id.clone(), direction)
                             .await?;
-                        session.local_media_direction = direction;
                     }
+                    session.local_media_direction = direction;
                 }
                 "ResumeMedia" => {
+                    let direction = crate::types::MediaDirection::SendRecv;
                     if let Some(media_id) = &session.media_session_id {
-                        let direction = crate::types::MediaDirection::SendRecv;
                         media_adapter
                             .set_media_direction(media_id.clone(), direction)
                             .await?;
-                        session.local_media_direction = direction;
                     }
+                    session.local_media_direction = direction;
                 }
                 "CheckReadiness" => {
                     return Ok(ActionOutcome::with_event(EventType::CheckConditions));

--- a/crates/sip/rvoip-sip/src/state_machine/actions.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/actions.rs
@@ -173,6 +173,23 @@ fn prepare_session_refresh_reinvite(
     Ok(ActionOutcome::with_event(EventType::SendOutboundReInvite))
 }
 
+pub(crate) fn stage_reinvite_local_sdp(session: &mut SessionState, offer: String) {
+    if session.stable_local_sdp_before_reinvite.is_none() {
+        session.stable_local_sdp_before_reinvite = Some(session.local_sdp.clone());
+    }
+    session.local_sdp = Some(offer);
+}
+
+fn commit_reinvite_local_sdp(session: &mut SessionState) {
+    session.stable_local_sdp_before_reinvite = None;
+}
+
+fn rollback_reinvite_local_sdp(session: &mut SessionState) {
+    if let Some(stable) = session.stable_local_sdp_before_reinvite.take() {
+        session.local_sdp = stable;
+    }
+}
+
 /// Retire every lifecycle attachment derived from one media allocation in the
 /// lane-owned working state. The executor publishes this mutation exactly once
 /// after all ordered actions have finished.
@@ -181,6 +198,7 @@ fn retire_lane_owned_media_identity(session: &mut SessionState) {
     session.media_session_ready = false;
     session.sdp_negotiated = false;
     session.local_sdp = None;
+    session.stable_local_sdp_before_reinvite = None;
     session.negotiated_config = None;
 }
 
@@ -2019,6 +2037,7 @@ pub(crate) async fn execute_action(
             }
         }
         Action::ClearPendingReinvite => {
+            rollback_reinvite_local_sdp(session);
             session.pending_reinvite = None;
             session.reinvite_retry_attempts = 0;
             debug!(
@@ -2036,6 +2055,7 @@ pub(crate) async fn execute_action(
             use crate::state_table::types::Role;
             const MAX_GLARE_RETRIES: u8 = 3;
             if session.reinvite_retry_attempts >= MAX_GLARE_RETRIES {
+                rollback_reinvite_local_sdp(session);
                 session.pending_reinvite = None;
                 return Err(format!(
                     "491 glare retry limit ({}) exceeded for session {}",
@@ -2224,7 +2244,7 @@ pub(crate) async fn execute_action(
                 .create_hold_sdp_for_session_lane_owned(session)
                 .await
                 .map_err(|e| format!("create_hold_sdp failed: {}", e))?;
-            session.local_sdp = Some(hold_sdp.clone());
+            stage_reinvite_local_sdp(session, hold_sdp.clone());
             session.pending_reinvite = Some(crate::session_store::state::PendingReinvite::Hold);
             dialog_adapter
                 .send_reinvite_with_options_lane_owned(
@@ -2242,7 +2262,7 @@ pub(crate) async fn execute_action(
                 .create_active_sdp_for_session_lane_owned(session)
                 .await
                 .map_err(|e| format!("create_active_sdp failed: {}", e))?;
-            session.local_sdp = Some(active_sdp.clone());
+            stage_reinvite_local_sdp(session, active_sdp.clone());
             session.pending_reinvite = Some(crate::session_store::state::PendingReinvite::Resume);
             dialog_adapter
                 .send_reinvite_with_options_lane_owned(
@@ -2338,6 +2358,7 @@ pub(crate) async fn execute_action(
                 session.local_media_direction = config.local_direction;
                 session.remote_media_direction = config.remote_direction;
                 session.sdp_negotiated = true;
+                commit_reinvite_local_sdp(session);
                 info!("SDP negotiated as UAC for session {}", session.session_id);
             }
         }
@@ -2515,7 +2536,7 @@ pub(crate) async fn execute_action(
                     .await
                     .map_err(|e| format!("create_active_sdp failed: {}", e))?
             };
-            session.local_sdp = Some(sdp.clone());
+            stage_reinvite_local_sdp(session, sdp.clone());
             session.pending_reinvite = Some(kind);
             // A 491/ReinviteGlare response is queued on the same exact-session
             // lane. It observes this SDP and retry intent only after the
@@ -4984,6 +5005,49 @@ mod negotiated_audio_shape_tests {
         assert_eq!(negotiated_audio_shape("PCMA"), (8_000, 1));
         assert_eq!(negotiated_audio_shape("opus"), (48_000, 2));
         assert_eq!(negotiated_audio_shape("OPUS"), (48_000, 2));
+    }
+}
+
+#[cfg(test)]
+mod reinvite_sdp_snapshot_tests {
+    use super::{commit_reinvite_local_sdp, rollback_reinvite_local_sdp, stage_reinvite_local_sdp};
+    use crate::session_store::state::SessionState;
+    use crate::state_table::{Role, SessionId};
+
+    #[test]
+    fn failed_reinvite_restores_the_preceding_stable_local_sdp() {
+        let mut session = SessionState::new(SessionId::new(), Role::UAC);
+        session.local_sdp = Some("stable".to_string());
+
+        stage_reinvite_local_sdp(&mut session, "hold-offer".to_string());
+        stage_reinvite_local_sdp(&mut session, "hold-retry".to_string());
+        rollback_reinvite_local_sdp(&mut session);
+
+        assert_eq!(session.local_sdp.as_deref(), Some("stable"));
+        assert!(session.stable_local_sdp_before_reinvite.is_none());
+    }
+
+    #[test]
+    fn successful_reinvite_commits_the_new_local_sdp() {
+        let mut session = SessionState::new(SessionId::new(), Role::UAC);
+        session.local_sdp = Some("stable".to_string());
+
+        stage_reinvite_local_sdp(&mut session, "resume-offer".to_string());
+        commit_reinvite_local_sdp(&mut session);
+
+        assert_eq!(session.local_sdp.as_deref(), Some("resume-offer"));
+        assert!(session.stable_local_sdp_before_reinvite.is_none());
+    }
+
+    #[test]
+    fn failed_reinvite_preserves_an_absent_stable_local_sdp() {
+        let mut session = SessionState::new(SessionId::new(), Role::UAC);
+
+        stage_reinvite_local_sdp(&mut session, "offer".to_string());
+        rollback_reinvite_local_sdp(&mut session);
+
+        assert!(session.local_sdp.is_none());
+        assert!(session.stable_local_sdp_before_reinvite.is_none());
     }
 }
 

--- a/crates/sip/rvoip-sip/src/state_machine/executor.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/executor.rs
@@ -1982,7 +1982,7 @@ impl StateMachine {
                                             return Err(error);
                                         }
                                     };
-                                    session.local_sdp = Some(sdp.clone());
+                                    actions::stage_reinvite_local_sdp(&mut session, sdp.clone());
                                     let committed = commit_lane_state(&dispatch_store, session)
                                         .map_err(|error| error.to_string())?;
 

--- a/crates/sip/rvoip-sip/state_tables/default.yaml
+++ b/crates/sip/rvoip-sip/state_tables/default.yaml
@@ -758,6 +758,20 @@ transitions:
       - type: "SendReINVITE"
     description: "Send hold re-INVITE; stay on current media until 2xx (RFC 3261 §14.1)"
 
+  # Repeating an already-satisfied local direction request is a successful
+  # no-op. In particular, do not create another offer or re-INVITE.
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "HoldCall"
+    description: "Already held — idempotent success without another re-INVITE"
+
+  - role: "Both"
+    state: "Active"
+    event:
+      type: "ResumeCall"
+    description: "Already active — idempotent success without another re-INVITE"
+
   - role: "Both"
     state: "HoldPending"
     event:

--- a/crates/sip/rvoip-sip/tests/signaling_only_hold_resume.rs
+++ b/crates/sip/rvoip-sip/tests/signaling_only_hold_resume.rs
@@ -1,0 +1,104 @@
+//! End-to-end hold/resume coverage when neither endpoint allocates media-core RTP.
+
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use rvoip_sip::{CallState, Config, Event, SessionHandle, StreamPeer};
+
+fn reserve_loopback_port() -> u16 {
+    UdpSocket::bind("127.0.0.1:0")
+        .expect("reserve loopback port")
+        .local_addr()
+        .expect("reserved loopback address")
+        .port()
+}
+
+async fn wait_for_state(call: &SessionHandle, expected: CallState) {
+    tokio::time::timeout(Duration::from_secs(8), async {
+        loop {
+            if matches!(call.state().await, Ok(state) if state == expected) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("call did not reach {expected:?}"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn signaling_only_hold_resume_is_negotiated_and_idempotent() {
+    let server_port = reserve_loopback_port();
+    let mut client_port = reserve_loopback_port();
+    while client_port == server_port {
+        client_port = reserve_loopback_port();
+    }
+
+    let mut server = StreamPeer::with_config(
+        Config::local("signaling-only-server", server_port).with_signaling_only_media(9),
+    )
+    .await
+    .expect("start signaling-only server");
+    let server_task = tokio::spawn(async move {
+        let incoming = tokio::time::timeout(Duration::from_secs(8), server.wait_for_incoming())
+            .await
+            .map_err(|_| "incoming call timed out".to_string())?
+            .map_err(|error| error.to_string())?;
+        let call = incoming.accept().await.map_err(|error| error.to_string())?;
+        let mut events = call.events().await.map_err(|error| error.to_string())?;
+        let mut remote_holds = 0;
+        let mut remote_resumes = 0;
+
+        tokio::time::timeout(Duration::from_secs(15), async {
+            while let Some(event) = events.next().await {
+                match event {
+                    Event::RemoteCallOnHold { .. } => remote_holds += 1,
+                    Event::RemoteCallResumed { .. } => remote_resumes += 1,
+                    Event::CallEnded { .. } | Event::CallFailed { .. } => break,
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .map_err(|_| "server event loop timed out".to_string())?;
+        server.shutdown().await.map_err(|error| error.to_string())?;
+        Ok::<_, String>((remote_holds, remote_resumes))
+    });
+
+    let client = StreamPeer::with_config(
+        Config::local("signaling-only-client", client_port).with_signaling_only_media(9),
+    )
+    .await
+    .expect("start signaling-only client");
+    let call_id = client
+        .invite(format!("sip:server@127.0.0.1:{server_port}"))
+        .send()
+        .await
+        .expect("send signaling-only INVITE");
+    let call = client.coordinator().session(&call_id);
+    call.wait_for_answered(Some(Duration::from_secs(8)))
+        .await
+        .expect("signaling-only call answered");
+
+    call.hold().await.expect("send signaling-only hold");
+    wait_for_state(&call, CallState::OnHold).await;
+    call.hold().await.expect("repeat hold is idempotent");
+    assert_eq!(call.state().await.expect("held state"), CallState::OnHold);
+
+    call.resume().await.expect("send signaling-only resume");
+    wait_for_state(&call, CallState::Active).await;
+    call.resume().await.expect("repeat resume is idempotent");
+    assert_eq!(call.state().await.expect("active state"), CallState::Active);
+
+    call.hangup().await.expect("hang up signaling-only call");
+    client.shutdown().await.expect("shutdown client");
+    let (remote_holds, remote_resumes) = server_task
+        .await
+        .expect("join server task")
+        .expect("server scenario");
+    assert_eq!(remote_holds, 1, "repeated hold emitted another negotiation");
+    assert_eq!(
+        remote_resumes, 1,
+        "repeated resume emitted another negotiation"
+    );
+}

--- a/crates/sip/rvoip-sip/tests/state_table_validation_tests.rs
+++ b/crates/sip/rvoip-sip/tests/state_table_validation_tests.rs
@@ -147,6 +147,32 @@ fn test_hold_resume_transitions() {
         "Missing resume transition from OnHold state"
     );
 
+    let repeated_hold = table
+        .get(&StateKey {
+            role: Role::Both,
+            state: CallState::OnHold,
+            event: EventType::HoldCall,
+        })
+        .expect("Missing idempotent hold transition from OnHold state");
+    assert_eq!(repeated_hold.next_state, None);
+    assert!(
+        repeated_hold.actions.is_empty(),
+        "Repeated hold must not send another re-INVITE"
+    );
+
+    let repeated_resume = table
+        .get(&StateKey {
+            role: Role::Both,
+            state: CallState::Active,
+            event: EventType::ResumeCall,
+        })
+        .expect("Missing idempotent resume transition from Active state");
+    assert_eq!(repeated_resume.next_state, None);
+    assert!(
+        repeated_resume.actions.is_empty(),
+        "Repeated resume must not send another re-INVITE"
+    );
+
     let hold_commit_key = StateKey {
         role: Role::Both,
         state: CallState::HoldPending,


### PR DESCRIPTION
## Summary
- generate hold/resume SDP before resolving an optional media allocation
- keep signaling-only direction and call state synchronized
- make repeated hold/resume requests idempotent
- roll back rejected offers to the preceding stable state

## Verification
- cargo fmt --all -- --check
- cargo test -p rvoip-sip --lib --locked (758 passed)
- cargo test -p rvoip-sip --test signaling_only_hold_resume --locked -- --nocapture
- cargo test -p rvoip-sip --test state_table_validation_tests --locked (11 passed)

This is intentionally separate from the broader SIP renegotiation repair.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hold/resume and re-INVITE SDP state in the SIP state machine; behavior is well covered by tests but affects negotiated call state on failure and signaling-only paths.
> 
> **Overview**
> **Signaling-only** endpoints can complete hold/resume without touching media-core: local SDP offer generation returns early on the signaling-only path before `lane_owned_media` resolution, and **SuspendMedia** / **ResumeMedia** always update `local_media_direction` even when there is no `media_session_id`.
> 
> Re-INVITE offers are **staged** via `stable_local_sdp_before_reinvite` and `stage_reinvite_local_sdp`; successful negotiation commits the new offer, while glare clears, retry exhaustion, and similar failures **roll back** to the prior stable `local_sdp`. Hold, resume, glare retry, and session-refresh re-INVITE paths use this staging instead of overwriting `local_sdp` directly.
> 
> Repeated **HoldCall** while **OnHold** or **ResumeCall** while **Active** are **idempotent** no-ops in `default.yaml` (no extra re-INVITE). New unit and integration tests cover signaling-only SDP, snapshot rollback/commit, and idempotent hold/resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfecb900309df032a3bfba06d25105df16b0d1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->