### PR TITLE
fix(registrar): satisfy strict 0.3.5 release gates

### DIFF
--- a/crates/sip/sip-registrar/src/api/mod.rs
+++ b/crates/sip/sip-registrar/src/api/mod.rs
@@ -179,9 +179,11 @@ impl RegistrarService {
 
     /// Create a new registrar service for B2BUA mode
     pub async fn new_b2bua() -> Result<Self> {
-        let mut config = RegistrarConfig::default();
-        config.auto_buddy_lists = true;
-        config.default_presence_enabled = true;
+        let config = RegistrarConfig {
+            auto_buddy_lists: true,
+            default_presence_enabled: true,
+            ..RegistrarConfig::default()
+        };
 
         Self::new_with_mode(ServiceMode::B2BUA, config).await
     }
@@ -520,10 +522,10 @@ impl RegistrarService {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         replay.sweep(now);
-        if !replay
+        if replay
             .nonces
             .get(nonce)
-            .is_some_and(|issued| issued.expires_at > now)
+            .is_none_or(|issued| issued.expires_at <= now)
         {
             return false;
         }

--- a/crates/sip/sip-registrar/src/events.rs
+++ b/crates/sip/sip-registrar/src/events.rs
@@ -186,6 +186,12 @@ pub struct RegistrarEventAdapter {
     session_handler: Option<Box<dyn Fn(RegistrarServiceEvent) + Send + Sync>>,
 }
 
+impl Default for RegistrarEventAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RegistrarEventAdapter {
     pub fn new() -> Self {
         Self {

--- a/crates/sip/sip-registrar/src/presence/mod.rs
+++ b/crates/sip/sip-registrar/src/presence/mod.rs
@@ -22,6 +22,12 @@ pub struct Presence {
     pidf: Arc<PidfGenerator>,
 }
 
+impl Default for Presence {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Presence {
     /// Create a new presence instance
     pub fn new() -> Self {

--- a/crates/sip/sip-registrar/src/presence/pidf.rs
+++ b/crates/sip/sip-registrar/src/presence/pidf.rs
@@ -25,6 +25,12 @@ fn decode_text(e: &BytesText) -> Result<String> {
 /// PIDF (Presence Information Data Format) generator and parser
 pub struct PidfGenerator;
 
+impl Default for PidfGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PidfGenerator {
     pub fn new() -> Self {
         Self
@@ -171,7 +177,7 @@ impl PidfGenerator {
             .map_err(|e| RegistrarError::PidfError(e.to_string()))?;
 
         let xml = writer.into_inner().into_inner();
-        Ok(String::from_utf8(xml).map_err(|e| RegistrarError::PidfError(e.to_string()))?)
+        String::from_utf8(xml).map_err(|e| RegistrarError::PidfError(e.to_string()))
     }
 
     /// Parse PIDF XML document into presence state
@@ -202,15 +208,11 @@ impl PidfGenerator {
                     match e.name().as_ref() {
                         b"presence" => {
                             // Extract entity attribute
-                            for attr in e.attributes() {
-                                if let Ok(attr) = attr {
-                                    if attr.key.as_ref() == b"entity" {
-                                        let entity = String::from_utf8_lossy(&attr.value);
-                                        presence.user_id = entity
-                                            .strip_prefix("sip:")
-                                            .unwrap_or(&entity)
-                                            .to_string();
-                                    }
+                            for attr in e.attributes().flatten() {
+                                if attr.key.as_ref() == b"entity" {
+                                    let entity = String::from_utf8_lossy(&attr.value);
+                                    presence.user_id =
+                                        entity.strip_prefix("sip:").unwrap_or(&entity).to_string();
                                 }
                             }
                         }
@@ -250,10 +252,10 @@ impl PidfGenerator {
                         ),
                     });
                 }
-                Ok(Event::End(ref e)) => match e.name().as_ref() {
-                    b"dm:activities" => in_activities = false,
-                    _ => {}
-                },
+                Ok(Event::End(ref e)) if e.name().as_ref() == b"dm:activities" => {
+                    in_activities = false;
+                }
+                Ok(Event::End(_)) => {}
                 Ok(Event::Eof) => break,
                 Err(e) => return Err(RegistrarError::PidfError(e.to_string())),
                 _ => {}

--- a/crates/sip/sip-registrar/src/presence/server.rs
+++ b/crates/sip/sip-registrar/src/presence/server.rs
@@ -66,11 +66,11 @@ impl PresenceServer {
                     display_name: Some(buddy_id.clone()),
                     status: presence
                         .extended_status
-                        .map(|s| PresenceStatus::from(s))
+                        .map(PresenceStatus::from)
                         .unwrap_or(PresenceStatus::Offline),
                     note: presence.note,
                     last_updated: presence.last_updated,
-                    is_online: presence.devices.len() > 0,
+                    is_online: !presence.devices.is_empty(),
                     active_devices: presence.devices.len(),
                 });
             }

--- a/crates/sip/sip-registrar/src/presence/store.rs
+++ b/crates/sip/sip-registrar/src/presence/store.rs
@@ -12,6 +12,12 @@ pub struct PresenceStore {
     presence: Arc<DashMap<String, PresenceState>>,
 }
 
+impl Default for PresenceStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PresenceStore {
     pub fn new() -> Self {
         Self {

--- a/crates/sip/sip-registrar/src/presence/subscription.rs
+++ b/crates/sip/sip-registrar/src/presence/subscription.rs
@@ -19,6 +19,12 @@ pub struct SubscriptionManager {
     watching: Arc<DashMap<String, Vec<String>>>,
 }
 
+impl Default for SubscriptionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SubscriptionManager {
     pub fn new() -> Self {
         Self {
@@ -172,7 +178,7 @@ impl SubscriptionManager {
 
         // Remove expired subscriptions
         for sub_id in to_expire {
-            if let Ok(_) = self.remove_subscription(&sub_id).await {
+            if self.remove_subscription(&sub_id).await.is_ok() {
                 expired.push(sub_id);
             }
         }

--- a/crates/sip/sip-registrar/src/registrar/mod.rs
+++ b/crates/sip/sip-registrar/src/registrar/mod.rs
@@ -28,6 +28,12 @@ pub struct Registrar {
     domain_aliases: Arc<DashMap<String, String>>,
 }
 
+impl Default for Registrar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Registrar {
     pub fn new() -> Self {
         Self::with_config(RegistrarConfig::default())

--- a/crates/sip/sip-registrar/src/registrar/registry.rs
+++ b/crates/sip/sip-registrar/src/registrar/registry.rs
@@ -585,6 +585,12 @@ impl UserRegistry {
     }
 }
 
+impl Default for UserRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn same_binding(existing: &ContactInfo, incoming: &ContactInfo) -> bool {
     existing.uri == incoming.uri
         || (incoming.reg_id.is_some()

--- a/crates/sip/sip-registrar/src/types.rs
+++ b/crates/sip/sip-registrar/src/types.rs
@@ -207,17 +207,12 @@ impl fmt::Debug for ContactInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ContactReachability {
+    #[default]
     Unknown,
     Reachable,
     Unreachable,
-}
-
-impl Default for ContactReachability {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 impl ContactInfo {

--- a/crates/sip/sip-registrar/tests/registration_hardening.rs
+++ b/crates/sip/sip-registrar/tests/registration_hardening.rs
@@ -126,9 +126,11 @@ async fn refresh_and_unregister_update_individual_aor_bindings() {
 
 #[tokio::test]
 async fn expired_contacts_are_not_returned_by_live_lookup() {
-    let mut config = RegistrarConfig::default();
-    config.min_expires = 1;
-    config.default_expires = 1;
+    let config = RegistrarConfig {
+        min_expires: 1,
+        default_expires: 1,
+        ..RegistrarConfig::default()
+    };
     let registrar = service_with_config(config).await;
     let alice = aor("sip:alice@example.com");
 
@@ -259,8 +261,10 @@ async fn path_and_outbound_flow_metadata_round_trip() {
         .unwrap();
     assert_eq!(registrar.lookup_aor(&alice).await.unwrap().len(), 2);
 
-    let mut no_path_config = RegistrarConfig::default();
-    no_path_config.support_path = false;
+    let no_path_config = RegistrarConfig {
+        support_path: false,
+        ..RegistrarConfig::default()
+    };
     let no_path_registrar = service_with_config(no_path_config).await;
     let bob = aor("sip:bob@example.com");
     let mut path_contact = contact("sip:bob@192.0.2.10:5060", 1.0);
@@ -276,10 +280,12 @@ async fn path_and_outbound_flow_metadata_round_trip() {
 
 #[tokio::test]
 async fn max_contact_policy_rejects_replaces_or_removes_unavailable() {
-    let mut reject_config = RegistrarConfig::default();
-    reject_config.max_contacts_per_aor = 1;
-    reject_config.remove_existing = false;
-    reject_config.remove_unavailable = false;
+    let reject_config = RegistrarConfig {
+        max_contacts_per_aor: 1,
+        remove_existing: false,
+        remove_unavailable: false,
+        ..RegistrarConfig::default()
+    };
     let reject_registrar = service_with_config(reject_config).await;
     let alice = aor("sip:alice@example.com");
     reject_registrar
@@ -311,9 +317,11 @@ async fn max_contact_policy_rejects_replaces_or_removes_unavailable() {
         Err(RegistrarError::UserNotFound(_))
     ));
 
-    let mut replace_config = RegistrarConfig::default();
-    replace_config.max_contacts_per_aor = 1;
-    replace_config.remove_existing = true;
+    let replace_config = RegistrarConfig {
+        max_contacts_per_aor: 1,
+        remove_existing: true,
+        ..RegistrarConfig::default()
+    };
     let replace_registrar = service_with_config(replace_config).await;
     let bob = aor("sip:bob@example.com");
     replace_registrar
@@ -328,10 +336,12 @@ async fn max_contact_policy_rejects_replaces_or_removes_unavailable() {
     assert_eq!(contacts.len(), 1);
     assert_eq!(contacts[0].uri, "sip:bob@192.0.2.11:5060");
 
-    let mut remove_unavailable_config = RegistrarConfig::default();
-    remove_unavailable_config.max_contacts_per_aor = 1;
-    remove_unavailable_config.remove_existing = false;
-    remove_unavailable_config.remove_unavailable = true;
+    let remove_unavailable_config = RegistrarConfig {
+        max_contacts_per_aor: 1,
+        remove_existing: false,
+        remove_unavailable: true,
+        ..RegistrarConfig::default()
+    };
     let remove_unavailable_registrar = service_with_config(remove_unavailable_config).await;
     let carol = aor("sip:carol@example.com");
     remove_unavailable_registrar


### PR DESCRIPTION
## Summary

- clear strict Clippy findings across rvoip-sip-registrar production code and registration-hardening tests
- add conventional Default implementations without changing registrar behavior
- keep the patch isolated from SIP renegotiation and signaling hot paths

## Validation

- `cargo clippy -p rvoip-sip-registrar --all-targets --no-deps --locked -- -D warnings`
- `cargo test -p rvoip-sip-registrar --locked`
- 28 unit tests, 7 registration-hardening tests, and doc tests pass
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical Clippy and Default wiring; digest nonce check is logically equivalent and scoped to sip-registrar with tests passing per PR description.
> 
> **Overview**
> Clears **strict Clippy** (`-D warnings`) across `rvoip-sip-registrar` with style and API cleanups that are intended to leave registrar behavior unchanged.
> 
> **`Default` implementations** are added for core types (`Registrar`, `Presence`, `PresenceStore`, `SubscriptionManager`, `PidfGenerator`, `UserRegistry`, `RegistrarEventAdapter`) and **`ContactReachability`** now uses derive `Default` instead of a hand-written impl. B2BUA startup and tests build **`RegistrarConfig`** with struct update syntax (`..Default()`) instead of mutating a default struct field-by-field.
> 
> **Digest replay** in `accept_register_nonce_count` rewrites the nonce validity check with `is_none_or` (same reject-if-missing-or-expired logic). **PIDF** parsing/generation gets minor Clippy fixes (attribute iteration, `Event::End` matching, direct `Result` return). Small idioms elsewhere: `map(PresenceStatus::from)`, `!devices.is_empty()`, and `remove_subscription(...).is_ok()` in subscription expiry.
> 
> **Registration-hardening tests** use the same config struct pattern; no new features or signaling-path changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b24927d00b62504bc86b433dd99e1e61beb053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->