### PR TITLE
fix(sip): make offer-answer renegotiation transactional

### DIFF
--- a/crates/foundation/infra-common/src/events/cross_crate.rs
+++ b/crates/foundation/infra-common/src/events/cross_crate.rs
@@ -1097,6 +1097,9 @@ pub enum DialogToSessionEvent {
         /// SIP method for the completed request attempt.
         method: String,
         outcome: OutboundRequestOutcome,
+        /// Transaction-correlated SDP answer, when present.
+        #[serde(default)]
+        response_sdp: Option<String>,
     },
 
     /// 3xx redirect response received (RFC 3261 §8.1.3.4 / §21.3). The UAC
@@ -1498,12 +1501,18 @@ impl fmt::Debug for DialogToSessionEvent {
                 transaction_id,
                 method,
                 outcome,
+                response_sdp,
             } => f
                 .debug_struct("OutboundRequestCompleted")
                 .field("transaction_id_present", &!transaction_id.is_empty())
                 .field("transaction_id_bytes", &transaction_id.len())
                 .field("method", &safe_auth_method_debug_label(method))
                 .field("outcome", outcome)
+                .field("response_sdp_present", &response_sdp.is_some())
+                .field(
+                    "response_sdp_bytes",
+                    &response_sdp.as_ref().map_or(0, String::len),
+                )
                 .finish(),
             Self::CallRedirected {
                 session_id,

--- a/crates/foundation/infra-common/src/events/cross_crate.rs
+++ b/crates/foundation/infra-common/src/events/cross_crate.rs
@@ -3066,6 +3066,7 @@ mod tests {
             transaction_id: TRANSACTION_SECRET.to_string(),
             method: METHOD_SECRET.to_string(),
             outcome: OutboundRequestOutcome::FinalResponse { status_code: 486 },
+            response_sdp: None,
         };
 
         let rendered = format!("{event:?}");

--- a/crates/media/media-core/src/relay/controller/mod.rs
+++ b/crates/media/media-core/src/relay/controller/mod.rs
@@ -1022,7 +1022,7 @@ impl MediaSessionController {
 
         // RtpSession exposes its transport via a typed accessor; we
         // need the UdpRtpTransport concrete type to reach
-        // `set_srtp_contexts`. Downcast once — the only transport
+        // the reversible SRTP context API. Downcast once — the only transport
         // type media-core constructs is UDP, so this is the
         // architecturally-correct narrowing.
         let session_guard = session_arc.lock().await;
@@ -1035,12 +1035,69 @@ impl MediaSessionController {
                     "install_srtp_contexts: RTP session is not a UdpRtpTransport".to_string(),
                 )
             })?;
-        udp_transport
-            .set_srtp_contexts(send_ctx, recv_ctx)
+        let _rollback = udp_transport
+            .replace_srtp_contexts(send_ctx, recv_ctx)
             .await
             .map_err(|error| Error::config(format!("failed to install SRTP contexts: {error}")))?;
         info!("Installed SDES-SRTP contexts on dialog {}", dialog_id);
         Ok(())
+    }
+
+    /// Prepare a reversible directional SRTP replacement for one exact RTP
+    /// session. Dropping the returned token commits the new contexts.
+    pub async fn prepare_srtp_context_swap(
+        &self,
+        dialog_id: &DialogId,
+        send_ctx: rvoip_rtp_core::srtp::SrtpContext,
+        recv_ctx: rvoip_rtp_core::srtp::SrtpContext,
+    ) -> Result<rvoip_rtp_core::transport::SrtpContextRollback> {
+        let session_arc = self
+            .rtp_sessions
+            .get(dialog_id)
+            .map(|entry| entry.value().session.clone())
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+        let session_guard = session_arc.lock().await;
+        let transport = session_guard.transport();
+        let udp_transport = transport
+            .as_any()
+            .downcast_ref::<rvoip_rtp_core::transport::UdpRtpTransport>()
+            .ok_or_else(|| {
+                Error::config(
+                    "prepare_srtp_context_swap: RTP session is not a UdpRtpTransport".to_string(),
+                )
+            })?;
+        udp_transport
+            .replace_srtp_contexts(send_ctx, recv_ctx)
+            .await
+            .map_err(|error| Error::config(format!("failed to replace SRTP contexts: {error}")))
+    }
+
+    /// Restore a prepared SRTP replacement if its SIP commit reaches a
+    /// definite zero-wire failure.
+    pub async fn rollback_srtp_context_swap(
+        &self,
+        dialog_id: &DialogId,
+        rollback: rvoip_rtp_core::transport::SrtpContextRollback,
+    ) -> Result<()> {
+        let session_arc = self
+            .rtp_sessions
+            .get(dialog_id)
+            .map(|entry| entry.value().session.clone())
+            .ok_or_else(|| Error::session_not_found(dialog_id.as_str()))?;
+        let session_guard = session_arc.lock().await;
+        let transport = session_guard.transport();
+        let udp_transport = transport
+            .as_any()
+            .downcast_ref::<rvoip_rtp_core::transport::UdpRtpTransport>()
+            .ok_or_else(|| {
+                Error::config(
+                    "rollback_srtp_context_swap: RTP session is not a UdpRtpTransport".to_string(),
+                )
+            })?;
+        udp_transport
+            .rollback_srtp_contexts(rollback)
+            .await
+            .map_err(|error| Error::config(format!("failed to restore SRTP contexts: {error}")))
     }
 
     fn cleanup_per_dialog_side_state(&self, dialog_id: &DialogId) {

--- a/crates/media/rtp-core/src/transport/mod.rs
+++ b/crates/media/rtp-core/src/transport/mod.rs
@@ -141,7 +141,7 @@ pub use allocator::{
 pub use security_transport::SecurityRtpTransport;
 pub use symmetric::{SymmetricRtpDiagnostics, SymmetricRtpPolicy};
 pub use tcp::TcpRtpTransport;
-pub use udp::{set_diagnostics as set_udp_diagnostics, UdpRtpTransport};
+pub use udp::{set_diagnostics as set_udp_diagnostics, SrtpContextRollback, UdpRtpTransport};
 pub use validation::{PlatformSocketStrategy, PlatformType, RtpSocketValidator};
 
 #[cfg(test)]

--- a/crates/media/rtp-core/src/transport/udp.rs
+++ b/crates/media/rtp-core/src/transport/udp.rs
@@ -1124,9 +1124,15 @@ impl UdpRtpTransport {
         send: crate::srtp::SrtpContext,
         recv: crate::srtp::SrtpContext,
     ) -> Result<SrtpContextRollback> {
+        // Latch before inspecting caller-provided contexts. A rejected
+        // installation must fail closed even when its error is ignored; the
+        // exact rollback token may restore the previous policy only after a
+        // fully validated pair has actually been installed.
+        let previous_secure_media_required =
+            self.secure_media_required.swap(true, Ordering::AcqRel);
         send.validate_for_secure_transport()?;
         recv.validate_for_secure_transport()?;
-        let (previous_send, previous_recv, previous_secure_media_required, installed_generation) = {
+        let (previous_send, previous_recv, installed_generation) = {
             let mut send_guard = self.srtp_send.lock();
             let mut recv_guard = self.srtp_recv.lock();
             let current_generation = self.srtp_context_generation.load(Ordering::Acquire);
@@ -1134,18 +1140,11 @@ impl UdpRtpTransport {
                 Error::InvalidState("SRTP context generation exhausted".to_string())
             })?;
             let installed_generation = current_generation + 1;
-            let previous_secure_media_required = self.secure_media_required.load(Ordering::Acquire);
             let previous_send = std::mem::replace(&mut *send_guard, Some(send));
             let previous_recv = std::mem::replace(&mut *recv_guard, Some(recv));
             self.srtp_context_generation
                 .store(installed_generation, Ordering::Release);
-            self.secure_media_required.store(true, Ordering::Release);
-            (
-                previous_send,
-                previous_recv,
-                previous_secure_media_required,
-                installed_generation,
-            )
+            (previous_send, previous_recv, installed_generation)
         };
         if srtp_diagnostics_enabled() {
             info!(

--- a/crates/media/rtp-core/src/transport/udp.rs
+++ b/crates/media/rtp-core/src/transport/udp.rs
@@ -370,6 +370,11 @@ pub struct UdpRtpTransport {
     /// replacement so it cannot overwrite a later re-key.
     srtp_context_generation: Arc<AtomicU64>,
 
+    /// Serializes SRTP context replacement and rollback. The guard protects
+    /// only CPU-local validation and pointer swaps and is never held across
+    /// network I/O or an `.await` point.
+    srtp_context_update: Arc<parking_lot::Mutex<()>>,
+
     /// Makes allocator release idempotent across explicit close and Drop.
     allocator_release_started: AtomicBool,
 
@@ -564,6 +569,7 @@ impl UdpRtpTransport {
             active: Arc::new(AtomicBool::new(false)),
             secure_media_required: Arc::new(AtomicBool::new(false)),
             srtp_context_generation: Arc::new(AtomicU64::new(0)),
+            srtp_context_update: Arc::new(parking_lot::Mutex::new(())),
             allocator_release_started: AtomicBool::new(false),
             srtp_send: Arc::new(parking_lot::Mutex::new(None)),
             srtp_recv: Arc::new(parking_lot::Mutex::new(None)),
@@ -1124,21 +1130,39 @@ impl UdpRtpTransport {
         send: crate::srtp::SrtpContext,
         recv: crate::srtp::SrtpContext,
     ) -> Result<SrtpContextRollback> {
+        let _update_guard = self.srtp_context_update.lock();
         // Latch before inspecting caller-provided contexts. A rejected
         // installation must fail closed even when its error is ignored; the
         // exact rollback token may restore the previous policy only after a
         // fully validated pair has actually been installed.
         let previous_secure_media_required =
             self.secure_media_required.swap(true, Ordering::AcqRel);
-        send.validate_for_secure_transport()?;
-        recv.validate_for_secure_transport()?;
+        if let Err(error) = send
+            .validate_for_secure_transport()
+            .and_then(|()| recv.validate_for_secure_transport())
+        {
+            // A rejected secure-media installation is itself a newer policy
+            // decision. Retire any earlier rollback token so it cannot later
+            // reopen the plaintext path by restoring an older latch value.
+            let current_generation = self.srtp_context_generation.load(Ordering::Acquire);
+            self.srtp_context_generation
+                .store(current_generation.saturating_add(1), Ordering::Release);
+            return Err(error);
+        }
         let (previous_send, previous_recv, installed_generation) = {
             let mut send_guard = self.srtp_send.lock();
             let mut recv_guard = self.srtp_recv.lock();
             let current_generation = self.srtp_context_generation.load(Ordering::Acquire);
-            current_generation.checked_add(2).ok_or_else(|| {
-                Error::InvalidState("SRTP context generation exhausted".to_string())
-            })?;
+            if current_generation.checked_add(2).is_none() {
+                // As with validation failure, an exhausted replacement must
+                // invalidate older rollback authority while remaining
+                // permanently fail closed.
+                self.srtp_context_generation
+                    .store(current_generation.saturating_add(1), Ordering::Release);
+                return Err(Error::InvalidState(
+                    "SRTP context generation exhausted".to_string(),
+                ));
+            }
             let installed_generation = current_generation + 1;
             let previous_send = std::mem::replace(&mut *send_guard, Some(send));
             let previous_recv = std::mem::replace(&mut *recv_guard, Some(recv));
@@ -1164,6 +1188,7 @@ impl UdpRtpTransport {
     /// A later replacement invalidates the token instead of allowing stale
     /// rollback to overwrite newer keys.
     pub async fn rollback_srtp_contexts(&self, rollback: SrtpContextRollback) -> Result<()> {
+        let _update_guard = self.srtp_context_update.lock();
         let mut send_guard = self.srtp_send.lock();
         let mut recv_guard = self.srtp_recv.lock();
         if self.srtp_context_generation.load(Ordering::Acquire) != rollback.installed_generation {
@@ -2330,6 +2355,33 @@ mod tests {
         assert!(transport.srtp_enabled().await);
 
         transport.rollback_srtp_contexts(current).await.unwrap();
+        assert!(transport.srtp_enabled().await);
+    }
+
+    #[tokio::test]
+    async fn rejected_srtp_replacement_retires_earlier_plaintext_rollback_authority() {
+        let transport = make_srtp_rollback_transport("srtp-rejected-replacement").await;
+        let (send, recv) = make_srtp_ctx_pair();
+        let plaintext_rollback = transport.replace_srtp_contexts(send, recv).await.unwrap();
+
+        let (mut disabled_send, mut disabled_recv) = make_srtp_ctx_pair();
+        disabled_send.set_enabled(false);
+        disabled_recv.set_enabled(false);
+        let error = match transport
+            .replace_srtp_contexts(disabled_send, disabled_recv)
+            .await
+        {
+            Ok(_) => panic!("disabled contexts must be rejected"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, Error::InvalidState(_)));
+
+        let rollback_error = transport
+            .rollback_srtp_contexts(plaintext_rollback)
+            .await
+            .expect_err("a rejected replacement must retire older rollback authority");
+        assert!(matches!(rollback_error, Error::InvalidState(_)));
+        assert!(transport.secure_media_required.load(Ordering::Acquire));
         assert!(transport.srtp_enabled().await);
     }
 

--- a/crates/media/rtp-core/src/transport/udp.rs
+++ b/crates/media/rtp-core/src/transport/udp.rs
@@ -305,6 +305,15 @@ impl Drop for PortAllocationCancellationGuard {
     }
 }
 
+/// Move-only authority to restore the exact SRTP state replaced by one
+/// successful context installation. Dropping it commits the replacement.
+pub struct SrtpContextRollback {
+    previous_send: Option<crate::srtp::SrtpContext>,
+    previous_recv: Option<crate::srtp::SrtpContext>,
+    previous_secure_media_required: bool,
+    installed_generation: u64,
+}
+
 pub struct UdpRtpTransport {
     /// RTP socket
     rtp_socket: Arc<UdpSocket>,
@@ -356,6 +365,10 @@ pub struct UdpRtpTransport {
     /// Irreversible secure-media policy latch. Once set, every RTP and RTCP
     /// operation must pass through an installed SRTP/SRTCP context.
     secure_media_required: Arc<AtomicBool>,
+
+    /// Fences the move-only rollback token returned by a prepared context
+    /// replacement so it cannot overwrite a later re-key.
+    srtp_context_generation: Arc<AtomicU64>,
 
     /// Makes allocator release idempotent across explicit close and Drop.
     allocator_release_started: AtomicBool,
@@ -550,6 +563,7 @@ impl UdpRtpTransport {
             receiver_tasks: Arc::new(Mutex::new(Vec::with_capacity(2))),
             active: Arc::new(AtomicBool::new(false)),
             secure_media_required: Arc::new(AtomicBool::new(false)),
+            srtp_context_generation: Arc::new(AtomicU64::new(0)),
             allocator_release_started: AtomicBool::new(false),
             srtp_send: Arc::new(parking_lot::Mutex::new(None)),
             srtp_recv: Arc::new(parking_lot::Mutex::new(None)),
@@ -1098,17 +1112,76 @@ impl UdpRtpTransport {
         send: crate::srtp::SrtpContext,
         recv: crate::srtp::SrtpContext,
     ) -> Result<()> {
-        self.secure_media_required.store(true, Ordering::Release);
+        let _rollback = self.replace_srtp_contexts(send, recv).await?;
+        Ok(())
+    }
+
+    /// Install a validated directional pair and return move-only authority to
+    /// restore the immediately preceding pair. This is used across a SIP
+    /// zero-wire commit boundary; dropping the token commits the replacement.
+    pub async fn replace_srtp_contexts(
+        &self,
+        send: crate::srtp::SrtpContext,
+        recv: crate::srtp::SrtpContext,
+    ) -> Result<SrtpContextRollback> {
         send.validate_for_secure_transport()?;
         recv.validate_for_secure_transport()?;
-        *self.srtp_send.lock() = Some(send);
-        *self.srtp_recv.lock() = Some(recv);
+        let (previous_send, previous_recv, previous_secure_media_required, installed_generation) = {
+            let mut send_guard = self.srtp_send.lock();
+            let mut recv_guard = self.srtp_recv.lock();
+            let current_generation = self.srtp_context_generation.load(Ordering::Acquire);
+            current_generation.checked_add(2).ok_or_else(|| {
+                Error::InvalidState("SRTP context generation exhausted".to_string())
+            })?;
+            let installed_generation = current_generation + 1;
+            let previous_secure_media_required = self.secure_media_required.load(Ordering::Acquire);
+            let previous_send = std::mem::replace(&mut *send_guard, Some(send));
+            let previous_recv = std::mem::replace(&mut *recv_guard, Some(recv));
+            self.srtp_context_generation
+                .store(installed_generation, Ordering::Release);
+            self.secure_media_required.store(true, Ordering::Release);
+            (
+                previous_send,
+                previous_recv,
+                previous_secure_media_required,
+                installed_generation,
+            )
+        };
         if srtp_diagnostics_enabled() {
             info!(
                 "SRTP_DIAG contexts_installed local={:?}",
                 self.rtp_socket.local_addr().ok()
             );
         }
+        Ok(SrtpContextRollback {
+            previous_send,
+            previous_recv,
+            previous_secure_media_required,
+            installed_generation,
+        })
+    }
+
+    /// Consume an exact replacement token and restore its former contexts.
+    /// A later replacement invalidates the token instead of allowing stale
+    /// rollback to overwrite newer keys.
+    pub async fn rollback_srtp_contexts(&self, rollback: SrtpContextRollback) -> Result<()> {
+        let mut send_guard = self.srtp_send.lock();
+        let mut recv_guard = self.srtp_recv.lock();
+        if self.srtp_context_generation.load(Ordering::Acquire) != rollback.installed_generation {
+            return Err(Error::InvalidState(
+                "SRTP rollback token was superseded by a later context replacement".to_string(),
+            ));
+        }
+        let retired_generation = rollback
+            .installed_generation
+            .checked_add(1)
+            .ok_or_else(|| Error::InvalidState("SRTP context generation exhausted".to_string()))?;
+        *send_guard = rollback.previous_send;
+        *recv_guard = rollback.previous_recv;
+        self.srtp_context_generation
+            .store(retired_generation, Ordering::Release);
+        self.secure_media_required
+            .store(rollback.previous_secure_media_required, Ordering::Release);
         Ok(())
     }
 
@@ -2207,6 +2280,76 @@ mod tests {
 
     fn test_receiver_report(ssrc: u32) -> RtcpPacket {
         RtcpPacket::ReceiverReport(crate::packet::rtcp::RtcpReceiverReport::new(ssrc))
+    }
+
+    async fn make_srtp_rollback_transport(session_id: &str) -> UdpRtpTransport {
+        UdpRtpTransport::new(RtpTransportConfig {
+            local_rtp_addr: "127.0.0.1:0".parse().unwrap(),
+            local_rtcp_addr: None,
+            symmetric_rtp: false,
+            rtcp_mux: true,
+            session_id: Some(session_id.to_string()),
+            use_port_allocator: false,
+            buffer_config: Default::default(),
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn exact_srtp_replacement_token_restores_plaintext_state() {
+        let transport = make_srtp_rollback_transport("srtp-exact-rollback").await;
+        assert!(!transport.srtp_enabled().await);
+
+        let (send, recv) = make_srtp_ctx_pair();
+        let rollback = transport.replace_srtp_contexts(send, recv).await.unwrap();
+        assert!(transport.srtp_enabled().await);
+
+        transport.rollback_srtp_contexts(rollback).await.unwrap();
+        assert!(!transport.srtp_enabled().await);
+    }
+
+    #[tokio::test]
+    async fn stale_srtp_replacement_token_cannot_overwrite_newer_keys() {
+        let transport = make_srtp_rollback_transport("srtp-stale-rollback").await;
+        let (send_a, recv_a) = make_srtp_ctx_pair();
+        let stale = transport
+            .replace_srtp_contexts(send_a, recv_a)
+            .await
+            .unwrap();
+        let (send_b, recv_b) = make_aes256_srtp_ctx_pair();
+        let current = transport
+            .replace_srtp_contexts(send_b, recv_b)
+            .await
+            .unwrap();
+
+        let error = transport
+            .rollback_srtp_contexts(stale)
+            .await
+            .expect_err("a superseded rollback token must be rejected");
+        assert!(matches!(error, Error::InvalidState(_)));
+        assert!(transport.srtp_enabled().await);
+
+        transport.rollback_srtp_contexts(current).await.unwrap();
+        assert!(transport.srtp_enabled().await);
+    }
+
+    #[tokio::test]
+    async fn exhausted_srtp_context_generation_fails_without_mutating_security_state() {
+        let transport = make_srtp_rollback_transport("srtp-generation-exhaustion").await;
+        transport
+            .srtp_context_generation
+            .store(u64::MAX - 1, Ordering::Release);
+        let (send, recv) = make_srtp_ctx_pair();
+
+        let error = match transport.replace_srtp_contexts(send, recv).await {
+            Ok(_) => panic!("generation exhaustion must fail closed"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, Error::InvalidState(_)));
+        assert!(!transport.srtp_enabled().await);
+        assert!(transport.srtp_send.lock().is_none());
+        assert!(transport.srtp_recv.lock().is_none());
     }
 
     #[tokio::test]

--- a/crates/sip/rvoip-sip/src/adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapter.rs
@@ -6077,6 +6077,19 @@ Signal=5\r\nDuration=160\r\n";
             HeaderName::Contact,
             HeaderValue::Raw(format!("<{contact_uri}>").into_bytes()),
         ));
+        accepted.headers.push(TypedHeader::ContentType(
+            rvoip_sip_core::types::ContentType::sdp(),
+        ));
+        accepted.body = bytes::Bytes::from(format!(
+            "v=0\r\no=capture 1 1 IN IP4 127.0.0.1\r\ns=bye-compensation\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio {} RTP/AVP 8 101\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:101 telephone-event/8000\r\na=fmtp:101 0-15\r\na=sendrecv\r\n",
+            target.port()
+        ));
+        accepted
+            .headers
+            .retain(|header| !matches!(header, TypedHeader::ContentLength(_)));
+        accepted.headers.push(TypedHeader::ContentLength(
+            rvoip_sip_core::types::ContentLength::new(accepted.body.len() as u32),
+        ));
         let accepted_to = accepted
             .raw_header_value(&HeaderName::To)
             .expect("accepted To");
@@ -6245,6 +6258,19 @@ Signal=5\r\nDuration=160\r\n";
             HeaderName::Contact,
             HeaderValue::Raw(format!("<sip:target@{target}>").into_bytes()),
         ));
+        accepted.headers.push(TypedHeader::ContentType(
+            rvoip_sip_core::types::ContentType::sdp(),
+        ));
+        accepted.body = bytes::Bytes::from(format!(
+            "v=0\r\no=capture 1 1 IN IP4 127.0.0.1\r\ns=bye-timeout\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio {} RTP/AVP 8 101\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:101 telephone-event/8000\r\na=fmtp:101 0-15\r\na=sendrecv\r\n",
+            target.port()
+        ));
+        accepted
+            .headers
+            .retain(|header| !matches!(header, TypedHeader::ContentLength(_)));
+        accepted.headers.push(TypedHeader::ContentLength(
+            rvoip_sip_core::types::ContentLength::new(accepted.body.len() as u32),
+        ));
         capture
             .send_to(&SipMessage::Response(accepted).to_bytes(), uac)
             .await
@@ -6378,6 +6404,19 @@ Signal=5\r\nDuration=160\r\n";
         accepted.headers.push(TypedHeader::Other(
             HeaderName::Contact,
             HeaderValue::Raw(format!("<sip:target@{target}>").into_bytes()),
+        ));
+        accepted.headers.push(TypedHeader::ContentType(
+            rvoip_sip_core::types::ContentType::sdp(),
+        ));
+        accepted.body = bytes::Bytes::from(format!(
+            "v=0\r\no=capture 1 1 IN IP4 127.0.0.1\r\ns=bye-rejected\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio {} RTP/AVP 8 101\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:101 telephone-event/8000\r\na=fmtp:101 0-15\r\na=sendrecv\r\n",
+            target.port()
+        ));
+        accepted
+            .headers
+            .retain(|header| !matches!(header, TypedHeader::ContentLength(_)));
+        accepted.headers.push(TypedHeader::ContentLength(
+            rvoip_sip_core::types::ContentLength::new(accepted.body.len() as u32),
         ));
         capture
             .send_to(&SipMessage::Response(accepted).to_bytes(), uac)

--- a/crates/sip/rvoip-sip/src/adapters/dialog_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/dialog_adapter.rs
@@ -3361,6 +3361,54 @@ impl DialogAdapter {
         )))
     }
 
+    pub(crate) async fn send_delayed_offer_ack_exact(
+        &self,
+        handle: &SessionRegistryHandle,
+        transaction_id: &TransactionKey,
+        response: &Response,
+        sdp_answer: &str,
+    ) -> Result<()> {
+        self.store
+            .get_session_snapshot_exact(handle)
+            .map_err(|_| SessionError::SessionNotFound(handle.session_id().0.clone()))?;
+        self.dialog_api
+            .send_delayed_offer_ack_for_session_transaction(
+                &handle.session_id().0,
+                transaction_id,
+                response,
+                sdp_answer,
+            )
+            .await
+            .map_err(|_| {
+                SessionError::DialogError(
+                    "Delayed-offer ACK failed exact validation or transport write".to_string(),
+                )
+            })
+    }
+
+    pub(crate) async fn send_invite_2xx_ack_exact(
+        &self,
+        handle: &SessionRegistryHandle,
+        transaction_id: &TransactionKey,
+        response: &Response,
+    ) -> Result<()> {
+        self.store
+            .get_session_snapshot_exact(handle)
+            .map_err(|_| SessionError::SessionNotFound(handle.session_id().0.clone()))?;
+        self.dialog_api
+            .send_invite_2xx_ack_for_session_transaction(
+                &handle.session_id().0,
+                transaction_id,
+                response,
+            )
+            .await
+            .map_err(|_| {
+                SessionError::DialogError(
+                    "INVITE 2xx ACK failed exact validation or transport write".to_string(),
+                )
+            })
+    }
+
     /// Compatibility facade for a default established-call BYE.
     pub async fn send_bye_session(&self, session_id: &SessionId) -> Result<()> {
         self.send_bye_with_options(session_id, ByeRequestOptions::default())

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -1033,6 +1033,10 @@ pub struct MediaAdapter {
 }
 
 impl MediaAdapter {
+    pub(crate) fn discard_pending_srtp_offer(&self, session_id: &SessionId) {
+        self.pending_srtp_offerers.remove(session_id);
+    }
+
     /// Create a new media adapter (no SRTP — equivalent to the
     /// pre-Step-2B behaviour).
     pub fn new(
@@ -1736,6 +1740,50 @@ impl MediaAdapter {
         // Event publishing will be handled by SessionCrossCrateEventHandler
 
         Ok(config)
+    }
+
+    /// Validate a locally supplied offer before an in-dialog request reaches
+    /// the wire. Codec agreement is still determined by the remote answer.
+    pub(crate) fn validate_local_sdp_offer(&self, local_sdp: &str) -> Result<()> {
+        let parsed_offer = SdpSession::from_str(local_sdp)
+            .map_err(|_| bounded_sdp_failure("local-offer", "syntax"))?;
+        self.parse_sdp_connection(local_sdp)?;
+        if !parsed_offer
+            .media_descriptions
+            .iter()
+            .any(|media| media.media == "audio" && !media.formats.is_empty())
+        {
+            return Err(SessionError::SDPNegotiationFailed(
+                "local SDP offer has no usable audio media description".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate an inbound re-INVITE/UPDATE offer without mutating media or
+    /// session state, allowing malformed offers to receive an exact 488.
+    pub(crate) fn validate_inbound_sdp_offer(&self, remote_sdp: &str) -> Result<()> {
+        let parsed_offer = SdpSession::from_str(remote_sdp)
+            .map_err(|_| bounded_sdp_failure("remote-offer", "syntax"))?;
+        self.parse_sdp_connection(remote_sdp)?;
+
+        let offered_crypto = Self::extract_audio_crypto(&parsed_offer);
+        if offered_crypto.is_empty() && self.srtp_required {
+            return Err(SessionError::SDPNegotiationFailed(
+                "srtp_required is set but the SDP offer carries no a=crypto: line".into(),
+            ));
+        }
+        if !offered_crypto.is_empty() && !self.offer_srtp {
+            return Ok(());
+        }
+        compute_answer_formats(
+            &parsed_offer,
+            &self.effective_offered_formats(),
+            self.strict_codec_matching,
+            self.offer_srtp,
+            self.srtp_required,
+        )?;
+        Ok(())
     }
 
     /// Generate SDP answer and negotiate (for UAS)

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -1635,7 +1635,7 @@ impl MediaAdapter {
         if result.is_err() {
             self.discard_staged_media_negotiation_for_session(&session);
         }
-        let security_changed = session.media_security != previous_security;
+        let security_changed = result.is_ok() && session.media_security != previous_security;
         let security_observation = security_changed
             .then(|| {
                 session
@@ -1858,13 +1858,14 @@ impl MediaAdapter {
         if result.is_err() {
             self.discard_staged_media_negotiation_for_session(&session);
         }
-        let state_changed = previous_origin
-            != (
-                session.sdp_origin_session_id.clone(),
-                session.sdp_origin_version,
-            )
-            || session.media_security != previous_security;
-        let security_observation = (session.media_security != previous_security)
+        let state_changed = result.is_ok()
+            && (previous_origin
+                != (
+                    session.sdp_origin_session_id.clone(),
+                    session.sdp_origin_version,
+                )
+                || session.media_security != previous_security);
+        let security_observation = (result.is_ok() && session.media_security != previous_security)
             .then(|| {
                 session
                     .lifecycle_handle
@@ -6509,6 +6510,83 @@ a=fmtp:101 0-15\r\n";
         assert_eq!(after.config.remote_addr, before.config.remote_addr);
         assert_eq!(after.config.preferred_codec, before.config.preferred_codec);
         assert_eq!(after.config.parameters, before.config.parameters);
+
+        adapter
+            .cleanup_session(&session_id)
+            .await
+            .expect("cleanup managed media");
+    }
+
+    #[tokio::test]
+    async fn failed_public_uas_commit_does_not_publish_advanced_sdp_origin() {
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use std::net::Ipv4Addr;
+
+        let controller = Arc::new(MediaSessionController::new());
+        let store = Arc::new(SessionStore::new());
+        let session_id = SessionId("failed-public-uas-origin-rollback".to_string());
+        store
+            .create_session(session_id.clone(), Role::UAS, false)
+            .await
+            .expect("create exact UAS session");
+        let mut adapter = MediaAdapter::new(
+            controller,
+            Arc::clone(&store),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            17_200,
+            17_300,
+        );
+        adapter.set_srtp_policy(true, true, vec![CryptoSuite::AesCm128HmacSha1_80]);
+        adapter
+            .start_session(&session_id)
+            .await
+            .expect("start exact media");
+
+        let handle = store
+            .lifecycle_handle(&session_id)
+            .expect("capture exact UAS lifetime");
+        let before = store
+            .get_session_exact(&handle)
+            .await
+            .expect("load stable UAS state");
+        let (_, offered_crypto) = SrtpNegotiator::new_offerer(&[CryptoSuite::AesCm128HmacSha1_80])
+            .expect("build SRTP offer");
+        let mut offer = SdpBuilder::new("Session")
+            .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
+            .connection("IN", "IP4", "127.0.0.1")
+            .time("0", "0")
+            .media_audio(35_010, "RTP/SAVP")
+            .formats(&["0"])
+            .rtpmap("0", "PCMU/8000");
+        for crypto in offered_crypto {
+            offer = offer.crypto_attribute(crypto);
+        }
+        let offer = offer
+            .attribute("sendrecv", None::<String>)
+            .done()
+            .build()
+            .expect("build SRTP SDP offer")
+            .to_string();
+
+        adapter
+            .fail_media_commit_after_srtp_swap
+            .store(true, Ordering::Release);
+        adapter
+            .negotiate_sdp_as_uas(&session_id, &offer)
+            .await
+            .expect_err("injected media commit failure must reject the answer");
+
+        let after = store
+            .get_session_exact(&handle)
+            .await
+            .expect("reload stable UAS state");
+        assert_eq!(after.sdp_origin_session_id, before.sdp_origin_session_id);
+        assert_eq!(after.sdp_origin_version, before.sdp_origin_version);
+        assert_eq!(after.media_security, before.media_security);
+        assert!(adapter.staged_media_negotiations.is_empty());
+        assert!(adapter.negotiated_srtp.is_empty());
 
         adapter
             .cleanup_session(&session_id)

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -653,6 +653,41 @@ pub struct NegotiatedConfig {
     pub remote_direction: crate::types::MediaDirection,
 }
 
+/// Validated offer/answer result waiting for its SIP commit boundary.
+#[derive(Debug, Clone)]
+struct StagedMediaNegotiation {
+    config: NegotiatedConfig,
+    stable_local_direction: crate::types::MediaDirection,
+    srtp_negotiated: bool,
+}
+
+/// Exact key for pre-commit media artifacts. Production always uses the
+/// generation-qualified registry handle; the raw-ID variant exists only for
+/// isolated unit tests that exercise lane-owned helpers without a registry.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum MediaNegotiationKey {
+    Exact(SessionRegistryHandle),
+    #[cfg(test)]
+    Unit(SessionId),
+}
+
+/// Reversible lower-media application held across one SIP response or ACK
+/// write. Dropping the embedded SRTP token commits its context replacement.
+pub(crate) struct PreparedMediaNegotiation {
+    session_id: SessionId,
+    negotiation_key: MediaNegotiationKey,
+    remote_addr: SocketAddr,
+    previous_media_security: Option<MediaSecurityState>,
+    lower: Option<PreparedLowerMediaNegotiation>,
+}
+
+struct PreparedLowerMediaNegotiation {
+    exact_media: ExactMediaSession,
+    previous_config: MediaConfig,
+    srtp_rollback: Option<rvoip_rtp_core::transport::SrtpContextRollback>,
+    stable_local_direction: crate::types::MediaDirection,
+}
+
 #[derive(Clone)]
 struct MediaSessionBinding {
     handle: SessionRegistryHandle,
@@ -967,12 +1002,16 @@ pub struct MediaAdapter {
     /// UAC-side state held between `generate_sdp_offer` and
     /// `negotiate_sdp_as_uac`. The offerer-role `SrtpNegotiator`
     /// holds our locally-generated keys keyed by tag.
-    pending_srtp_offerers: Arc<DashMap<SessionId, SrtpNegotiator>>,
+    pending_srtp_offerers: Arc<DashMap<MediaNegotiationKey, SrtpNegotiator>>,
 
     /// Negotiated SRTP context pairs keyed by session. Phase 2B.2
     /// will read these out and hand them to media-core's
     /// `start_secure_media`.
-    pub(crate) negotiated_srtp: Arc<DashMap<SessionId, SrtpPair>>,
+    negotiated_srtp: Arc<DashMap<MediaNegotiationKey, SrtpPair>>,
+
+    /// SDP results that passed validation but have not crossed their exact
+    /// SIP offer/answer commit boundary.
+    staged_media_negotiations: Arc<DashMap<MediaNegotiationKey, StagedMediaNegotiation>>,
 
     /// Global event coordinator for publishing RFC 4733 DTMF events
     /// onto the rvoip-sip API event bus. Populated at boot via
@@ -1030,11 +1069,39 @@ pub struct MediaAdapter {
     media_create_allocated: Arc<tokio::sync::Notify>,
     #[cfg(test)]
     resume_media_create: Arc<tokio::sync::Notify>,
+    #[cfg(test)]
+    fail_media_commit_after_srtp_swap: Arc<AtomicBool>,
+    #[cfg(test)]
+    fail_media_rollback: Arc<AtomicBool>,
 }
 
 impl MediaAdapter {
-    pub(crate) fn discard_pending_srtp_offer(&self, session_id: &SessionId) {
-        self.pending_srtp_offerers.remove(session_id);
+    fn media_negotiation_key(session: &SessionState) -> Result<MediaNegotiationKey> {
+        if let Some(handle) = session.lifecycle_handle.clone() {
+            return Ok(MediaNegotiationKey::Exact(handle));
+        }
+        #[cfg(test)]
+        let missing_exact_authority = Ok(MediaNegotiationKey::Unit(session.session_id.clone()));
+        #[cfg(not(test))]
+        let missing_exact_authority = Err(SessionError::InvalidTransition(
+            "media negotiation requires exact session authority".to_string(),
+        ));
+        missing_exact_authority
+    }
+
+    fn exact_media_negotiation_key(handle: &SessionRegistryHandle) -> MediaNegotiationKey {
+        MediaNegotiationKey::Exact(handle.clone())
+    }
+
+    pub(crate) fn discard_pending_srtp_offer_for_session(&self, session: &SessionState) {
+        if let Ok(key) = Self::media_negotiation_key(session) {
+            self.pending_srtp_offerers.remove(&key);
+        }
+    }
+
+    fn discard_pending_srtp_offer_exact(&self, handle: &SessionRegistryHandle) {
+        self.pending_srtp_offerers
+            .remove(&Self::exact_media_negotiation_key(handle));
     }
 
     /// Create a new media adapter (no SRTP — equivalent to the
@@ -1077,6 +1144,7 @@ impl MediaAdapter {
             ],
             pending_srtp_offerers: Arc::new(DashMap::new()),
             negotiated_srtp: Arc::new(DashMap::new()),
+            staged_media_negotiations: Arc::new(DashMap::new()),
             global_coordinator: Arc::new(tokio::sync::RwLock::new(None)),
             app_event_publisher: Arc::new(tokio::sync::RwLock::new(None)),
             public_rtp_addr: std::sync::RwLock::new(None),
@@ -1090,6 +1158,10 @@ impl MediaAdapter {
             media_create_allocated: Arc::new(tokio::sync::Notify::new()),
             #[cfg(test)]
             resume_media_create: Arc::new(tokio::sync::Notify::new()),
+            #[cfg(test)]
+            fail_media_commit_after_srtp_swap: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            fail_media_rollback: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1550,10 +1622,20 @@ impl MediaAdapter {
         let (lane, snapshot, mut session) =
             self.lock_and_load_exact_media_session(session_id).await?;
         let previous_security = session.media_security.clone();
-        let result = self
+        let result = match self
             .negotiate_sdp_as_uac_lane_owned(&mut session, remote_sdp)
-            .await;
-        let security_changed = result.is_ok() && session.media_security != previous_security;
+            .await
+        {
+            Ok(config) => self
+                .commit_staged_media_negotiation_lane_owned(&mut session)
+                .await
+                .map(|()| config),
+            Err(error) => Err(error),
+        };
+        if result.is_err() {
+            self.discard_staged_media_negotiation_for_session(&session);
+        }
+        let security_changed = session.media_security != previous_security;
         let security_observation = security_changed
             .then(|| {
                 session
@@ -1582,6 +1664,7 @@ impl MediaAdapter {
         remote_sdp: &str,
     ) -> Result<NegotiatedConfig> {
         let session_id = session.session_id.clone();
+        let negotiation_key = Self::media_negotiation_key(session)?;
         // Parse remote SDP to extract IP and port
         let (remote_ip, remote_port) = self.parse_sdp_connection(remote_sdp)?;
         let parsed_answer = SdpSession::from_str(remote_sdp)
@@ -1614,12 +1697,13 @@ impl MediaAdapter {
         // failure-with-487 hook today; if `srtp_required` and the
         // answer can't satisfy SRTP, we surface `SDPNegotiationFailed`
         // which the executor turns into terminal `CallFailed`.
-        if let Some((_, offerer_state)) = self.pending_srtp_offerers.remove(&session_id) {
+        let mut negotiated_srtp_pair = None;
+        if let Some((_, offerer_state)) = self.pending_srtp_offerers.remove(&negotiation_key) {
             // We did offer SRTP. Look for a matching `a=crypto:` in the answer.
             let attrs = Self::extract_audio_crypto(&parsed_answer);
             if let Some(chosen) = attrs.first() {
                 let pair = offerer_state.accept_answer(chosen)?;
-                self.negotiated_srtp.insert(session_id.clone(), pair);
+                negotiated_srtp_pair = Some(pair);
                 tracing::info!(
                     "SDES answer accepted for session {}: tag {} suite {:?}",
                     session_id.0,
@@ -1646,77 +1730,22 @@ impl MediaAdapter {
             }
         }
 
-        // Update media session with remote address. SRTP contexts (if
-        // negotiated in 2B.1) must be installed *between* updating the
-        // remote address and starting the audio transmitter — the
-        // transmitter spawns a send loop and we don't want any
-        // plaintext packets going out before the encrypt-side
-        // SrtpContext is in place.
+        // Validate the exact lower owner while leaving address, codec,
+        // direction and SRTP contexts at their last stable values. The answer
+        // has not crossed its ACK/response commit boundary yet.
         let signaling_only_port = self.signaling_only_local_port();
-        let exact_media = if signaling_only_port.is_some() {
-            None
-        } else {
-            Some(self.lane_owned_media(session)?)
-        };
-        if let Some(exact_media) = exact_media {
-            let dialog_id = &exact_media.dialog_id;
-            let remote_addr = SocketAddr::new(remote_ip, remote_port);
-
-            self.apply_negotiated_media_config(
-                dialog_id,
-                remote_addr,
-                &negotiated_codec,
-                payload_type,
-                clock_rate,
-                channels,
-            )
-            .await?;
-
-            // RFC 4568 SDES: install per-direction contexts before the
-            // first wire packet flows.
-            if let Some((_, pair)) = self.negotiated_srtp.remove(&session_id) {
-                let suite = pair.suite;
-                self.controller
-                    .install_srtp_contexts(dialog_id, pair.send_ctx, pair.recv_ctx)
-                    .await
-                    .map_err(|e| {
-                        SessionError::MediaError(format!("Failed to install SRTP contexts: {}", e))
-                    })?;
-                tracing::info!(
-                    "🔒 SRTP contexts installed for session {} (suite {:?})",
-                    session_id.0,
-                    suite
-                );
-                Self::record_media_security_negotiated_lane_owned(session, suite, true);
-                if srtp_diagnostics {
-                    emit_srtp_diag(format!(
-                        "srtp_contexts_installed session={} role=uac suite={:?}",
-                        session_id.0, suite
-                    ));
-                }
-            }
-
-            // Establish media flow (this starts audio transmission)
-            self.controller
-                .establish_media_flow(dialog_id, remote_addr)
+        if signaling_only_port.is_none() {
+            let exact_media = self.lane_owned_media(session)?;
+            if self
+                .controller
+                .get_session_info(&exact_media.dialog_id)
                 .await
-                .map_err(|e| {
-                    SessionError::MediaError(format!("Failed to establish media flow: {}", e))
-                })?;
-
-            tracing::info!(
-                "✅ Updated RTP remote address to {} for session {}",
-                remote_addr,
-                session_id.0
-            );
-            if !self.media_is_still_exact(&exact_media) {
+                .is_none()
+                || !self.media_is_still_exact(&exact_media)
+            {
                 return Err(SessionError::InvalidTransition(
-                    "media resource changed during UAC negotiation".to_string(),
+                    "media resource changed during UAC negotiation validation".to_string(),
                 ));
-            }
-        } else if signaling_only_port.is_some() {
-            if let Some((_, pair)) = self.negotiated_srtp.remove(&session_id) {
-                Self::record_media_security_negotiated_lane_owned(session, pair.suite, false);
             }
         }
 
@@ -1736,6 +1765,19 @@ impl MediaAdapter {
                 .map(sip_direction_to_session)
                 .unwrap_or(crate::types::MediaDirection::SendRecv),
         };
+
+        let srtp_negotiated = negotiated_srtp_pair.is_some();
+        if let Some(pair) = negotiated_srtp_pair {
+            self.negotiated_srtp.insert(negotiation_key.clone(), pair);
+        }
+        self.staged_media_negotiations.insert(
+            negotiation_key,
+            StagedMediaNegotiation {
+                config: config.clone(),
+                stable_local_direction: session.local_media_direction,
+                srtp_negotiated,
+            },
+        );
 
         // Event publishing will be handled by SessionCrossCrateEventHandler
 
@@ -1803,16 +1845,25 @@ impl MediaAdapter {
             session.sdp_origin_version,
         );
         let previous_security = session.media_security.clone();
-        let result = self
+        let result = match self
             .negotiate_sdp_as_uas_lane_owned(&mut session, remote_sdp)
-            .await;
-        let state_changed = result.is_ok()
-            && (previous_origin
-                != (
-                    session.sdp_origin_session_id.clone(),
-                    session.sdp_origin_version,
-                )
-                || session.media_security != previous_security);
+            .await
+        {
+            Ok((answer, config)) => self
+                .commit_staged_media_negotiation_lane_owned(&mut session)
+                .await
+                .map(|()| (answer, config)),
+            Err(error) => Err(error),
+        };
+        if result.is_err() {
+            self.discard_staged_media_negotiation_for_session(&session);
+        }
+        let state_changed = previous_origin
+            != (
+                session.sdp_origin_session_id.clone(),
+                session.sdp_origin_version,
+            )
+            || session.media_security != previous_security;
         let security_observation = (session.media_security != previous_security)
             .then(|| {
                 session
@@ -1837,6 +1888,8 @@ impl MediaAdapter {
         remote_sdp: &str,
     ) -> Result<(String, NegotiatedConfig)> {
         let session_id = session.session_id.clone();
+        let negotiation_key = Self::media_negotiation_key(session)?;
+        let stable_local_direction = session.local_media_direction;
         // Parse remote SDP — typed parse for both connection extraction
         // and SDES handling.
         let parsed_offer = SdpSession::from_str(remote_sdp)
@@ -1863,7 +1916,7 @@ impl MediaAdapter {
         let offered_transport = audio_transport(&parsed_offer)
             .unwrap_or("RTP/AVP")
             .to_string();
-        let (answer_attr, pending_srtp_pair, reject_with_port_zero) =
+        let (answer_attr, negotiated_srtp_pair, reject_with_port_zero) =
             if !offered_crypto.is_empty() && self.offer_srtp {
                 // Both sides want SRTP — negotiate.
                 let answerer = SrtpNegotiator::new_answerer();
@@ -1932,6 +1985,14 @@ impl MediaAdapter {
                 local_direction: crate::types::MediaDirection::Inactive,
                 remote_direction: crate::types::MediaDirection::Inactive,
             };
+            self.staged_media_negotiations.insert(
+                negotiation_key,
+                StagedMediaNegotiation {
+                    config: config.clone(),
+                    stable_local_direction,
+                    srtp_negotiated: false,
+                },
+            );
             return Ok((sdp_answer, config));
         }
 
@@ -1963,79 +2024,25 @@ impl MediaAdapter {
         let offered_direction = audio_direction(&parsed_offer);
         let answer_direction = answer_direction_for_offer(&offered_direction);
 
-        // Update media session with remote address. SRTP contexts must
-        // be installed BEFORE establish_media_flow starts the audio
-        // transmitter — see `negotiate_sdp_as_uac` for the same
-        // ordering rationale.
+        // Validate the exact lower owner without mutating it. The generated
+        // answer is still pre-wire state and must be retryable after a
+        // definite zero-wire response failure.
         let exact_media = if signaling_only_port.is_some() {
             None
         } else {
             Some(self.lane_owned_media(session)?)
         };
         if let Some(exact_media) = exact_media {
-            let dialog_id = &exact_media.dialog_id;
-            let remote_addr = SocketAddr::new(remote_ip, remote_port);
-
-            self.apply_negotiated_media_config(
-                dialog_id,
-                remote_addr,
-                &negotiated_codec,
-                negotiated_payload_type,
-                clock_rate,
-                channels,
-            )
-            .await?;
-
-            let negotiated_suite = if let Some(pair) = pending_srtp_pair {
-                let suite = pair.suite;
-                self.controller
-                    .install_srtp_contexts(dialog_id, pair.send_ctx, pair.recv_ctx)
-                    .await
-                    .map_err(|e| {
-                        SessionError::MediaError(format!(
-                            "Failed to install SRTP contexts (UAS): {}",
-                            e
-                        ))
-                    })?;
-                tracing::info!(
-                    "🔒 SRTP contexts installed for session {} (UAS, suite {:?})",
-                    session_id.0,
-                    suite
-                );
-                if srtp_diagnostics {
-                    emit_srtp_diag(format!(
-                        "srtp_contexts_installed session={} role=uas suite={:?}",
-                        session_id.0, suite
-                    ));
-                }
-                Some(suite)
-            } else {
-                None
-            };
-
-            self.controller
-                .establish_media_flow(dialog_id, remote_addr)
+            if self
+                .controller
+                .get_session_info(&exact_media.dialog_id)
                 .await
-                .map_err(|e| {
-                    SessionError::MediaError(format!("Failed to establish media flow: {}", e))
-                })?;
-
-            tracing::info!(
-                "✅ Updated RTP remote address to {} for session {} (UAS)",
-                remote_addr,
-                session_id.0
-            );
-            if !self.media_is_still_exact(&exact_media) {
+                .is_none()
+                || !self.media_is_still_exact(&exact_media)
+            {
                 return Err(SessionError::InvalidTransition(
-                    "media resource changed during UAS negotiation".to_string(),
+                    "media resource changed during UAS negotiation validation".to_string(),
                 ));
-            }
-            if let Some(suite) = negotiated_suite {
-                Self::record_media_security_negotiated_lane_owned(session, suite, true);
-            }
-        } else if signaling_only_port.is_some() {
-            if let Some(pair) = pending_srtp_pair {
-                Self::record_media_security_negotiated_lane_owned(session, pair.suite, false);
             }
         }
 
@@ -2132,11 +2139,362 @@ impl MediaAdapter {
                 .unwrap_or(crate::types::MediaDirection::SendRecv),
         };
 
+        let srtp_negotiated = negotiated_srtp_pair.is_some();
+        if let Some(pair) = negotiated_srtp_pair {
+            self.negotiated_srtp.insert(negotiation_key.clone(), pair);
+        }
+        self.staged_media_negotiations.insert(
+            negotiation_key,
+            StagedMediaNegotiation {
+                config: config.clone(),
+                stable_local_direction,
+                srtp_negotiated,
+            },
+        );
+
         // Event publishing will be handled by SessionCrossCrateEventHandler
 
         // Media flow is already represented by MediaStreamStarted above
 
         Ok((sdp_answer, config))
+    }
+
+    /// Drop every pre-commit media artifact for an offer/answer exchange.
+    pub(crate) fn discard_staged_media_negotiation_for_session(&self, session: &SessionState) {
+        if let Ok(key) = Self::media_negotiation_key(session) {
+            self.staged_media_negotiations.remove(&key);
+            self.negotiated_srtp.remove(&key);
+        }
+    }
+
+    fn discard_staged_media_negotiation_exact(&self, handle: &SessionRegistryHandle) {
+        let key = Self::exact_media_negotiation_key(handle);
+        self.staged_media_negotiations.remove(&key);
+        self.negotiated_srtp.remove(&key);
+    }
+
+    pub(crate) fn has_staged_media_negotiation(&self, session: &SessionState) -> bool {
+        Self::media_negotiation_key(session)
+            .is_ok_and(|key| self.staged_media_negotiations.contains_key(&key))
+    }
+
+    /// Apply one validated negotiation while retaining exact rollback
+    /// authority until its SIP response or ACK crosses the wire boundary.
+    pub(crate) async fn prepare_staged_media_negotiation_lane_owned(
+        &self,
+        session: &mut SessionState,
+    ) -> Result<PreparedMediaNegotiation> {
+        let session_id = session.session_id.clone();
+        let negotiation_key = Self::media_negotiation_key(session)?;
+        let staged = self
+            .staged_media_negotiations
+            .get(&negotiation_key)
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| {
+                SessionError::InvalidTransition(
+                    "no validated media negotiation is staged for commit".to_string(),
+                )
+            })?;
+        let previous_media_security = session.media_security.clone();
+
+        if previous_media_security.is_some() && !staged.srtp_negotiated {
+            return Err(SessionError::SDPNegotiationFailed(
+                "an established secure media session cannot be downgraded to plaintext".to_string(),
+            ));
+        }
+
+        if self.signaling_only_local_port().is_some() {
+            if let Some((_, pair)) = self.negotiated_srtp.remove(&negotiation_key) {
+                Self::record_media_security_negotiated_lane_owned(session, pair.suite, false);
+            }
+            return Ok(PreparedMediaNegotiation {
+                session_id,
+                negotiation_key,
+                remote_addr: staged.config.remote_addr,
+                previous_media_security,
+                lower: None,
+            });
+        }
+
+        let exact_media = self.lane_owned_media(session)?;
+        let dialog_id = exact_media.dialog_id.clone();
+        let previous_config = self
+            .controller
+            .get_session_info(&dialog_id)
+            .await
+            .ok_or_else(|| {
+                SessionError::MediaError(format!("No media session for dialog {dialog_id}"))
+            })?
+            .config;
+        if !self.media_is_still_exact(&exact_media) {
+            return Err(SessionError::InvalidTransition(
+                "media resource changed before negotiated media commit".to_string(),
+            ));
+        }
+
+        let remote_addr = staged.config.remote_addr;
+        let mut lower = PreparedLowerMediaNegotiation {
+            exact_media,
+            previous_config,
+            srtp_rollback: None,
+            stable_local_direction: staged.stable_local_direction,
+        };
+        let apply_result = async {
+            self.apply_negotiated_media_config(
+                &dialog_id,
+                remote_addr,
+                &staged.config.codec,
+                staged.config.payload_type,
+                staged.config.clock_rate,
+                staged.config.channels,
+            )
+            .await?;
+
+            if let Some((_, pair)) = self.negotiated_srtp.remove(&negotiation_key) {
+                let suite = pair.suite;
+                lower.srtp_rollback = Some(
+                    self.controller
+                        .prepare_srtp_context_swap(&dialog_id, pair.send_ctx, pair.recv_ctx)
+                        .await
+                        .map_err(|error| {
+                            SessionError::MediaError(format!(
+                                "Failed to install SRTP contexts: {error}"
+                            ))
+                        })?,
+                );
+                Self::record_media_security_negotiated_lane_owned(session, suite, true);
+                if srtp_diagnostics_enabled() {
+                    emit_srtp_diag(format!(
+                        "srtp_contexts_installed session={} role=commit suite={suite:?}",
+                        session_id.0
+                    ));
+                }
+            }
+
+            #[cfg(test)]
+            if lower.srtp_rollback.is_some()
+                && self
+                    .fail_media_commit_after_srtp_swap
+                    .swap(false, Ordering::AcqRel)
+            {
+                return Err(SessionError::MediaError(
+                    "injected failure after SRTP context replacement".to_string(),
+                ));
+            }
+
+            self.controller
+                .establish_media_flow(&dialog_id, remote_addr)
+                .await
+                .map_err(|error| {
+                    SessionError::MediaError(format!(
+                        "Failed to establish negotiated media flow: {error}"
+                    ))
+                })?;
+            let media_direction = match staged.config.local_direction {
+                crate::types::MediaDirection::SendRecv => {
+                    rvoip_media_core::types::MediaDirection::SendRecv
+                }
+                crate::types::MediaDirection::SendOnly => {
+                    rvoip_media_core::types::MediaDirection::SendOnly
+                }
+                crate::types::MediaDirection::RecvOnly => {
+                    rvoip_media_core::types::MediaDirection::RecvOnly
+                }
+                crate::types::MediaDirection::Inactive => {
+                    rvoip_media_core::types::MediaDirection::Inactive
+                }
+            };
+            self.controller
+                .set_media_direction(&dialog_id, media_direction)
+                .await
+                .map_err(|error| {
+                    SessionError::MediaError(format!(
+                        "Failed to apply negotiated media direction: {error}"
+                    ))
+                })?;
+            if !self.media_is_still_exact(&lower.exact_media) {
+                return Err(SessionError::InvalidTransition(
+                    "media resource changed during negotiated media commit".to_string(),
+                ));
+            }
+            Ok(())
+        }
+        .await;
+
+        let prepared = PreparedMediaNegotiation {
+            session_id,
+            negotiation_key,
+            remote_addr,
+            previous_media_security,
+            lower: Some(lower),
+        };
+        if let Err(error) = apply_result {
+            return match self
+                .rollback_prepared_media_negotiation_lane_owned(session, prepared)
+                .await
+            {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(rollback_error),
+            };
+        }
+        Ok(prepared)
+    }
+
+    pub(crate) async fn finalize_prepared_media_negotiation_lane_owned(
+        &self,
+        session: &mut SessionState,
+        prepared: PreparedMediaNegotiation,
+    ) -> Result<()> {
+        if prepared.session_id != session.session_id {
+            return Err(SessionError::InvalidTransition(
+                "prepared media negotiation belongs to another session".to_string(),
+            ));
+        }
+        let current_key = Self::media_negotiation_key(session)?;
+        if current_key != prepared.negotiation_key {
+            self.staged_media_negotiations
+                .remove(&prepared.negotiation_key);
+            self.negotiated_srtp.remove(&prepared.negotiation_key);
+            if let Some(lower) = prepared.lower.as_ref() {
+                let _ = lower.exact_media._resource.release_lower_once().await;
+            }
+            return Err(SessionError::InvalidTransition(
+                "prepared media negotiation belongs to a stale session generation".to_string(),
+            ));
+        }
+        if prepared
+            .lower
+            .as_ref()
+            .is_some_and(|lower| !self.media_is_still_exact(&lower.exact_media))
+        {
+            if let Some(lower) = prepared.lower.as_ref() {
+                let _ = lower.exact_media._resource.release_lower_once().await;
+            }
+            session.media_session_id = None;
+            session.media_session_ready = false;
+            session.media_security = None;
+            self.staged_media_negotiations
+                .remove(&prepared.negotiation_key);
+            self.negotiated_srtp.remove(&prepared.negotiation_key);
+            return Err(SessionError::InvalidTransition(
+                "media resource changed before negotiated media finalization".to_string(),
+            ));
+        }
+        self.staged_media_negotiations
+            .remove(&prepared.negotiation_key);
+        self.negotiated_srtp.remove(&prepared.negotiation_key);
+        tracing::info!(
+            "Committed negotiated media for session {} at {}",
+            session.session_id.0,
+            prepared.remote_addr
+        );
+        Ok(())
+    }
+
+    pub(crate) async fn rollback_prepared_media_negotiation_lane_owned(
+        &self,
+        session: &mut SessionState,
+        mut prepared: PreparedMediaNegotiation,
+    ) -> Result<()> {
+        if prepared.session_id != session.session_id {
+            return Err(SessionError::InvalidTransition(
+                "prepared media rollback belongs to another session".to_string(),
+            ));
+        }
+        let same_generation = Self::media_negotiation_key(session)? == prepared.negotiation_key;
+        self.staged_media_negotiations
+            .remove(&prepared.negotiation_key);
+        self.negotiated_srtp.remove(&prepared.negotiation_key);
+
+        let Some(mut lower) = prepared.lower.take() else {
+            if same_generation {
+                session.media_security = prepared.previous_media_security;
+                return Ok(());
+            }
+            return Err(SessionError::InvalidTransition(
+                "prepared media rollback retired a stale session generation".to_string(),
+            ));
+        };
+        let dialog_id = lower.exact_media.dialog_id.clone();
+        let mut rollback_failures = Vec::new();
+        if let Some(rollback) = lower.srtp_rollback.take() {
+            if self
+                .controller
+                .rollback_srtp_context_swap(&dialog_id, rollback)
+                .await
+                .is_err()
+            {
+                rollback_failures.push("srtp");
+            }
+        }
+        if self
+            .controller
+            .update_media(dialog_id.clone(), lower.previous_config)
+            .await
+            .is_err()
+        {
+            rollback_failures.push("configuration");
+        }
+        let stable_direction = match lower.stable_local_direction {
+            crate::types::MediaDirection::SendRecv => {
+                rvoip_media_core::types::MediaDirection::SendRecv
+            }
+            crate::types::MediaDirection::SendOnly => {
+                rvoip_media_core::types::MediaDirection::SendOnly
+            }
+            crate::types::MediaDirection::RecvOnly => {
+                rvoip_media_core::types::MediaDirection::RecvOnly
+            }
+            crate::types::MediaDirection::Inactive => {
+                rvoip_media_core::types::MediaDirection::Inactive
+            }
+        };
+        if self
+            .controller
+            .set_media_direction(&dialog_id, stable_direction)
+            .await
+            .is_err()
+        {
+            rollback_failures.push("direction");
+        }
+        if !self.media_is_still_exact(&lower.exact_media) {
+            rollback_failures.push("ownership");
+        }
+        #[cfg(test)]
+        if self.fail_media_rollback.swap(false, Ordering::AcqRel) {
+            rollback_failures.push("injected");
+        }
+
+        if rollback_failures.is_empty() {
+            if same_generation {
+                session.media_security = prepared.previous_media_security;
+                return Ok(());
+            }
+            return Err(SessionError::InvalidTransition(
+                "prepared media rollback retired a stale session generation".to_string(),
+            ));
+        }
+        let _ = lower.exact_media._resource.release_lower_once().await;
+        if same_generation {
+            session.media_session_id = None;
+            session.media_session_ready = false;
+            session.media_security = None;
+        }
+        Err(SessionError::MediaError(format!(
+            "negotiated media rollback failed at {}; media was quarantined",
+            rollback_failures.join(",")
+        )))
+    }
+
+    pub(crate) async fn commit_staged_media_negotiation_lane_owned(
+        &self,
+        session: &mut SessionState,
+    ) -> Result<()> {
+        let prepared = self
+            .prepare_staged_media_negotiation_lane_owned(session)
+            .await?;
+        self.finalize_prepared_media_negotiation_lane_owned(session, prepared)
+            .await
     }
 
     fn record_media_security_negotiated_lane_owned(
@@ -2859,6 +3217,7 @@ impl MediaAdapter {
         direction: crate::types::MediaDirection,
     ) -> Result<String> {
         let session_id = session.session_id.clone();
+        let negotiation_key = Self::media_negotiation_key(session)?;
         if self.signaling_only_local_port().is_some() {
             return self
                 .generate_signaling_only_sdp_offer_lane_owned(session, direction)
@@ -2908,7 +3267,7 @@ impl MediaAdapter {
         let (transport, crypto_attrs) = if self.offer_srtp {
             let (negotiator, attrs) = SrtpNegotiator::new_offerer(&self.srtp_offered_suites)?;
             self.pending_srtp_offerers
-                .insert(session_id.clone(), negotiator);
+                .insert(negotiation_key, negotiator);
             ("RTP/SAVP", attrs)
         } else {
             ("RTP/AVP", Vec::new())
@@ -3209,6 +3568,9 @@ impl MediaAdapter {
                 media_id
             ))
         })?;
+        if !exact._resource.core_media_allocated {
+            return Ok(());
+        }
         let media_direction = match direction {
             crate::types::MediaDirection::SendRecv => {
                 rvoip_media_core::types::MediaDirection::SendRecv
@@ -3505,6 +3867,8 @@ impl MediaAdapter {
         }
 
         let session_id = handle.session_id();
+        self.discard_pending_srtp_offer_exact(handle);
+        self.discard_staged_media_negotiation_exact(handle);
         let retained_binding = self
             .media_resources
             .get(session_id)
@@ -3643,6 +4007,8 @@ impl MediaAdapter {
                 ))
             })?;
         let session_id = handle.session_id();
+        self.discard_pending_srtp_offer_exact(handle);
+        self.discard_staged_media_negotiation_exact(handle);
         let managed_resource = self
             .media_resources
             .get(session_id)
@@ -3773,6 +4139,7 @@ impl MediaAdapter {
         direction: crate::types::MediaDirection,
     ) -> Result<String> {
         let session_id = session.session_id.clone();
+        let negotiation_key = Self::media_negotiation_key(session)?;
         let (origin_session_id, origin_version) = advance_sdp_origin(session);
         let origin_version = origin_version.to_string();
         let advertised_ip = self
@@ -3788,7 +4155,7 @@ impl MediaAdapter {
         let (transport, crypto_attrs) = if self.offer_srtp {
             let (negotiator, attrs) = SrtpNegotiator::new_offerer(&self.srtp_offered_suites)?;
             self.pending_srtp_offerers
-                .insert(session_id.clone(), negotiator);
+                .insert(negotiation_key, negotiator);
             ("RTP/SAVP", attrs)
         } else {
             ("RTP/AVP", Vec::new())
@@ -4014,6 +4381,7 @@ impl Clone for MediaAdapter {
             srtp_offered_suites: self.srtp_offered_suites.clone(),
             pending_srtp_offerers: self.pending_srtp_offerers.clone(),
             negotiated_srtp: self.negotiated_srtp.clone(),
+            staged_media_negotiations: self.staged_media_negotiations.clone(),
             global_coordinator: self.global_coordinator.clone(),
             app_event_publisher: self.app_event_publisher.clone(),
             public_rtp_addr: std::sync::RwLock::new(self.public_rtp_addr()),
@@ -4027,6 +4395,10 @@ impl Clone for MediaAdapter {
             media_create_allocated: self.media_create_allocated.clone(),
             #[cfg(test)]
             resume_media_create: self.resume_media_create.clone(),
+            #[cfg(test)]
+            fail_media_commit_after_srtp_swap: self.fail_media_commit_after_srtp_swap.clone(),
+            #[cfg(test)]
+            fail_media_rollback: self.fail_media_rollback.clone(),
         }
     }
 }
@@ -5081,7 +5453,7 @@ a=fmtp:101 0-15\r\n";
             .await
             .is_err());
         assert!(session.media_security.is_none());
-        assert!(!adapter.negotiated_srtp.contains_key(&session_id));
+        assert!(adapter.negotiated_srtp.is_empty());
     }
 
     /// Sprint 3.5 — strict mode + zero overlap returns
@@ -5891,6 +6263,370 @@ a=fmtp:101 0-15\r\n";
             .remove_session_exact(&generation_b)
             .await
             .expect("cleanup generation B");
+    }
+
+    #[tokio::test]
+    async fn stale_media_negotiation_cleanup_cannot_cross_session_generation_reuse() {
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use std::net::Ipv4Addr;
+
+        let store = Arc::new(SessionStore::new());
+        let session_id = SessionId("exact-negotiation-reuse".to_string());
+        store
+            .create_session(session_id.clone(), Role::UAC, false)
+            .await
+            .expect("create generation A");
+        let generation_a = store
+            .lifecycle_handle(&session_id)
+            .expect("generation A handle");
+        store
+            .remove_session_exact(&generation_a)
+            .await
+            .expect("retire generation A");
+        assert!(store.authority().elapse_reuse_horizon_for_test(&session_id));
+        store
+            .create_session(session_id.clone(), Role::UAC, false)
+            .await
+            .expect("create generation B");
+        let generation_b = store
+            .lifecycle_handle(&session_id)
+            .expect("generation B handle");
+
+        let adapter = MediaAdapter::new(
+            Arc::new(MediaSessionController::new()),
+            store,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_400,
+            16_500,
+        );
+        let staged = StagedMediaNegotiation {
+            config: NegotiatedConfig {
+                local_addr: "127.0.0.1:16400".parse().unwrap(),
+                remote_addr: "127.0.0.1:16402".parse().unwrap(),
+                codec: "PCMU".to_string(),
+                payload_type: 0,
+                clock_rate: 8_000,
+                channels: 1,
+                local_direction: crate::types::MediaDirection::SendRecv,
+                remote_direction: crate::types::MediaDirection::SendRecv,
+            },
+            stable_local_direction: crate::types::MediaDirection::SendRecv,
+            srtp_negotiated: false,
+        };
+        adapter.staged_media_negotiations.insert(
+            MediaNegotiationKey::Exact(generation_a.clone()),
+            staged.clone(),
+        );
+        adapter
+            .staged_media_negotiations
+            .insert(MediaNegotiationKey::Exact(generation_b.clone()), staged);
+
+        adapter.discard_staged_media_negotiation_exact(&generation_a);
+
+        assert!(!adapter
+            .staged_media_negotiations
+            .contains_key(&MediaNegotiationKey::Exact(generation_a)));
+        assert!(adapter
+            .staged_media_negotiations
+            .contains_key(&MediaNegotiationKey::Exact(generation_b)));
+    }
+
+    #[tokio::test]
+    async fn stale_prepared_media_finalization_cannot_cross_session_generation_reuse() {
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use std::net::Ipv4Addr;
+
+        let store = Arc::new(SessionStore::new());
+        let session_id = SessionId("exact-prepared-negotiation-reuse".to_string());
+        store
+            .create_session(session_id.clone(), Role::UAC, false)
+            .await
+            .expect("create generation A");
+        let generation_a = store
+            .lifecycle_handle(&session_id)
+            .expect("generation A handle");
+        store
+            .remove_session_exact(&generation_a)
+            .await
+            .expect("retire generation A");
+        assert!(store.authority().elapse_reuse_horizon_for_test(&session_id));
+        store
+            .create_session(session_id.clone(), Role::UAC, false)
+            .await
+            .expect("create generation B");
+        let generation_b = store
+            .lifecycle_handle(&session_id)
+            .expect("generation B handle");
+
+        let mut adapter = MediaAdapter::new(
+            Arc::new(MediaSessionController::new()),
+            store,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_400,
+            16_500,
+        );
+        adapter.set_media_mode(MediaMode::SignalingOnly { sdp_rtp_port: 9 });
+        let staged = StagedMediaNegotiation {
+            config: NegotiatedConfig {
+                local_addr: "127.0.0.1:16400".parse().unwrap(),
+                remote_addr: "127.0.0.1:16402".parse().unwrap(),
+                codec: "PCMU".to_string(),
+                payload_type: 0,
+                clock_rate: 8_000,
+                channels: 1,
+                local_direction: crate::types::MediaDirection::SendRecv,
+                remote_direction: crate::types::MediaDirection::SendRecv,
+            },
+            stable_local_direction: crate::types::MediaDirection::SendRecv,
+            srtp_negotiated: false,
+        };
+        adapter.staged_media_negotiations.insert(
+            MediaNegotiationKey::Exact(generation_a.clone()),
+            staged.clone(),
+        );
+        adapter
+            .staged_media_negotiations
+            .insert(MediaNegotiationKey::Exact(generation_b.clone()), staged);
+        let mut working = SessionState::new(session_id, Role::UAC);
+        working.lifecycle_handle = Some(generation_a.clone());
+        let prepared = adapter
+            .prepare_staged_media_negotiation_lane_owned(&mut working)
+            .await
+            .expect("prepare generation A");
+
+        working.lifecycle_handle = Some(generation_b.clone());
+        adapter
+            .finalize_prepared_media_negotiation_lane_owned(&mut working, prepared)
+            .await
+            .expect_err("stale prepared authority must fail closed");
+
+        assert!(!adapter
+            .staged_media_negotiations
+            .contains_key(&MediaNegotiationKey::Exact(generation_a)));
+        assert!(adapter
+            .staged_media_negotiations
+            .contains_key(&MediaNegotiationKey::Exact(generation_b)));
+    }
+
+    #[tokio::test]
+    async fn failed_commit_after_srtp_swap_restores_stable_media() {
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use rvoip_rtp_core::srtp::{SrtpContext, SrtpCryptoKey, SRTP_AES128_CM_SHA1_80};
+        use std::net::Ipv4Addr;
+
+        let controller = Arc::new(MediaSessionController::new());
+        let store = Arc::new(SessionStore::new());
+        let session_id = SessionId("post-srtp-swap-rollback".to_string());
+        store
+            .create_session(session_id.clone(), Role::UAC, false)
+            .await
+            .expect("create exact session");
+        let adapter = MediaAdapter::new(
+            Arc::clone(&controller),
+            Arc::clone(&store),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_400,
+            16_500,
+        );
+        let dialog_id = adapter
+            .create_session(&session_id)
+            .await
+            .expect("create managed media");
+        let handle = store
+            .lifecycle_handle(&session_id)
+            .expect("exact lifecycle handle");
+        let mut working = store
+            .get_session_exact(&handle)
+            .await
+            .expect("load exact session");
+        working.media_session_id = Some(dialog_id.clone());
+        working.media_session_ready = true;
+        working.local_media_direction = crate::types::MediaDirection::SendRecv;
+
+        let before = controller
+            .get_session_info(&dialog_id)
+            .await
+            .expect("stable lower media");
+        let make_context = |key_byte, salt_byte| {
+            SrtpContext::new(
+                SRTP_AES128_CM_SHA1_80,
+                SrtpCryptoKey::new(vec![key_byte; 16], vec![salt_byte; 14]),
+            )
+            .expect("test SRTP context")
+        };
+        let key = MediaNegotiationKey::Exact(handle.clone());
+        adapter.negotiated_srtp.insert(
+            key.clone(),
+            SrtpPair {
+                send_ctx: make_context(0x11, 0x22),
+                recv_ctx: make_context(0x33, 0x44),
+                suite: CryptoSuite::AesCm128HmacSha1_80,
+            },
+        );
+        adapter.staged_media_negotiations.insert(
+            key,
+            StagedMediaNegotiation {
+                config: NegotiatedConfig {
+                    local_addr: before.config.local_addr,
+                    remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 35_000),
+                    codec: "PCMA".to_string(),
+                    payload_type: 8,
+                    clock_rate: 8_000,
+                    channels: 1,
+                    local_direction: crate::types::MediaDirection::Inactive,
+                    remote_direction: crate::types::MediaDirection::SendRecv,
+                },
+                stable_local_direction: crate::types::MediaDirection::SendRecv,
+                srtp_negotiated: true,
+            },
+        );
+        adapter
+            .fail_media_commit_after_srtp_swap
+            .store(true, Ordering::Release);
+
+        let error = adapter
+            .commit_staged_media_negotiation_lane_owned(&mut working)
+            .await
+            .expect_err("post-swap failure must abort the media commit");
+        assert!(matches!(
+            &error,
+            SessionError::MediaError(detail)
+                if detail == "injected failure after SRTP context replacement"
+        ));
+        assert_eq!(working.media_security, None);
+
+        let after = controller
+            .get_session_info(&dialog_id)
+            .await
+            .expect("restored lower media");
+        assert_eq!(after.config.local_addr, before.config.local_addr);
+        assert_eq!(after.config.remote_addr, before.config.remote_addr);
+        assert_eq!(after.config.preferred_codec, before.config.preferred_codec);
+        assert_eq!(after.config.parameters, before.config.parameters);
+
+        adapter
+            .cleanup_session(&session_id)
+            .await
+            .expect("cleanup managed media");
+    }
+
+    #[tokio::test]
+    async fn failed_prepared_media_rollback_quarantines_exact_allocation() {
+        use crate::api::events::{MediaSecurityKeying, MediaSecurityProfile, MediaSecurityState};
+        use crate::session_store::SessionStore;
+        use crate::state_table::types::Role;
+        use rvoip_media_core::relay::controller::MediaSessionController;
+        use rvoip_rtp_core::srtp::{SrtpContext, SrtpCryptoKey, SRTP_AES128_CM_SHA1_80};
+        use std::net::Ipv4Addr;
+
+        let controller = Arc::new(MediaSessionController::new());
+        let store = Arc::new(SessionStore::new());
+        let session_id = SessionId("failed-media-rollback-quarantine".to_string());
+        store
+            .create_session(session_id.clone(), Role::UAC, false)
+            .await
+            .expect("create exact session");
+        let adapter = MediaAdapter::new(
+            Arc::clone(&controller),
+            Arc::clone(&store),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            16_600,
+            16_700,
+        );
+        let dialog_id = adapter
+            .create_session(&session_id)
+            .await
+            .expect("create managed media");
+        let handle = store
+            .lifecycle_handle(&session_id)
+            .expect("exact lifecycle handle");
+        let mut working = store
+            .get_session_exact(&handle)
+            .await
+            .expect("load exact session");
+        working.media_session_id = Some(dialog_id.clone());
+        working.media_session_ready = true;
+        working.local_media_direction = crate::types::MediaDirection::SendRecv;
+        working.media_security = Some(MediaSecurityState {
+            keying: MediaSecurityKeying::Sdes,
+            suite: CryptoSuite::AesCm128HmacSha1_80,
+            profile: MediaSecurityProfile::RtpSavp,
+            contexts_installed: true,
+        });
+
+        let make_context = |key_byte, salt_byte| {
+            SrtpContext::new(
+                SRTP_AES128_CM_SHA1_80,
+                SrtpCryptoKey::new(vec![key_byte; 16], vec![salt_byte; 14]),
+            )
+            .expect("test SRTP context")
+        };
+        controller
+            .install_srtp_contexts(
+                &dialog_id,
+                make_context(0x01, 0x02),
+                make_context(0x03, 0x04),
+            )
+            .await
+            .expect("install stable SRTP contexts");
+        let before = controller
+            .get_session_info(&dialog_id)
+            .await
+            .expect("stable lower media");
+        let key = MediaNegotiationKey::Exact(handle);
+        adapter.negotiated_srtp.insert(
+            key.clone(),
+            SrtpPair {
+                send_ctx: make_context(0x11, 0x12),
+                recv_ctx: make_context(0x13, 0x14),
+                suite: CryptoSuite::AesCm128HmacSha1_80,
+            },
+        );
+        adapter.staged_media_negotiations.insert(
+            key,
+            StagedMediaNegotiation {
+                config: NegotiatedConfig {
+                    local_addr: before.config.local_addr,
+                    remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 35_200),
+                    codec: "PCMA".to_string(),
+                    payload_type: 8,
+                    clock_rate: 8_000,
+                    channels: 1,
+                    local_direction: crate::types::MediaDirection::Inactive,
+                    remote_direction: crate::types::MediaDirection::SendRecv,
+                },
+                stable_local_direction: crate::types::MediaDirection::SendRecv,
+                srtp_negotiated: true,
+            },
+        );
+
+        let prepared = adapter
+            .prepare_staged_media_negotiation_lane_owned(&mut working)
+            .await
+            .expect("reversibly apply new media");
+        adapter.fail_media_rollback.store(true, Ordering::Release);
+        let error = adapter
+            .rollback_prepared_media_negotiation_lane_owned(&mut working, prepared)
+            .await
+            .expect_err("rollback failure must quarantine media");
+        assert!(matches!(
+            error,
+            SessionError::MediaError(detail)
+                if detail.contains("media was quarantined") && detail.contains("injected")
+        ));
+        assert_eq!(working.media_session_id, None);
+        assert!(!working.media_session_ready);
+        assert_eq!(working.media_security, None);
+        assert!(
+            controller.get_session_info(&dialog_id).await.is_none(),
+            "the failed rollback must release the exact lower allocation"
+        );
     }
 
     #[tokio::test]

--- a/crates/sip/rvoip-sip/src/adapters/outbound_request_tracker.rs
+++ b/crates/sip/rvoip-sip/src/adapters/outbound_request_tracker.rs
@@ -154,6 +154,7 @@ pub(crate) enum DeferredTrackedRequestEvent {
         transaction_id: String,
         method: String,
         outcome: rvoip_infra_common::events::cross_crate::OutboundRequestOutcome,
+        response_sdp: Option<String>,
     },
 }
 
@@ -947,6 +948,7 @@ mod tests {
                 rvoip_infra_common::events::cross_crate::OutboundRequestOutcome::FinalResponse {
                     status_code: 200,
                 },
+            response_sdp: None,
         }
     }
 

--- a/crates/sip/rvoip-sip/src/adapters/session_event_handler.rs
+++ b/crates/sip/rvoip-sip/src/adapters/session_event_handler.rs
@@ -26,7 +26,8 @@ use crate::session_registry::{PendingInboundBundle, SessionRegistry, SessionRegi
 use crate::session_store::SessionStateSnapshot;
 use crate::state_machine::executor::{
     AuthRequiredProcessOutcome, AuthRequiredStateInput, InboundResponseStateInput,
-    ReferNotifyInput, ReferNotifyOutcome, SessionRefreshStateInput, TransferRequestStateInput,
+    Invite2xxAckStateInput, ReferNotifyInput, ReferNotifyOutcome, SessionRefreshStateInput,
+    TransferRequestStateInput,
 };
 use crate::state_machine::{
     ProcessEventResult, StateMachine as StateMachineExecutor, StateMachineHelpers,
@@ -770,6 +771,20 @@ async fn process_event_with_remote_sdp_exact_on_fresh_task(
     join_state_machine_task(task).await
 }
 
+async fn process_invite_2xx_answer_exact_on_fresh_task(
+    state_machine: Arc<StateMachineExecutor>,
+    handle: SessionRegistryHandle,
+    remote_sdp: Option<String>,
+    ack: Invite2xxAckStateInput,
+) -> StateMachineProcessResult {
+    let task = AbortStateMachineTaskOnDrop::new(tokio::spawn(async move {
+        state_machine
+            .process_invite_2xx_answer_exact(&handle, remote_sdp, ack)
+            .await
+    }));
+    join_state_machine_task(task).await
+}
+
 async fn process_auth_required_on_fresh_task(
     state_machine: Arc<StateMachineExecutor>,
     handle: SessionRegistryHandle,
@@ -833,6 +848,117 @@ fn outbound_request_outcome_label(outcome: OutboundRequestOutcome) -> &'static s
         OutboundRequestOutcome::FinalResponse { .. } => "final-response",
         OutboundRequestOutcome::Timeout => "timeout",
         OutboundRequestOutcome::TransportFailure => "transport-failure",
+    }
+}
+
+fn reinvite_completion_failure(
+    outcome: OutboundRequestOutcome,
+) -> Option<(EventType, &'static str)> {
+    match outcome {
+        OutboundRequestOutcome::FinalResponse { status_code }
+            if (200..300).contains(&status_code) || status_code == 491 =>
+        {
+            None
+        }
+        OutboundRequestOutcome::FinalResponse { status_code } if status_code < 500 => Some((
+            EventType::Dialog4xxFailure(status_code),
+            "re-INVITE was rejected",
+        )),
+        OutboundRequestOutcome::FinalResponse { status_code } if status_code < 600 => Some((
+            EventType::Dialog5xxFailure(status_code),
+            "re-INVITE failed with a server error",
+        )),
+        OutboundRequestOutcome::FinalResponse { status_code } => Some((
+            EventType::Dialog6xxFailure(status_code),
+            "re-INVITE failed globally",
+        )),
+        OutboundRequestOutcome::Timeout => {
+            Some((EventType::DialogTimeout, "re-INVITE transaction timed out"))
+        }
+        OutboundRequestOutcome::TransportFailure => {
+            Some((EventType::DialogTimeout, "re-INVITE transport failed"))
+        }
+    }
+}
+
+fn update_completion_transition(
+    outcome: OutboundRequestOutcome,
+) -> (EventType, Option<&'static str>) {
+    match outcome {
+        OutboundRequestOutcome::FinalResponse { status_code }
+            if (200..300).contains(&status_code) =>
+        {
+            (EventType::Dialog200OK, None)
+        }
+        OutboundRequestOutcome::FinalResponse { status_code } if status_code < 500 => (
+            EventType::Dialog4xxFailure(status_code),
+            Some("UPDATE was rejected"),
+        ),
+        OutboundRequestOutcome::FinalResponse { status_code } if status_code < 600 => (
+            EventType::Dialog5xxFailure(status_code),
+            Some("UPDATE failed with a server error"),
+        ),
+        OutboundRequestOutcome::FinalResponse { status_code } => (
+            EventType::Dialog6xxFailure(status_code),
+            Some("UPDATE failed globally"),
+        ),
+        OutboundRequestOutcome::Timeout => (
+            EventType::DialogTimeout,
+            Some("UPDATE transaction timed out"),
+        ),
+        OutboundRequestOutcome::TransportFailure => {
+            (EventType::DialogTimeout, Some("UPDATE transport failed"))
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PendingOfferTransactionCorrelation {
+    NoPendingOffer,
+    OtherMethod,
+    Exact,
+    Mismatched,
+}
+
+fn correlate_pending_offer_transaction(
+    pending_method: Option<&rvoip_sip_core::Method>,
+    pending_transaction: Option<&rvoip_sip_dialog::transaction::TransactionKey>,
+    method: &rvoip_sip_core::Method,
+    transaction: Option<&rvoip_sip_dialog::transaction::TransactionKey>,
+) -> PendingOfferTransactionCorrelation {
+    let Some(pending_method) = pending_method else {
+        return PendingOfferTransactionCorrelation::NoPendingOffer;
+    };
+    if pending_method != method {
+        return PendingOfferTransactionCorrelation::OtherMethod;
+    }
+    if pending_transaction == transaction && transaction.is_some() {
+        PendingOfferTransactionCorrelation::Exact
+    } else {
+        PendingOfferTransactionCorrelation::Mismatched
+    }
+}
+
+fn invite_success_is_retransmission(
+    dialog_established: bool,
+    correlation: PendingOfferTransactionCorrelation,
+) -> bool {
+    dialog_established && correlation == PendingOfferTransactionCorrelation::NoPendingOffer
+}
+
+fn initial_invite_used_delayed_offer(snapshot: &SessionStateSnapshot) -> bool {
+    snapshot.role == Role::UAC
+        && snapshot
+            .pending_invite_options
+            .as_ref()
+            .and_then(|options| options.sdp.as_deref())
+            .is_some_and(|sdp| sdp.trim().is_empty())
+}
+
+fn response_from_bytes(raw_response: Option<&bytes::Bytes>) -> Option<rvoip_sip_core::Response> {
+    match rvoip_sip_core::parse_message(raw_response?.as_ref()).ok()? {
+        rvoip_sip_core::Message::Response(response) => Some(response),
+        rvoip_sip_core::Message::Request(_) => None,
     }
 }
 
@@ -1890,6 +2016,7 @@ impl SessionCrossCrateEventHandler {
                 transaction_id,
                 method,
                 outcome,
+                response_sdp,
             } => {
                 let session_id = handle.session_id().clone();
                 self.handle_outbound_request_completed_parts(
@@ -1897,6 +2024,7 @@ impl SessionCrossCrateEventHandler {
                     &transaction_id,
                     &method,
                     outcome,
+                    response_sdp,
                     handle,
                     true,
                 )
@@ -2063,12 +2191,14 @@ impl SessionCrossCrateEventHandler {
                 transaction_id,
                 method,
                 outcome,
+                response_sdp,
             } => {
                 self.handle_outbound_request_completed_parts(
                     SessionId(session_id.clone()),
                     transaction_id,
                     method,
                     *outcome,
+                    response_sdp.clone(),
                     exact_handle.cloned().ok_or_else(|| {
                         anyhow::anyhow!(
                             "OutboundRequestCompleted ingress lost exact session authority"
@@ -2198,11 +2328,11 @@ impl SessionCrossCrateEventHandler {
                 )
                 .await
             }
-            DialogToSessionEvent::AckReceived { session_id, .. } => {
-                self.handle_ack_received_session(require_dialog_event_handle(
-                    exact_handle,
-                    session_id,
-                )?)
+            DialogToSessionEvent::AckReceived { session_id, sdp } => {
+                self.handle_ack_received_session(
+                    require_dialog_event_handle(exact_handle, session_id)?,
+                    sdp.clone(),
+                )
                 .await
             }
             DialogToSessionEvent::RegistrationSuccess { session_id } => {
@@ -3979,6 +4109,88 @@ impl SessionCrossCrateEventHandler {
             }
         };
 
+        let parsed_response = response_from_bytes(raw_response.as_ref());
+        let response_transaction = parsed_response
+            .as_ref()
+            .and_then(rvoip_sip_dialog::transaction::TransactionKey::from_response);
+        let pending_offer = initial_snapshot.pending_offer_answer.as_ref();
+        let pending_correlation = correlate_pending_offer_transaction(
+            pending_offer.map(|pending| &pending.method),
+            pending_offer.and_then(|pending| pending.transaction_id.as_ref()),
+            &rvoip_sip_core::Method::Invite,
+            response_transaction.as_ref(),
+        );
+        if invite_success_is_retransmission(
+            initial_snapshot.dialog_established,
+            pending_correlation,
+        ) {
+            if let (Some(response), Some(transaction_id)) =
+                (parsed_response.as_ref(), response_transaction.as_ref())
+            {
+                if !response.body().is_empty() {
+                    self.dialog_adapter
+                        .send_invite_2xx_ack_exact(handle, transaction_id, response)
+                        .await?;
+                }
+            }
+            debug!(
+                session_id = %session_id,
+                "ACKed and ignored retransmitted INVITE 2xx after offer/answer commit"
+            );
+            return Ok(());
+        }
+        match pending_correlation {
+            PendingOfferTransactionCorrelation::OtherMethod => {
+                if let (Some(response), Some(transaction_id)) =
+                    (parsed_response.as_ref(), response_transaction.as_ref())
+                {
+                    if !response.body().is_empty() {
+                        self.dialog_adapter
+                            .send_invite_2xx_ack_exact(handle, transaction_id, response)
+                            .await?;
+                    }
+                }
+                warn!(
+                    session_id = %session_id,
+                    "Ignoring an INVITE success while another method owns the pending offer"
+                );
+                return Ok(());
+            }
+            PendingOfferTransactionCorrelation::Mismatched => {
+                if let (Some(response), Some(transaction_id)) =
+                    (parsed_response.as_ref(), response_transaction.as_ref())
+                {
+                    if !response.body().is_empty() {
+                        self.dialog_adapter
+                            .send_invite_2xx_ack_exact(handle, transaction_id, response)
+                            .await?;
+                    }
+                }
+                warn!(
+                    session_id = %session_id,
+                    "Ignoring a re-INVITE answer that does not own the pending offer transaction"
+                );
+                return Ok(());
+            }
+            PendingOfferTransactionCorrelation::Exact => {
+                if let Some(transaction) = response_transaction.as_ref() {
+                    if self
+                        .dialog_adapter
+                        .outbound_request_tracker
+                        .complete_if_matches(handle, TrackedInDialogMethod::Reinvite, transaction)
+                    {
+                        self.clear_tracked_request_auth_state(
+                            handle,
+                            TrackedInDialogMethod::Reinvite,
+                            transaction,
+                        )
+                        .await;
+                    }
+                }
+            }
+            PendingOfferTransactionCorrelation::NoPendingOffer => {}
+        }
+
         if initial_snapshot.session_refresh_phase
             == crate::session_store::state::SessionRefreshPhase::ReinviteInFlight
         {
@@ -3996,22 +4208,148 @@ impl SessionCrossCrateEventHandler {
             return Ok(());
         }
 
-        let result = match process_event_with_remote_sdp_exact_on_fresh_task(
-            Arc::clone(&self.state_machine),
-            handle.clone(),
-            EventType::Dialog200OK,
-            sdp_answer.clone(),
-        )
-        .await
+        let mid_dialog_offer = pending_correlation == PendingOfferTransactionCorrelation::Exact;
+        if mid_dialog_offer && sdp_answer.as_deref().is_none_or(str::is_empty) {
+            if let (Some(response), Some(transaction_id)) =
+                (parsed_response.as_ref(), response_transaction.as_ref())
+            {
+                if !response.body().is_empty() {
+                    self.dialog_adapter
+                        .send_invite_2xx_ack_exact(handle, transaction_id, response)
+                        .await?;
+                }
+            }
+            self.app_event_publisher.publish_exact(
+                handle,
+                crate::api::events::Event::RenegotiationFailed {
+                    call_id: session_id.clone(),
+                    method: "INVITE".to_string(),
+                    reason: "successful response contained no SDP answer".to_string(),
+                },
+            );
+            self.terminate_confirmed_negotiation(
+                handle,
+                "acknowledged re-INVITE contained no SDP answer",
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let delayed_offer = initial_invite_used_delayed_offer(&initial_snapshot);
+
+        let ack_input = parsed_response
+            .clone()
+            .zip(response_transaction.clone())
+            .filter(|(response, _)| !response.body().is_empty())
+            .map(|(response, transaction_id)| {
+                Invite2xxAckStateInput::new(transaction_id, response)
+            });
+        if delayed_offer
+            && (sdp_answer
+                .as_deref()
+                .is_none_or(|sdp| sdp.trim().is_empty())
+                || ack_input.is_none())
         {
+            if let (Some(response), Some(transaction_id)) =
+                (parsed_response.as_ref(), response_transaction.as_ref())
+            {
+                if !response.body().is_empty() {
+                    self.dialog_adapter
+                        .send_invite_2xx_ack_exact(handle, transaction_id, response)
+                        .await?;
+                }
+            }
+            self.app_event_publisher.publish_exact(
+                handle,
+                crate::api::events::Event::RenegotiationFailed {
+                    call_id: session_id.clone(),
+                    method: "INVITE".to_string(),
+                    reason: "offerless INVITE received no usable 200 OK SDP offer".to_string(),
+                },
+            );
+            self.fail_initial_invite_negotiation(
+                handle,
+                "offerless INVITE received no usable 200 OK SDP offer",
+            )
+            .await?;
+            return Ok(());
+        }
+        let process_result = if let Some(ack) = ack_input {
+            process_invite_2xx_answer_exact_on_fresh_task(
+                Arc::clone(&self.state_machine),
+                handle.clone(),
+                sdp_answer.clone(),
+                ack,
+            )
+            .await
+        } else {
+            process_event_with_remote_sdp_exact_on_fresh_task(
+                Arc::clone(&self.state_machine),
+                handle.clone(),
+                EventType::Dialog200OK,
+                sdp_answer.clone(),
+            )
+            .await
+        };
+        let result = match process_result {
             Ok(result) => result,
             Err(e) => {
                 error!("Failed to process CallEstablished as Dialog200OK: {}", e);
-                return Err(SessionError::InvalidTransition(format!(
-                    "Dialog200OK lifecycle transition failed for session {} role {:?} state {:?}: {}",
-                    session_id, initial_snapshot.role, initial_snapshot.call_state, e
-                ))
-                .into());
+                if matches!(
+                    e.downcast_ref::<SessionError>(),
+                    Some(SessionError::DialogError(_))
+                ) {
+                    // Leave the exact response pending so its retransmission
+                    // retries the same bodyless or cached answer-bearing ACK.
+                    return Err(SessionError::InvalidTransition(format!(
+                        "INVITE 2xx ACK write failed for session {}: {e}",
+                        session_id
+                    ))
+                    .into());
+                }
+                if let (Some(response), Some(transaction_id)) =
+                    (parsed_response.as_ref(), response_transaction.as_ref())
+                {
+                    if !response.body().is_empty() {
+                        self.dialog_adapter
+                            .send_invite_2xx_ack_exact(handle, transaction_id, response)
+                            .await?;
+                    }
+                }
+                if mid_dialog_offer || delayed_offer {
+                    self.app_event_publisher.publish_exact(
+                        handle,
+                        crate::api::events::Event::RenegotiationFailed {
+                            call_id: session_id.clone(),
+                            method: "INVITE".to_string(),
+                            reason: if delayed_offer {
+                                "invalid SDP offer or failed answer-bearing ACK".to_string()
+                            } else {
+                                "invalid or unacceptable SDP answer".to_string()
+                            },
+                        },
+                    );
+                    if delayed_offer {
+                        self.fail_initial_invite_negotiation(
+                            handle,
+                            "delayed-offer SDP negotiation or media commit failed",
+                        )
+                        .await?;
+                    } else {
+                        self.terminate_confirmed_negotiation(
+                            handle,
+                            "acknowledged re-INVITE answer could not be applied",
+                        )
+                        .await?;
+                    }
+                    return Ok(());
+                }
+                self.fail_initial_invite_negotiation(
+                    handle,
+                    "successful initial INVITE response had missing, invalid, or unusable SDP",
+                )
+                .await?;
+                return Ok(());
             }
         };
         match committed_dialog_200(&session_id, initial_snapshot.role, &result)? {
@@ -4037,6 +4375,38 @@ impl SessionCrossCrateEventHandler {
             }
         }
 
+        Ok(())
+    }
+
+    async fn fail_initial_invite_negotiation(
+        &self,
+        handle: &SessionRegistryHandle,
+        reason: &str,
+    ) -> Result<()> {
+        self.app_event_publisher.publish_exact(
+            handle,
+            crate::api::events::Event::CallFailed {
+                call_id: handle.session_id().clone(),
+                status_code: 488,
+                reason: reason.to_string(),
+            },
+        );
+        self.terminate_confirmed_negotiation(handle, reason).await
+    }
+
+    async fn terminate_confirmed_negotiation(
+        &self,
+        handle: &SessionRegistryHandle,
+        reason: &str,
+    ) -> Result<()> {
+        self.state_machine
+            .process_event_exact(handle, EventType::ConfirmedNegotiationFailure)
+            .await
+            .map_err(|error| {
+                SessionError::InvalidTransition(format!(
+                    "failed to terminate confirmed dialog after negotiation failure ({reason}): {error}"
+                ))
+            })?;
         Ok(())
     }
 
@@ -4232,6 +4602,45 @@ impl SessionCrossCrateEventHandler {
                             "stale RFC 4028 authentication failure was suppressed"
                         );
                     }
+                } else if matches!(
+                    tracked_method,
+                    TrackedInDialogMethod::Update | TrackedInDialogMethod::Reinvite
+                ) {
+                    let pending_matches = self
+                        .state_machine
+                        .store
+                        .get_session_snapshot_exact(&handle)
+                        .ok()
+                        .is_some_and(|snapshot| {
+                            let pending = snapshot.pending_offer_answer.as_ref();
+                            correlate_pending_offer_transaction(
+                                pending.map(|offer| &offer.method),
+                                pending.and_then(|offer| offer.transaction_id.as_ref()),
+                                &tracked_method.as_sip_method(),
+                                Some(transaction),
+                            ) == PendingOfferTransactionCorrelation::Exact
+                        });
+                    if pending_matches {
+                        self.state_machine
+                            .process_event_exact(&handle, EventType::Dialog4xxFailure(status))
+                            .await
+                            .map_err(|error| {
+                                SessionError::InvalidTransition(format!(
+                                    "failed to roll back an authenticated session modification: {error}"
+                                ))
+                            })?;
+                        self.app_event_publisher.publish_exact(
+                            &handle,
+                            crate::api::events::Event::RenegotiationFailed {
+                                call_id: session_id.clone(),
+                                method: tracked_method.as_sip_method().to_string(),
+                                reason: format!(
+                                    "authentication failed (class={})",
+                                    failure_class.label()
+                                ),
+                            },
+                        );
+                    }
                 }
             }
         }
@@ -4244,6 +4653,7 @@ impl SessionCrossCrateEventHandler {
         transaction_id: &str,
         method: &str,
         outcome: OutboundRequestOutcome,
+        response_sdp: Option<String>,
         handle: SessionRegistryHandle,
         exact_replay: bool,
     ) -> Result<()> {
@@ -4288,6 +4698,7 @@ impl SessionCrossCrateEventHandler {
                 transaction_id: transaction_id.to_string(),
                 method: method.to_string(),
                 outcome,
+                response_sdp: response_sdp.clone(),
             };
             match self
                 .dialog_adapter
@@ -4321,6 +4732,37 @@ impl SessionCrossCrateEventHandler {
                 .dialog_adapter
                 .outbound_request_tracker
                 .is_session_timer_reinvite(&handle, &transaction);
+        let pending_offer_correlation = self
+            .state_machine
+            .store
+            .get_session_snapshot_exact(&handle)
+            .ok()
+            .map(|snapshot| {
+                let pending = snapshot.pending_offer_answer.as_ref();
+                correlate_pending_offer_transaction(
+                    pending.map(|offer| &offer.method),
+                    pending.and_then(|offer| offer.transaction_id.as_ref()),
+                    &tracked_method.as_sip_method(),
+                    Some(&transaction),
+                )
+            })
+            .unwrap_or(PendingOfferTransactionCorrelation::NoPendingOffer);
+        if pending_offer_correlation == PendingOfferTransactionCorrelation::Mismatched {
+            if self
+                .dialog_adapter
+                .outbound_request_tracker
+                .complete_if_matches(&handle, tracked_method, &transaction)
+            {
+                self.clear_tracked_request_auth_state(&handle, tracked_method, &transaction)
+                    .await;
+            }
+            warn!(
+                session_id = %session_id,
+                method = safe_auth_method_label(method),
+                "Ignoring an answer that does not own the pending offer transaction"
+            );
+            return Ok(());
+        }
         if !self
             .dialog_adapter
             .outbound_request_tracker
@@ -4403,6 +4845,61 @@ impl SessionCrossCrateEventHandler {
                         "stale RFC 4028 completion was suppressed"
                     );
                 }
+            }
+        } else if tracked_method == TrackedInDialogMethod::Update
+            && pending_offer_correlation == PendingOfferTransactionCorrelation::Exact
+        {
+            let (mut completion_event, mut failure_reason) = update_completion_transition(outcome);
+            let successful_response = matches!(completion_event, EventType::Dialog200OK);
+            let remote_answer = if successful_response {
+                match response_sdp.filter(|sdp| !sdp.trim().is_empty()) {
+                    Some(answer) => Some(answer),
+                    None => {
+                        completion_event = EventType::Dialog4xxFailure(488);
+                        failure_reason = Some("successful UPDATE response contained no SDP answer");
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            if let Some(answer) = remote_answer {
+                self.state_machine
+                    .process_event_with_remote_sdp_exact(&handle, completion_event, Some(answer))
+                    .await
+                    .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+            } else {
+                self.state_machine
+                    .process_event_exact(&handle, completion_event)
+                    .await
+                    .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+            }
+            if let Some(reason) = failure_reason {
+                self.app_event_publisher.publish_exact(
+                    &handle,
+                    crate::api::events::Event::RenegotiationFailed {
+                        call_id: session_id.clone(),
+                        method: "UPDATE".to_string(),
+                        reason: reason.to_string(),
+                    },
+                );
+            }
+        } else if tracked_method == TrackedInDialogMethod::Reinvite
+            && pending_offer_correlation == PendingOfferTransactionCorrelation::Exact
+        {
+            if let Some((failure_event, reason)) = reinvite_completion_failure(outcome) {
+                self.state_machine
+                    .process_event_exact(&handle, failure_event)
+                    .await
+                    .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+                self.app_event_publisher.publish_exact(
+                    &handle,
+                    crate::api::events::Event::RenegotiationFailed {
+                        call_id: session_id,
+                        method: "INVITE".to_string(),
+                        reason: reason.to_string(),
+                    },
+                );
             }
         }
         Ok(())
@@ -4519,6 +5016,29 @@ impl SessionCrossCrateEventHandler {
             return Ok(());
         };
 
+        let response_transaction = response_from_bytes(raw_response.as_ref())
+            .as_ref()
+            .and_then(rvoip_sip_dialog::transaction::TransactionKey::from_response);
+        let pending_offer = initial_snapshot.pending_offer_answer.as_ref();
+        let pending_correlation = correlate_pending_offer_transaction(
+            pending_offer.map(|pending| &pending.method),
+            pending_offer.and_then(|pending| pending.transaction_id.as_ref()),
+            &rvoip_sip_core::Method::Invite,
+            response_transaction.as_ref(),
+        );
+        if matches!(
+            pending_correlation,
+            PendingOfferTransactionCorrelation::OtherMethod
+                | PendingOfferTransactionCorrelation::Mismatched
+        ) {
+            warn!(
+                session_id = %session_id,
+                status,
+                "Ignoring an INVITE failure that does not own the pending offer transaction"
+            );
+            return Ok(());
+        }
+
         if initial_snapshot.session_refresh_phase
             == crate::session_store::state::SessionRefreshPhase::ReinviteInFlight
         {
@@ -4581,6 +5101,16 @@ impl SessionCrossCrateEventHandler {
                     "session {} in-dialog request failed with {}; committed a non-terminal YAML rollback and retained the call",
                     session_id, status
                 );
+                if pending_correlation == PendingOfferTransactionCorrelation::Exact {
+                    self.app_event_publisher.publish_exact(
+                        handle,
+                        crate::api::events::Event::RenegotiationFailed {
+                            call_id: session_id.clone(),
+                            method: "INVITE".to_string(),
+                            reason: format!("re-INVITE failed with SIP status {status}"),
+                        },
+                    );
+                }
                 return Ok(());
             }
             CommittedCallFailure::Cancelled => {
@@ -5265,6 +5795,31 @@ impl SessionCrossCrateEventHandler {
             })?;
         let previous_remote_direction = Some(snapshot.remote_media_direction);
         let has_sdp = sdp.is_some();
+        if let Some(offer) = sdp.as_deref() {
+            if let Err(error) = self.media_adapter.validate_inbound_sdp_offer(offer) {
+                let mut response_input = Some(inbound_response);
+                let terminal = crate::state_machine::actions::send_exact_inbound_final_response(
+                    handle.session_id(),
+                    response_input.as_mut(),
+                    &self.dialog_adapter,
+                    488,
+                    None,
+                    None,
+                )
+                .await
+                .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+                warn!(
+                    session_id = %handle.session_id(),
+                    method = %method,
+                    error_class = %error,
+                    "Rejected invalid inbound session-modification offer"
+                );
+                if let Some(error) = terminal.terminal_error {
+                    return Err(anyhow::anyhow!(error.to_string()));
+                }
+                return Ok(());
+            }
+        }
         let event = if method.eq_ignore_ascii_case("UPDATE") {
             EventType::UpdateReceived { sdp }
         } else {
@@ -5294,7 +5849,7 @@ impl SessionCrossCrateEventHandler {
                 "Inbound re-INVITE/UPDATE response reached a terminal wire disposition"
             );
         }
-        if method.eq_ignore_ascii_case("INVITE") && has_sdp {
+        if has_sdp {
             self.apply_inbound_reinvite_media_direction(handle, previous_remote_direction)
                 .await;
         }
@@ -5546,7 +6101,11 @@ impl SessionCrossCrateEventHandler {
         processing_ack.map_err(anyhow::Error::msg)
     }
 
-    async fn handle_ack_received_session(&self, handle: &SessionRegistryHandle) -> Result<()> {
+    async fn handle_ack_received_session(
+        &self,
+        handle: &SessionRegistryHandle,
+        sdp_answer: Option<String>,
+    ) -> Result<()> {
         let session_id = handle.session_id();
         if self
             .state_machine
@@ -5562,15 +6121,45 @@ impl SessionCrossCrateEventHandler {
         }
 
         rvoip_sip_dialog::diagnostics::record_ack_event_delivered();
-        if let Err(error) = self
+        let delayed_offer_answer = !self
             .state_machine
-            .process_event_exact(handle, EventType::DialogACK)
-            .await
-        {
+            .store
+            .get_session_snapshot_exact(handle)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?
+            .sdp_negotiated;
+        let process_result = if delayed_offer_answer {
+            self.state_machine
+                .process_event_with_remote_sdp_exact(handle, EventType::DialogACK, sdp_answer)
+                .await
+        } else {
+            self.state_machine
+                .process_event_exact(handle, EventType::DialogACK)
+                .await
+        };
+        if let Err(error) = process_result {
             error!(
                 "Failed to process DialogACK event after AckReceived: {}",
                 error
             );
+            if delayed_offer_answer {
+                self.app_event_publisher.publish_exact(
+                    handle,
+                    crate::api::events::Event::RenegotiationFailed {
+                        call_id: session_id.clone(),
+                        method: "ACK".to_string(),
+                        reason: "missing, invalid, or unacceptable ACK SDP answer".to_string(),
+                    },
+                );
+            }
+            self.terminate_confirmed_negotiation(
+                handle,
+                if delayed_offer_answer {
+                    "ACK carried a missing, invalid, or unusable SDP answer"
+                } else {
+                    "confirmed UAS dialog could not activate negotiated media"
+                },
+            )
+            .await?;
         } else if let Some(coordinator) = self.coordinator.get().and_then(|w| w.upgrade()) {
             coordinator
                 .schedule_active_call_media_timeout_if_current(session_id)
@@ -7545,6 +8134,7 @@ mod tests {
             transaction_id: transaction.to_string(),
             method: "INFO".to_string(),
             outcome: rvoip_infra_common::events::cross_crate::OutboundRequestOutcome::Timeout,
+            response_sdp: None,
         };
         let mut replay = tracker.take_deferred_replay_receiver().unwrap();
         assert_eq!(
@@ -7579,6 +8169,7 @@ mod tests {
             transaction_id: transaction.to_string(),
             method: "INFO".to_string(),
             outcome: rvoip_infra_common::events::cross_crate::OutboundRequestOutcome::Timeout,
+            response_sdp: None,
         };
         let mut replay = tracker.take_deferred_replay_receiver().unwrap();
         assert_eq!(

--- a/crates/sip/rvoip-sip/src/adapters/session_event_handler.rs
+++ b/crates/sip/rvoip-sip/src/adapters/session_event_handler.rs
@@ -4127,11 +4127,9 @@ impl SessionCrossCrateEventHandler {
             if let (Some(response), Some(transaction_id)) =
                 (parsed_response.as_ref(), response_transaction.as_ref())
             {
-                if !response.body().is_empty() {
-                    self.dialog_adapter
-                        .send_invite_2xx_ack_exact(handle, transaction_id, response)
-                        .await?;
-                }
+                self.dialog_adapter
+                    .send_invite_2xx_ack_exact(handle, transaction_id, response)
+                    .await?;
             }
             debug!(
                 session_id = %session_id,
@@ -7092,6 +7090,22 @@ mod tests {
             );
         }
         assert!(stale_dialog_dispatch_result("bye_received").is_ok());
+    }
+
+    #[test]
+    fn committed_invite_2xx_retransmission_always_sends_ack() {
+        let source = include_str!("session_event_handler.rs");
+        let retransmission = source
+            .split("if invite_success_is_retransmission(")
+            .nth(1)
+            .and_then(|tail| tail.split("match pending_correlation").next())
+            .expect("committed INVITE 2xx retransmission branch");
+
+        assert!(retransmission.contains("send_invite_2xx_ack_exact"));
+        assert!(
+            !retransmission.contains("body().is_empty()"),
+            "a bodyless INVITE 2xx retransmission still requires ACK"
+        );
     }
 
     #[test]

--- a/crates/sip/rvoip-sip/src/api/callback_peer.rs
+++ b/crates/sip/rvoip-sip/src/api/callback_peer.rs
@@ -2578,7 +2578,8 @@ impl<H: CallHandler> CallbackPeer<H> {
                 | Event::IncomingCallAuthenticated { .. }
                 | Event::CallProgressDetailed(_)
                 | Event::CallEstablishedDetailed(_)
-                | Event::CallFailedDetailed(_) => {}
+                | Event::CallFailedDetailed(_)
+                | Event::RenegotiationFailed { .. } => {}
                 // SIP_API_DESIGN_2 Phase E: typed mid-dialog inbound
                 // events. Rehydrate the coordinator hook on the
                 // IncomingRequest before forwarding to the handler so

--- a/crates/sip/rvoip-sip/src/api/events.rs
+++ b/crates/sip/rvoip-sip/src/api/events.rs
@@ -363,6 +363,17 @@ pub enum Event {
         reason: String,
     },
 
+    /// A mid-dialog or delayed-offer SDP exchange failed. Stable SDP,
+    /// directions, and media state are preserved.
+    RenegotiationFailed {
+        /// Session identifier for the failed exchange.
+        call_id: CallId,
+        /// `INVITE`, `UPDATE`, or `ACK`.
+        method: String,
+        /// Bounded diagnostic category; SDP bodies are never included.
+        reason: String,
+    },
+
     /// RFC 3261 §22.2 — server challenged our INVITE with 401/407 and we're
     /// about to retry with a digest authorization header. Informational; no
     /// action required from the app. If the retry fails (wrong credentials
@@ -804,6 +815,11 @@ impl std::fmt::Debug for Event {
                 .debug_struct("SessionRefreshFailed")
                 .field("reason_bytes", &reason.len())
                 .finish(),
+            Self::RenegotiationFailed { method, reason, .. } => formatter
+                .debug_struct("RenegotiationFailed")
+                .field("method_bytes", &method.len())
+                .field("reason_bytes", &reason.len())
+                .finish(),
             Self::CallAuthRetrying {
                 status_code, realm, ..
             } => formatter
@@ -1043,6 +1059,7 @@ impl Event {
             | Event::CallCancelled { call_id, .. }
             | Event::SessionRefreshed { call_id, .. }
             | Event::SessionRefreshFailed { call_id, .. }
+            | Event::RenegotiationFailed { call_id, .. }
             | Event::CallAuthRetrying { call_id, .. }
             | Event::ReferReceived { call_id, .. }
             | Event::TransferAccepted { call_id, .. }
@@ -1108,6 +1125,7 @@ impl Event {
                 | Event::CallProgressDetailed(_)
                 | Event::CallEstablishedDetailed(_)
                 | Event::CallFailedDetailed(_)
+                | Event::RenegotiationFailed { .. }
                 | Event::InfoReceived { .. }
                 | Event::MessageReceived { .. }
                 | Event::OptionsReceived { .. }

--- a/crates/sip/rvoip-sip/src/api/send/outbound_call.rs
+++ b/crates/sip/rvoip-sip/src/api/send/outbound_call.rs
@@ -202,6 +202,17 @@ impl OutboundCallBuilder {
         self
     }
 
+    /// Send the initial INVITE without an SDP offer.
+    ///
+    /// If the successful response contains an SDP offer, the coordinator
+    /// generates its answer and carries it in ACK as required by RFC 3261.
+    pub fn without_sdp(mut self) -> Self {
+        // `None` means "use the generated offer" at dispatch, so retain an
+        // explicit empty snapshot to represent delayed offer.
+        self.sdp = Some(String::new());
+        self
+    }
+
     /// Attach Digest credentials for UAC 401/407 retry.
     pub fn with_credentials(mut self, creds: Credentials) -> Self {
         self.credentials = Some(creds);

--- a/crates/sip/rvoip-sip/src/api/unified.rs
+++ b/crates/sip/rvoip-sip/src/api/unified.rs
@@ -7727,6 +7727,7 @@ impl UnifiedCoordinator {
                 "invite_2xx_response_cache": transaction_counts.invite_2xx_response_cache,
                 "invite_2xx_response_due_queue": transaction_counts.invite_2xx_response_due_queue,
                 "transaction_destinations": transaction_counts.transaction_destinations,
+                "orphaned_transaction_destinations": transaction_manager.orphaned_transaction_destination_count(),
                 "retired_client_transactions": transaction_manager.retired_client_transaction_count(),
                 "event_subscribers": transaction_counts.event_subscribers,
                 "subscriber_to_transactions": transaction_counts.subscriber_to_transactions,

--- a/crates/sip/rvoip-sip/src/session_store/state.rs
+++ b/crates/sip/rvoip-sip/src/session_store/state.rs
@@ -54,6 +54,24 @@ pub enum PendingReinvite {
     SdpUpdate(String),
 }
 
+/// Stable offer/answer state retained while an outbound session modification
+/// is in flight. The new offer may have reached the wire, but it is not the
+/// dialog's stable description until the exact transaction receives and
+/// successfully applies a valid answer.
+#[derive(Clone)]
+pub(crate) struct PendingOfferAnswer {
+    pub(crate) method: rvoip_sip_core::Method,
+    pub(crate) transaction_id: Option<TransactionKey>,
+    pub(crate) local_offer: String,
+    stable_local_sdp: Option<String>,
+    stable_remote_sdp: Option<String>,
+    stable_negotiated_config: Option<NegotiatedConfig>,
+    stable_media_security: Option<MediaSecurityState>,
+    stable_sdp_negotiated: bool,
+    stable_local_direction: MediaDirection,
+    stable_remote_direction: MediaDirection,
+}
+
 /// Private RFC 4028 refresh ownership for one exact session lifetime.
 ///
 /// This is deliberately separate from [`PendingReinvite`]. That public
@@ -168,6 +186,7 @@ pub struct SessionStateCold {
     pub redirect_targets: Vec<String>,
     pub redirect_attempts: u8,
     pub pending_reinvite: Option<PendingReinvite>,
+    pub(crate) pending_offer_answer: Option<PendingOfferAnswer>,
     /// Stable local SDP captured before an outbound re-INVITE replaces the
     /// working offer. The outer option marks an in-flight snapshot; the inner
     /// option preserves whether the stable dialog had local SDP at all.
@@ -385,6 +404,14 @@ impl fmt::Debug for SessionState {
             PendingReinvite::Resume => "resume",
             PendingReinvite::SdpUpdate(_) => "sdp_update",
         });
+        let pending_offer_answer_method = self
+            .pending_offer_answer
+            .as_ref()
+            .map(|pending| pending.method.to_string());
+        let pending_offer_answer_transaction_present = self
+            .pending_offer_answer
+            .as_ref()
+            .is_some_and(|pending| pending.transaction_id.is_some());
         let pending_auth_status = self.pending_auth.as_ref().map(|(status, _)| *status);
         let pending_auth_transport_secure = self
             .pending_auth_transport
@@ -509,6 +536,11 @@ impl fmt::Debug for SessionState {
             .field("redirect_target_count", &self.redirect_targets.len())
             .field("redirect_attempts", &self.redirect_attempts)
             .field("pending_reinvite", &pending_reinvite)
+            .field("pending_offer_answer_method", &pending_offer_answer_method)
+            .field(
+                "pending_offer_answer_transaction_present",
+                &pending_offer_answer_transaction_present,
+            )
             .field("reinvite_retry_attempts", &self.reinvite_retry_attempts)
             .field("session_timer_min_se", &self.session_timer_min_se)
             .field("session_timer_retry_count", &self.session_timer_retry_count)
@@ -897,6 +929,7 @@ impl SessionState {
                 redirect_targets: Vec::new(),
                 redirect_attempts: 0,
                 pending_reinvite: None,
+                pending_offer_answer: None,
                 stable_local_sdp_before_reinvite: None,
                 reinvite_retry_attempts: 0,
                 session_timer_min_se: None,
@@ -957,6 +990,77 @@ impl SessionState {
         }
     }
 
+    pub(crate) fn begin_offer_answer(
+        &mut self,
+        method: rvoip_sip_core::Method,
+        local_offer: String,
+    ) -> crate::errors::Result<()> {
+        if self.pending_offer_answer.is_some() {
+            return Err(crate::errors::SessionError::Conflict { method });
+        }
+        self.pending_offer_answer = Some(PendingOfferAnswer {
+            method,
+            transaction_id: None,
+            local_offer,
+            stable_local_sdp: self.local_sdp.clone(),
+            stable_remote_sdp: self.remote_sdp.clone(),
+            stable_negotiated_config: self.negotiated_config.clone(),
+            stable_media_security: self.media_security.clone(),
+            stable_sdp_negotiated: self.sdp_negotiated,
+            stable_local_direction: self.local_media_direction,
+            stable_remote_direction: self.remote_media_direction,
+        });
+        Ok(())
+    }
+
+    pub(crate) fn bind_offer_answer_transaction(
+        &mut self,
+        transaction_id: TransactionKey,
+    ) -> crate::errors::Result<()> {
+        if let Some(pending) = self.pending_offer_answer.as_mut() {
+            if transaction_id.is_server() || transaction_id.method() != &pending.method {
+                return Err(crate::errors::SessionError::InvalidTransition(
+                    "outbound offer/answer transaction did not match its pending method"
+                        .to_string(),
+                ));
+            }
+            pending.transaction_id = Some(transaction_id);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn replace_pending_local_offer(&mut self, local_offer: String) {
+        if let Some(pending) = self.pending_offer_answer.as_mut() {
+            pending.local_offer = local_offer;
+        }
+    }
+
+    pub(crate) fn commit_offer_answer(&mut self) {
+        if let Some(pending) = self.pending_offer_answer.take() {
+            self.local_sdp = Some(pending.local_offer);
+        }
+    }
+
+    pub(crate) fn discard_offer_answer_rollback_image(&mut self) {
+        self.pending_offer_answer = None;
+    }
+
+    /// Restore the preceding stable negotiation. SDP origin version is not
+    /// rolled back because a version that could have reached the wire must
+    /// never be reused.
+    pub(crate) fn rollback_offer_answer(&mut self) {
+        let Some(pending) = self.pending_offer_answer.take() else {
+            return;
+        };
+        self.local_sdp = pending.stable_local_sdp;
+        self.remote_sdp = pending.stable_remote_sdp;
+        self.negotiated_config = pending.stable_negotiated_config;
+        self.media_security = pending.stable_media_security;
+        self.sdp_negotiated = pending.stable_sdp_negotiated;
+        self.local_media_direction = pending.stable_local_direction;
+        self.remote_media_direction = pending.stable_remote_direction;
+    }
+
     /// Final-state safety net for pending request options.
     ///
     /// The immutable presence check is load-bearing for the normal call path:
@@ -979,6 +1083,7 @@ impl SessionState {
             || cold.auth_challenge_replaces_nonce.is_some()
             || !cold.digest_nc.is_empty()
             || cold.pending_reinvite_options.is_some()
+            || cold.pending_offer_answer.is_some()
             || cold.pending_register_options.is_some()
             || cold.pending_refer_options.is_some()
             || cold.pending_bye_options.is_some()
@@ -1012,6 +1117,7 @@ impl SessionState {
         cold.auth_challenge_replaces_nonce = None;
         cold.digest_nc.clear();
         cold.pending_reinvite_options = None;
+        cold.pending_offer_answer = None;
         cold.pending_register_options = None;
         cold.pending_refer_options = None;
         cold.pending_bye_options = None;
@@ -1306,6 +1412,49 @@ mod tests {
 
         assert_eq!(debug, "SdpUpdate");
         assert!(!debug.contains(SECRET));
+    }
+
+    #[test]
+    fn pending_offer_answer_commits_or_restores_stable_negotiation_atomically() {
+        let mut session = SessionState::new(SessionId::new(), Role::UAC);
+        session.local_sdp = Some("stable-local".into());
+        session.remote_sdp = Some("stable-remote".into());
+        session.sdp_negotiated = true;
+        session.local_media_direction = MediaDirection::SendRecv;
+        session.remote_media_direction = MediaDirection::SendRecv;
+
+        session
+            .begin_offer_answer(rvoip_sip_core::Method::Invite, "hold-offer".into())
+            .expect("begin hold offer");
+        session
+            .bind_offer_answer_transaction(TransactionKey::new(
+                "z9hG4bK-pending-test".into(),
+                rvoip_sip_core::Method::Invite,
+                false,
+            ))
+            .expect("bind pending transaction");
+        session.remote_sdp = Some("invalid-answer".into());
+        session.sdp_negotiated = false;
+        session.local_media_direction = MediaDirection::SendOnly;
+        session.rollback_offer_answer();
+
+        assert_eq!(session.local_sdp.as_deref(), Some("stable-local"));
+        assert_eq!(session.remote_sdp.as_deref(), Some("stable-remote"));
+        assert!(session.sdp_negotiated);
+        assert_eq!(session.local_media_direction, MediaDirection::SendRecv);
+        assert!(session.pending_offer_answer.is_none());
+
+        session
+            .begin_offer_answer(rvoip_sip_core::Method::Invite, "committed-offer".into())
+            .expect("begin successful offer");
+        session.remote_sdp = Some("committed-answer".into());
+        session.local_media_direction = MediaDirection::SendOnly;
+        session.commit_offer_answer();
+
+        assert_eq!(session.local_sdp.as_deref(), Some("committed-offer"));
+        assert_eq!(session.remote_sdp.as_deref(), Some("committed-answer"));
+        assert_eq!(session.local_media_direction, MediaDirection::SendOnly);
+        assert!(session.pending_offer_answer.is_none());
     }
 
     #[test]

--- a/crates/sip/rvoip-sip/src/state_machine/actions.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/actions.rs
@@ -174,6 +174,14 @@ fn prepare_session_refresh_update(
     Ok(ActionOutcome::with_event(EventType::SendOutboundUpdate))
 }
 
+fn response_sdp_for_event(event: &EventType, local_sdp: &Option<String>) -> Option<String> {
+    if matches!(event, EventType::UpdateReceived { sdp: None }) {
+        None
+    } else {
+        local_sdp.clone()
+    }
+}
+
 fn prepare_session_refresh_reinvite(
     session: &mut SessionState,
 ) -> crate::errors::Result<ActionOutcome> {
@@ -219,6 +227,12 @@ fn rollback_reinvite_local_sdp(session: &mut SessionState) {
     if let Some(stable) = session.stable_local_sdp_before_reinvite.take() {
         session.local_sdp = stable;
     }
+}
+
+fn rollback_reinvite_with_media(session: &mut SessionState, media_adapter: &MediaAdapter) {
+    rollback_reinvite_local_sdp(session);
+    media_adapter.discard_pending_srtp_offer_for_session(session);
+    media_adapter.discard_staged_media_negotiation_for_session(session);
 }
 
 fn initial_invite_used_delayed_offer(session: &SessionState, event: &EventType) -> bool {
@@ -1890,7 +1904,7 @@ pub(crate) async fn execute_action(
             }
         }
         Action::SendSIPResponse(code, _reason) => {
-            let response_code = session.pending_response_status_override.unwrap_or(*code);
+            let mut response_code = session.pending_response_status_override.unwrap_or(*code);
             let extras = session
                 .reject_response_extras
                 .clone()
@@ -1905,6 +1919,7 @@ pub(crate) async fn execute_action(
                     "YAML UAS response status is outside the SIP response range",
                 ));
             }
+            let mut response_sdp = response_sdp_for_event(triggering_event, &session.local_sdp);
 
             let initial_invite_event = matches!(
                 triggering_event,
@@ -1922,53 +1937,91 @@ pub(crate) async fn execute_action(
             let initial_invite_response = initial_invite_event
                 || (inbound_response.is_none()
                     && session.pending_inbound_invite_transaction_id.is_some());
+            let mut prepared_media = None;
+            let mut media_preparation_error = None;
+            let response_commits_media = (response_is_final && (200..300).contains(&response_code))
+                || (response_is_provisional && response_sdp.is_some());
+            if response_commits_media && media_adapter.has_staged_media_negotiation(session) {
+                match media_adapter
+                    .prepare_staged_media_negotiation_lane_owned(session)
+                    .await
+                {
+                    Ok(prepared) => prepared_media = Some(prepared),
+                    Err(error) if response_is_final => {
+                        response_code = 488;
+                        response_sdp = None;
+                        media_preparation_error = Some(error);
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            }
             let mut terminal_error = None;
-            if response_is_final && initial_invite_response {
-                let terminal = send_exact_initial_invite_final_response(
-                    session,
-                    dialog_adapter,
-                    response_code,
-                    session.local_sdp.clone(),
-                    extras,
-                )
-                .await?;
-                consume_exact_initial_invite_response_authority(
-                    session,
-                    dialog_adapter,
-                    &terminal,
-                    response_code == 200,
-                );
-                terminal_error = terminal.terminal_error;
-            } else if response_is_final {
-                let terminal = send_exact_inbound_final_response(
-                    &session.session_id,
-                    inbound_response.as_deref_mut(),
-                    dialog_adapter,
-                    response_code,
-                    session.local_sdp.clone(),
-                    extras,
-                )
-                .await?;
-                terminal_error = terminal.terminal_error;
-            } else if initial_invite_response {
-                send_exact_initial_invite_provisional_response(
-                    session,
-                    dialog_adapter,
-                    response_code,
-                    session.local_sdp.clone(),
-                    extras,
-                )
-                .await?;
-            } else {
-                send_exact_inbound_provisional_response(
-                    &session.session_id,
-                    inbound_response.as_deref_mut(),
-                    dialog_adapter,
-                    response_code,
-                    session.local_sdp.clone(),
-                    extras,
-                )
-                .await?;
+            let dispatch_result: Result<(), Box<dyn std::error::Error + Send + Sync>> = async {
+                if response_is_final && initial_invite_response {
+                    let terminal = send_exact_initial_invite_final_response(
+                        session,
+                        dialog_adapter,
+                        response_code,
+                        response_sdp.clone(),
+                        extras,
+                    )
+                    .await?;
+                    consume_exact_initial_invite_response_authority(
+                        session,
+                        dialog_adapter,
+                        &terminal,
+                        response_code == 200,
+                    );
+                    terminal_error = terminal.terminal_error;
+                } else if response_is_final {
+                    let terminal = send_exact_inbound_final_response(
+                        &session.session_id,
+                        inbound_response.as_deref_mut(),
+                        dialog_adapter,
+                        response_code,
+                        response_sdp.clone(),
+                        extras,
+                    )
+                    .await?;
+                    terminal_error = terminal.terminal_error;
+                } else if initial_invite_response {
+                    send_exact_initial_invite_provisional_response(
+                        session,
+                        dialog_adapter,
+                        response_code,
+                        response_sdp.clone(),
+                        extras,
+                    )
+                    .await?;
+                } else {
+                    send_exact_inbound_provisional_response(
+                        &session.session_id,
+                        inbound_response.as_deref_mut(),
+                        dialog_adapter,
+                        response_code,
+                        response_sdp,
+                        extras,
+                    )
+                    .await?;
+                }
+                Ok(())
+            }
+            .await;
+            if let Err(error) = dispatch_result {
+                if let Some(prepared) = prepared_media.take() {
+                    if let Err(rollback_error) = media_adapter
+                        .rollback_prepared_media_negotiation_lane_owned(session, prepared)
+                        .await
+                    {
+                        return Err(Box::new(ExactSipResponseActionError::new(
+                            exact_sip_response_failure_disposition(error.as_ref()).unwrap_or(
+                                rvoip_sip_dialog::FinalResponseCompletionDisposition::ZeroWireRetryable,
+                            ),
+                            rollback_error,
+                        )));
+                    }
+                }
+                return Err(error);
             }
 
             // The event-local response input remains intact across every
@@ -1984,6 +2037,44 @@ pub(crate) async fn execute_action(
                     "Dialog established (UAS sent {} final response) for session {}",
                     response_code, session.session_id
                 );
+            }
+            let committed_disposition = terminal_error
+                .as_ref()
+                .and_then(|error| exact_sip_response_failure_disposition(error.as_ref()))
+                .unwrap_or(
+                    rvoip_sip_dialog::FinalResponseCompletionDisposition::WrittenSuccessTerminal,
+                );
+            if let Some(prepared) = prepared_media.take() {
+                if let Err(error) = media_adapter
+                    .finalize_prepared_media_negotiation_lane_owned(session, prepared)
+                    .await
+                {
+                    return Err(Box::new(ExactSipResponseActionError::new(
+                        committed_disposition,
+                        error,
+                    )));
+                }
+            }
+            if let Some(error) = media_preparation_error {
+                media_adapter.discard_staged_media_negotiation_for_session(session);
+                if initial_invite_response {
+                    let cleanup_result =
+                        release_lane_owned_resources(session, dialog_adapter, media_adapter).await;
+                    session.call_state =
+                        crate::types::CallState::Failed(crate::types::FailureReason::MediaError);
+                    if let Err(cleanup_error) = cleanup_result {
+                        return Err(Box::new(ExactSipResponseActionError::new(
+                            committed_disposition,
+                            crate::errors::SessionError::MediaError(format!(
+                                "initial answer media preparation failed and cleanup was incomplete: {cleanup_error}"
+                            )),
+                        )));
+                    }
+                }
+                return Err(Box::new(ExactSipResponseActionError::new(
+                    committed_disposition,
+                    error,
+                )));
             }
             if let Some(error) = terminal_error {
                 return Err(error);
@@ -2082,14 +2173,48 @@ pub(crate) async fn execute_action(
         }
         Action::ClearPendingReinvite => {
             match triggering_event {
-                EventType::Dialog200OK => commit_reinvite_local_sdp(session),
-                EventType::ReinviteReceived { .. } => {
-                    // A peer offer accepted during glare supersedes our local
-                    // pending offer. Preserve the newly negotiated answer.
+                EventType::Dialog4xxFailure(_)
+                | EventType::Dialog5xxFailure(_)
+                | EventType::Dialog6xxFailure(_)
+                | EventType::DialogTimeout => {
+                    rollback_reinvite_with_media(session, media_adapter);
+                }
+                EventType::MediaEvent(name)
+                    if name
+                        == crate::state_machine::executor::SESSION_REFRESH_REINVITE_FAILED_EVENT =>
+                {
+                    rollback_reinvite_with_media(session, media_adapter);
+                }
+                EventType::Dialog200OK => {
+                    if media_adapter.has_staged_media_negotiation(session) {
+                        media_adapter
+                            .commit_staged_media_negotiation_lane_owned(session)
+                            .await?;
+                    }
+                    commit_reinvite_local_sdp(session);
+                }
+                _ => {
+                    if matches!(triggering_event, EventType::ReinviteReceived { .. }) {
+                        let superseded_transaction = session
+                            .pending_offer_answer
+                            .as_ref()
+                            .filter(|pending| pending.method == rvoip_sip_core::Method::Invite)
+                            .and_then(|pending| pending.transaction_id.clone());
+                        if let Some(transaction) = superseded_transaction {
+                            let handle = exact_request_tracker_handle(session)?;
+                            dialog_adapter.outbound_request_tracker.abort_matching(
+                                handle,
+                                TrackedInDialogMethod::Reinvite,
+                                &transaction,
+                            );
+                            session.clear_tracked_auth_if_transaction(&transaction.to_string());
+                        }
+                    }
                     session.discard_offer_answer_rollback_image();
                     session.stable_local_sdp_before_reinvite = None;
+                    media_adapter.discard_pending_srtp_offer_for_session(session);
+                    media_adapter.discard_staged_media_negotiation_for_session(session);
                 }
-                _ => rollback_reinvite_local_sdp(session),
             }
             session.pending_reinvite = None;
             session.reinvite_retry_attempts = 0;
@@ -2108,7 +2233,7 @@ pub(crate) async fn execute_action(
             use crate::state_table::types::Role;
             const MAX_GLARE_RETRIES: u8 = 3;
             if session.reinvite_retry_attempts >= MAX_GLARE_RETRIES {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 session.pending_reinvite = None;
                 return Err(format!(
                     "491 glare retry limit ({}) exceeded for session {}",
@@ -2230,21 +2355,47 @@ pub(crate) async fn execute_action(
             }
         }
         Action::SendACK => {
+            let delayed_offer = initial_invite_used_delayed_offer(session, triggering_event);
+            let mut prepared_media = None;
+            let mut media_preparation_error = None;
+            let mut ack_negotiation_error = None;
+            if invite_2xx_ack.is_some() && media_adapter.has_staged_media_negotiation(session) {
+                match media_adapter
+                    .prepare_staged_media_negotiation_lane_owned(session)
+                    .await
+                {
+                    Ok(prepared) => prepared_media = Some(prepared),
+                    Err(error) => media_preparation_error = Some(error),
+                }
+            }
             if let Some(ack) = invite_2xx_ack {
-                if initial_invite_used_delayed_offer(session, triggering_event) {
-                    let answer = session.local_sdp.as_deref().ok_or_else(|| {
-                        crate::errors::SessionError::SDPNegotiationFailed(
-                            "delayed-offer ACK has no generated SDP answer".to_string(),
-                        )
-                    })?;
-                    dialog_adapter
-                        .send_delayed_offer_ack_exact(
-                            exact_request_tracker_handle(session)?,
-                            &ack.transaction_id,
-                            &ack.response,
-                            answer,
-                        )
-                        .await?;
+                let ack_result = if delayed_offer {
+                    if let Some(answer) = session.local_sdp.as_deref() {
+                        dialog_adapter
+                            .send_delayed_offer_ack_exact(
+                                exact_request_tracker_handle(session)?,
+                                &ack.transaction_id,
+                                &ack.response,
+                                answer,
+                            )
+                            .await
+                    } else {
+                        ack_negotiation_error =
+                            Some(crate::errors::SessionError::SDPNegotiationFailed(
+                                "delayed-offer ACK has no generated SDP answer".to_string(),
+                            ));
+                        // A 2xx INVITE response must still be ACKed even when
+                        // its offer cannot be answered. Stop retransmissions,
+                        // preserve stable negotiation state, and surface the
+                        // explicit failure after the write completes.
+                        dialog_adapter
+                            .send_invite_2xx_ack_exact(
+                                exact_request_tracker_handle(session)?,
+                                &ack.transaction_id,
+                                &ack.response,
+                            )
+                            .await
+                    }
                 } else {
                     dialog_adapter
                         .send_invite_2xx_ack_exact(
@@ -2252,13 +2403,49 @@ pub(crate) async fn execute_action(
                             &ack.transaction_id,
                             &ack.response,
                         )
-                        .await?;
+                        .await
+                };
+                if let Err(ack_error) = ack_result {
+                    if let Some(prepared) = prepared_media.take() {
+                        if let Err(rollback_error) = media_adapter
+                            .rollback_prepared_media_negotiation_lane_owned(session, prepared)
+                            .await
+                        {
+                            return Err(crate::errors::SessionError::MediaError(format!(
+                                "INVITE 2xx ACK write failed and prepared media rollback failed: {rollback_error}"
+                            ))
+                            .into());
+                        }
+                    }
+                    return Err(ack_error.into());
                 }
+            }
+            if let Some(prepared) = prepared_media.take() {
+                media_adapter
+                    .finalize_prepared_media_negotiation_lane_owned(session, prepared)
+                    .await?;
+            } else if invite_2xx_ack.is_none()
+                && session.pending_offer_answer.is_none()
+                && media_adapter.has_staged_media_negotiation(session)
+            {
+                media_adapter
+                    .commit_staged_media_negotiation_lane_owned(session)
+                    .await?;
+            }
+            if let Some(error) = ack_negotiation_error {
+                media_adapter.discard_pending_srtp_offer_for_session(session);
+                media_adapter.discard_staged_media_negotiation_for_session(session);
+                return Err(error.into());
+            }
+            if let Some(error) = media_preparation_error {
+                media_adapter.discard_pending_srtp_offer_for_session(session);
+                media_adapter.discard_staged_media_negotiation_for_session(session);
+                return Err(error.into());
             }
             session.dialog_established = true;
             info!(
-                "SendACK action completed for UAC session {}",
-                session.session_id
+                delayed_offer,
+                "SendACK action completed for UAC session {}", session.session_id
             );
         }
         Action::SendBYE => {
@@ -2331,7 +2518,7 @@ pub(crate) async fn execute_action(
             )
             .await
             {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 session.pending_reinvite = None;
                 return Err(error.into());
             }
@@ -2354,7 +2541,7 @@ pub(crate) async fn execute_action(
             )
             .await
             {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 session.pending_reinvite = None;
                 return Err(error.into());
             }
@@ -2670,7 +2857,7 @@ pub(crate) async fn execute_action(
             )
             .await
             {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 session.pending_reinvite = None;
                 return Err(error.into());
             }
@@ -4482,7 +4669,7 @@ pub(crate) async fn execute_action(
             ) {
                 Ok(lease) => lease,
                 Err(error) => {
-                    rollback_reinvite_local_sdp(session);
+                    rollback_reinvite_with_media(session, media_adapter);
                     return Err(error.into());
                 }
             };
@@ -4492,26 +4679,26 @@ pub(crate) async fn execute_action(
             {
                 Ok(transaction_id) => transaction_id,
                 Err(_) if options.session_timer_refresh => {
-                    rollback_reinvite_local_sdp(session);
+                    rollback_reinvite_with_media(session, media_adapter);
                     return Ok(session_refresh_immediate_effect(
                         session,
                         SessionRefreshDeadlineKind::UpdateFailed,
                     ));
                 }
                 Err(error) => {
-                    rollback_reinvite_local_sdp(session);
+                    rollback_reinvite_with_media(session, media_adapter);
                     return Err(error.into());
                 }
             };
             if let Err(error) = session.bind_offer_answer_transaction(transaction_id.clone()) {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 return Err(error.into());
             }
             if let Err(error) = dialog_adapter
                 .outbound_request_tracker
                 .activate(lease, transaction_id)
             {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 return Err(error.into());
             }
             if options.session_timer_refresh {
@@ -4554,7 +4741,7 @@ pub(crate) async fn execute_action(
             ) {
                 Ok(lease) => lease,
                 Err(error) => {
-                    rollback_reinvite_local_sdp(session);
+                    rollback_reinvite_with_media(session, media_adapter);
                     return Err(error.into());
                 }
             };
@@ -4571,7 +4758,7 @@ pub(crate) async fn execute_action(
             {
                 Ok(transaction_id) => transaction_id,
                 Err(_) if options.session_timer_refresh => {
-                    rollback_reinvite_local_sdp(session);
+                    rollback_reinvite_with_media(session, media_adapter);
                     session.pending_reinvite = None;
                     return Ok(session_refresh_immediate_effect(
                         session,
@@ -4579,13 +4766,13 @@ pub(crate) async fn execute_action(
                     ));
                 }
                 Err(error) => {
-                    rollback_reinvite_local_sdp(session);
+                    rollback_reinvite_with_media(session, media_adapter);
                     session.pending_reinvite = None;
                     return Err(error.into());
                 }
             };
             if let Err(error) = session.bind_offer_answer_transaction(transaction_id.clone()) {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 session.pending_reinvite = None;
                 return Err(error.into());
             }
@@ -4593,7 +4780,7 @@ pub(crate) async fn execute_action(
                 .outbound_request_tracker
                 .activate(lease, transaction_id)
             {
-                rollback_reinvite_local_sdp(session);
+                rollback_reinvite_with_media(session, media_adapter);
                 session.pending_reinvite = None;
                 return Err(error.into());
             }
@@ -5508,11 +5695,27 @@ mod lane_owned_action_state_tests {
 
         assert_eq!(
             production
-                .matches("release_lane_owned_resources(session, dialog_adapter, media_adapter)")
+                .matches("async fn release_lane_owned_resources(")
                 .count(),
-            2,
-            "ReleaseAllResources and CleanupResources must share one implementation"
+            1,
+            "resource cleanup must have exactly one implementation"
         );
+        for action in [
+            "Action::ReleaseAllResources =>",
+            "Action::CleanupResources =>",
+        ] {
+            let body = production
+                .split(action)
+                .nth(1)
+                .and_then(|tail| tail.split("\n        Action::").next())
+                .unwrap_or_else(|| panic!("missing {action}"));
+            assert!(
+                body.contains(
+                    "release_lane_owned_resources(session, dialog_adapter, media_adapter)"
+                ),
+                "{action} must delegate to the one cleanup implementation"
+            );
+        }
     }
 
     #[test]

--- a/crates/sip/rvoip-sip/src/state_machine/actions.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/actions.rs
@@ -2576,6 +2576,17 @@ pub(crate) async fn execute_action(
 
         // Media actions
         Action::StartMediaSession => {
+            // A received provisional answer (for example 183 early media) has
+            // no ACK boundary. Likewise, an offerless UAS completes the
+            // exchange when it receives the ACK answer. Commit either staged
+            // negotiation on this exact-session lane before exposing media as
+            // started. Ordinary final UAC answers have already crossed their
+            // wire boundary in SendACK, so this is a no-op for that path.
+            if media_adapter.has_staged_media_negotiation(session) {
+                media_adapter
+                    .commit_staged_media_negotiation_lane_owned(session)
+                    .await?;
+            }
             media_adapter.start_session(&session.session_id).await?;
             // Mark media as ready after successfully starting
             session.media_session_ready = true;
@@ -2612,6 +2623,17 @@ pub(crate) async fn execute_action(
             }
         }
         Action::NegotiateSDPAsUAC => {
+            if matches!(triggering_event, EventType::Dialog200OK)
+                && session.media_session_ready
+                && session.sdp_negotiated
+                && session.pending_offer_answer.is_none()
+            {
+                info!(
+                    "Action::NegotiateSDPAsUAC for session {}: final response confirms committed early-media answer",
+                    session.session_id
+                );
+                return Ok(ActionOutcome::default());
+            }
             if matches!(triggering_event, EventType::DialogACK) && session.sdp_negotiated {
                 info!(
                     "Action::NegotiateSDPAsUAC for session {}: ordinary ACK has no new offer/answer",

--- a/crates/sip/rvoip-sip/src/state_machine/actions.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/actions.rs
@@ -4,7 +4,8 @@ use crate::adapters::dialog_adapter::{
 use crate::adapters::outbound_request_tracker::{TrackedInDialogMethod, TrackedInDialogOptions};
 use crate::session_registry::SessionRegistryHandle;
 use crate::state_machine::executor::{
-    InboundResponseStateInput, PendingOptionsSlot, PendingOptionsSlotKind, StageDispatchClaim,
+    InboundResponseStateInput, Invite2xxAckStateInput, PendingOptionsSlot, PendingOptionsSlotKind,
+    StageDispatchClaim,
 };
 use crate::state_table::types::{EventType, SessionId};
 use rvoip_sip_core::types::{HeaderName, TypedHeader};
@@ -47,6 +48,28 @@ fn exact_request_tracker_handle(
             "outbound request tracking requires exact session authority".to_string(),
         )
     })
+}
+
+async fn send_tracked_reinvite_lane_owned(
+    session: &mut SessionState,
+    dialog_adapter: &Arc<DialogAdapter>,
+    options: ReInviteRequestOptions,
+) -> crate::errors::Result<rvoip_sip_dialog::transaction::TransactionKey> {
+    let tracked_options = Arc::new(options.clone());
+    let lease = dialog_adapter.outbound_request_tracker.prepare(
+        exact_request_tracker_handle(session)?,
+        TrackedInDialogOptions::Reinvite(tracked_options),
+    )?;
+    let transaction_id = dialog_adapter
+        .send_reinvite_with_options_lane_owned(session, options)
+        .await?;
+    // Bind before activation flushes any response/auth event that raced the
+    // transport write.
+    session.bind_offer_answer_transaction(transaction_id.clone())?;
+    dialog_adapter
+        .outbound_request_tracker
+        .activate(lease, transaction_id.clone())?;
+    Ok(transaction_id)
 }
 
 fn next_session_refresh_generation(session: &mut SessionState) -> u64 {
@@ -180,14 +203,34 @@ pub(crate) fn stage_reinvite_local_sdp(session: &mut SessionState, offer: String
     session.local_sdp = Some(offer);
 }
 
+fn begin_reinvite_offer(session: &mut SessionState, offer: String) -> crate::errors::Result<()> {
+    session.begin_offer_answer(rvoip_sip_core::Method::Invite, offer.clone())?;
+    stage_reinvite_local_sdp(session, offer);
+    Ok(())
+}
+
 fn commit_reinvite_local_sdp(session: &mut SessionState) {
+    session.commit_offer_answer();
     session.stable_local_sdp_before_reinvite = None;
 }
 
 fn rollback_reinvite_local_sdp(session: &mut SessionState) {
+    session.rollback_offer_answer();
     if let Some(stable) = session.stable_local_sdp_before_reinvite.take() {
         session.local_sdp = stable;
     }
+}
+
+fn initial_invite_used_delayed_offer(session: &SessionState, event: &EventType) -> bool {
+    matches!(event, EventType::Dialog200OK)
+        && session.role == crate::state_table::Role::UAC
+        && !session.dialog_established
+        && session.pending_offer_answer.is_none()
+        && session
+            .pending_invite_options
+            .as_ref()
+            .and_then(|options| options.sdp.as_deref())
+            .is_some_and(|sdp| sdp.trim().is_empty())
 }
 
 /// Retire every lifecycle attachment derived from one media allocation in the
@@ -1665,6 +1708,7 @@ pub(crate) async fn execute_action(
     _simple_peer_event_tx: &Option<tokio::sync::mpsc::Sender<Event>>, // Unused - events handled by SessionCrossCrateEventHandler
     stage_claim: Option<&StageDispatchClaim>,
     mut inbound_response: Option<&mut InboundResponseStateInput>,
+    invite_2xx_ack: Option<&Invite2xxAckStateInput>,
 ) -> Result<ActionOutcome, Box<dyn std::error::Error + Send + Sync>> {
     debug!("Executing action: {:?}", action);
 
@@ -2037,7 +2081,16 @@ pub(crate) async fn execute_action(
             }
         }
         Action::ClearPendingReinvite => {
-            rollback_reinvite_local_sdp(session);
+            match triggering_event {
+                EventType::Dialog200OK => commit_reinvite_local_sdp(session),
+                EventType::ReinviteReceived { .. } => {
+                    // A peer offer accepted during glare supersedes our local
+                    // pending offer. Preserve the newly negotiated answer.
+                    session.discard_offer_answer_rollback_image();
+                    session.stable_local_sdp_before_reinvite = None;
+                }
+                _ => rollback_reinvite_local_sdp(session),
+            }
             session.pending_reinvite = None;
             session.reinvite_retry_attempts = 0;
             debug!(
@@ -2177,12 +2230,34 @@ pub(crate) async fn execute_action(
             }
         }
         Action::SendACK => {
-            // NO-OP for SIP: dialog-core sends ACK automatically per RFC 3261
-            // However, we still set dialog_established = true here because for UAC,
-            // the dialog is considered established when ACK is sent
+            if let Some(ack) = invite_2xx_ack {
+                if initial_invite_used_delayed_offer(session, triggering_event) {
+                    let answer = session.local_sdp.as_deref().ok_or_else(|| {
+                        crate::errors::SessionError::SDPNegotiationFailed(
+                            "delayed-offer ACK has no generated SDP answer".to_string(),
+                        )
+                    })?;
+                    dialog_adapter
+                        .send_delayed_offer_ack_exact(
+                            exact_request_tracker_handle(session)?,
+                            &ack.transaction_id,
+                            &ack.response,
+                            answer,
+                        )
+                        .await?;
+                } else {
+                    dialog_adapter
+                        .send_invite_2xx_ack_exact(
+                            exact_request_tracker_handle(session)?,
+                            &ack.transaction_id,
+                            &ack.response,
+                        )
+                        .await?;
+                }
+            }
             session.dialog_established = true;
             info!(
-                "SendACK action: dialog-core handles ACK sending, dialog marked as established for UAC session {}",
+                "SendACK action completed for UAC session {}",
                 session.session_id
             );
         }
@@ -2244,17 +2319,22 @@ pub(crate) async fn execute_action(
                 .create_hold_sdp_for_session_lane_owned(session)
                 .await
                 .map_err(|e| format!("create_hold_sdp failed: {}", e))?;
-            stage_reinvite_local_sdp(session, hold_sdp.clone());
+            begin_reinvite_offer(session, hold_sdp.clone())?;
             session.pending_reinvite = Some(crate::session_store::state::PendingReinvite::Hold);
-            dialog_adapter
-                .send_reinvite_with_options_lane_owned(
-                    session,
-                    ReInviteRequestOptions {
-                        sdp: Some(hold_sdp),
-                        ..Default::default()
-                    },
-                )
-                .await?;
+            if let Err(error) = send_tracked_reinvite_lane_owned(
+                session,
+                dialog_adapter,
+                ReInviteRequestOptions {
+                    sdp: Some(hold_sdp),
+                    ..Default::default()
+                },
+            )
+            .await
+            {
+                rollback_reinvite_local_sdp(session);
+                session.pending_reinvite = None;
+                return Err(error.into());
+            }
         }
         Action::ResumeCall => {
             // Send re-INVITE with sendrecv SDP.
@@ -2262,17 +2342,22 @@ pub(crate) async fn execute_action(
                 .create_active_sdp_for_session_lane_owned(session)
                 .await
                 .map_err(|e| format!("create_active_sdp failed: {}", e))?;
-            stage_reinvite_local_sdp(session, active_sdp.clone());
+            begin_reinvite_offer(session, active_sdp.clone())?;
             session.pending_reinvite = Some(crate::session_store::state::PendingReinvite::Resume);
-            dialog_adapter
-                .send_reinvite_with_options_lane_owned(
-                    session,
-                    ReInviteRequestOptions {
-                        sdp: Some(active_sdp),
-                        ..Default::default()
-                    },
-                )
-                .await?;
+            if let Err(error) = send_tracked_reinvite_lane_owned(
+                session,
+                dialog_adapter,
+                ReInviteRequestOptions {
+                    sdp: Some(active_sdp),
+                    ..Default::default()
+                },
+            )
+            .await
+            {
+                rollback_reinvite_local_sdp(session);
+                session.pending_reinvite = None;
+                return Err(error.into());
+            }
         }
         Action::TransferCall(target) => {
             session.transfer_target = Some(target.clone());
@@ -2340,33 +2425,63 @@ pub(crate) async fn execute_action(
             }
         }
         Action::NegotiateSDPAsUAC => {
-            if let Some(remote_sdp) = session.remote_sdp.clone() {
+            if matches!(triggering_event, EventType::DialogACK) && session.sdp_negotiated {
+                info!(
+                    "Action::NegotiateSDPAsUAC for session {}: ordinary ACK has no new offer/answer",
+                    session.session_id
+                );
+                return Ok(ActionOutcome::default());
+            }
+            let remote_sdp = session.remote_sdp.clone().ok_or_else(|| {
+                crate::errors::SessionError::SDPNegotiationFailed(
+                    "received a successful offer/answer response without SDP".to_string(),
+                )
+            })?;
+            let delayed_offer = initial_invite_used_delayed_offer(session, triggering_event);
+            let (local_answer, config) = if delayed_offer {
+                let (answer, config) = media_adapter
+                    .negotiate_sdp_as_uas_lane_owned(session, &remote_sdp)
+                    .await?;
+                (Some(answer), config)
+            } else {
                 let config = media_adapter
                     .negotiate_sdp_as_uac_lane_owned(session, &remote_sdp)
                     .await?;
+                (None, config)
+            };
 
-                // Convert to session_store NegotiatedConfig
-                let session_config = crate::session_store::state::NegotiatedConfig {
-                    local_addr: config.local_addr,
-                    remote_addr: config.remote_addr,
-                    codec: config.codec,
-                    payload_type: config.payload_type,
-                    sample_rate: config.clock_rate,
-                    channels: config.channels,
-                };
-                session.negotiated_config = Some(session_config);
-                session.local_media_direction = config.local_direction;
-                session.remote_media_direction = config.remote_direction;
-                session.sdp_negotiated = true;
-                commit_reinvite_local_sdp(session);
-                info!("SDP negotiated as UAC for session {}", session.session_id);
+            // Convert to session_store NegotiatedConfig
+            let session_config = crate::session_store::state::NegotiatedConfig {
+                local_addr: config.local_addr,
+                remote_addr: config.remote_addr,
+                codec: config.codec,
+                payload_type: config.payload_type,
+                sample_rate: config.clock_rate,
+                channels: config.channels,
+            };
+            session.negotiated_config = Some(session_config);
+            session.local_media_direction = config.local_direction;
+            session.remote_media_direction = config.remote_direction;
+            session.sdp_negotiated = true;
+            if let Some(local_answer) = local_answer {
+                session.local_sdp = Some(local_answer);
             }
+            commit_reinvite_local_sdp(session);
+            info!("SDP negotiated as UAC for session {}", session.session_id);
         }
         Action::NegotiateSDPAsUAS => {
             let guard = cleanup_diag::stage_guard(
                 CleanupStage::ActionNegotiateSdpUas,
                 &session.session_id.0,
             );
+            if matches!(triggering_event, EventType::UpdateReceived { sdp: None }) {
+                info!(
+                    "Action::NegotiateSDPAsUAS for session {}: SDP-less UPDATE refresh",
+                    session.session_id
+                );
+                guard.finish_success();
+                return Ok(ActionOutcome::default());
+            }
             // Skip negotiation when caller supplied the answer SDP ahead of
             // time via `accept_call_with_sdp`. Same reasoning as
             // `GenerateLocalSDP` above.
@@ -2536,7 +2651,7 @@ pub(crate) async fn execute_action(
                     .await
                     .map_err(|e| format!("create_active_sdp failed: {}", e))?
             };
-            stage_reinvite_local_sdp(session, sdp.clone());
+            begin_reinvite_offer(session, sdp.clone())?;
             session.pending_reinvite = Some(kind);
             // A 491/ReinviteGlare response is queued on the same exact-session
             // lane. It observes this SDP and retry intent only after the
@@ -2545,15 +2660,20 @@ pub(crate) async fn execute_action(
                 "Sending re-INVITE for session {} (hold={})",
                 session.session_id, hold_direction
             );
-            dialog_adapter
-                .send_reinvite_with_options_lane_owned(
-                    session,
-                    ReInviteRequestOptions {
-                        sdp: Some(sdp),
-                        ..Default::default()
-                    },
-                )
-                .await?;
+            if let Err(error) = send_tracked_reinvite_lane_owned(
+                session,
+                dialog_adapter,
+                ReInviteRequestOptions {
+                    sdp: Some(sdp),
+                    ..Default::default()
+                },
+            )
+            .await
+            {
+                rollback_reinvite_local_sdp(session);
+                session.pending_reinvite = None;
+                return Err(error.into());
+            }
         }
 
         Action::PlayAudioFile(file) => {
@@ -4340,26 +4460,60 @@ pub(crate) async fn execute_action(
                 )
                 .into());
             };
-            let lease = dialog_adapter.outbound_request_tracker.prepare(
+            let snapshot = (*options).clone();
+            let local_offer = match snapshot.sdp.as_ref() {
+                Some(sdp) if sdp.trim().is_empty() => {
+                    return Err(crate::errors::SessionError::InvalidTransition(
+                        "an SDP-bearing UPDATE requires a non-empty local offer".to_string(),
+                    )
+                    .into());
+                }
+                Some(sdp) => Some(sdp.clone()),
+                None => None,
+            };
+            if let Some(local_offer) = local_offer.as_ref() {
+                media_adapter.validate_local_sdp_offer(local_offer)?;
+                session.begin_offer_answer(rvoip_sip_core::Method::Update, local_offer.clone())?;
+                stage_reinvite_local_sdp(session, local_offer.clone());
+            }
+            let lease = match dialog_adapter.outbound_request_tracker.prepare(
                 exact_request_tracker_handle(session)?,
                 TrackedInDialogOptions::Update(Arc::clone(&options)),
-            )?;
+            ) {
+                Ok(lease) => lease,
+                Err(error) => {
+                    rollback_reinvite_local_sdp(session);
+                    return Err(error.into());
+                }
+            };
             let transaction_id = match dialog_adapter
-                .send_update_with_options_lane_owned(session, (*options).clone())
+                .send_update_with_options_lane_owned(session, snapshot)
                 .await
             {
                 Ok(transaction_id) => transaction_id,
                 Err(_) if options.session_timer_refresh => {
+                    rollback_reinvite_local_sdp(session);
                     return Ok(session_refresh_immediate_effect(
                         session,
                         SessionRefreshDeadlineKind::UpdateFailed,
                     ));
                 }
-                Err(error) => return Err(error.into()),
+                Err(error) => {
+                    rollback_reinvite_local_sdp(session);
+                    return Err(error.into());
+                }
             };
-            dialog_adapter
+            if let Err(error) = session.bind_offer_answer_transaction(transaction_id.clone()) {
+                rollback_reinvite_local_sdp(session);
+                return Err(error.into());
+            }
+            if let Err(error) = dialog_adapter
                 .outbound_request_tracker
-                .activate(lease, transaction_id)?;
+                .activate(lease, transaction_id)
+            {
+                rollback_reinvite_local_sdp(session);
+                return Err(error.into());
+            }
             if options.session_timer_refresh {
                 return Ok(session_refresh_transaction_deadline_effect(
                     session,
@@ -4382,33 +4536,67 @@ pub(crate) async fn execute_action(
                 )
                 .into());
             };
-            let lease = dialog_adapter.outbound_request_tracker.prepare(
+            let snapshot = (*options).clone();
+            let local_offer = snapshot.sdp.clone().filter(|sdp| !sdp.trim().is_empty());
+            if local_offer.is_none() && !snapshot.session_timer_refresh {
+                return Err(crate::errors::SessionError::InvalidTransition(
+                    "offerless in-dialog re-INVITE is unsupported; supply an SDP offer".to_string(),
+                )
+                .into());
+            }
+            if let Some(local_offer) = local_offer.as_ref() {
+                media_adapter.validate_local_sdp_offer(local_offer)?;
+                begin_reinvite_offer(session, local_offer.clone())?;
+            }
+            let lease = match dialog_adapter.outbound_request_tracker.prepare(
                 exact_request_tracker_handle(session)?,
                 TrackedInDialogOptions::Reinvite(Arc::clone(&options)),
-            )?;
-            let snapshot = (*options).clone();
+            ) {
+                Ok(lease) => lease,
+                Err(error) => {
+                    rollback_reinvite_local_sdp(session);
+                    return Err(error.into());
+                }
+            };
             // RFC 3261 §14.1 — track the in-flight builder-API
             // re-INVITE so `HasPendingReinvite` fires the UAS-side glare path.
-            let sdp_snapshot = snapshot.sdp.clone().unwrap_or_default();
-            session.pending_reinvite = Some(
-                crate::session_store::state::PendingReinvite::SdpUpdate(sdp_snapshot),
-            );
+            if let Some(local_offer) = local_offer {
+                session.pending_reinvite = Some(
+                    crate::session_store::state::PendingReinvite::SdpUpdate(local_offer),
+                );
+            }
             let transaction_id = match dialog_adapter
                 .send_reinvite_with_options_lane_owned(session, snapshot)
                 .await
             {
                 Ok(transaction_id) => transaction_id,
                 Err(_) if options.session_timer_refresh => {
+                    rollback_reinvite_local_sdp(session);
+                    session.pending_reinvite = None;
                     return Ok(session_refresh_immediate_effect(
                         session,
                         SessionRefreshDeadlineKind::ReinviteFailed,
                     ));
                 }
-                Err(error) => return Err(error.into()),
+                Err(error) => {
+                    rollback_reinvite_local_sdp(session);
+                    session.pending_reinvite = None;
+                    return Err(error.into());
+                }
             };
-            dialog_adapter
+            if let Err(error) = session.bind_offer_answer_transaction(transaction_id.clone()) {
+                rollback_reinvite_local_sdp(session);
+                session.pending_reinvite = None;
+                return Err(error.into());
+            }
+            if let Err(error) = dialog_adapter
                 .outbound_request_tracker
-                .activate(lease, transaction_id)?;
+                .activate(lease, transaction_id)
+            {
+                rollback_reinvite_local_sdp(session);
+                session.pending_reinvite = None;
+                return Err(error.into());
+            }
             if options.session_timer_refresh {
                 return Ok(session_refresh_transaction_deadline_effect(
                     session,

--- a/crates/sip/rvoip-sip/src/state_machine/executor.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/executor.rs
@@ -538,6 +538,11 @@ struct EventStateInput {
     /// `None` with this bit set means the response/request carried no SDP;
     /// without the bit, the stable remote description is left untouched.
     remote_sdp_supplied: bool,
+    /// A final response after committed 183 early media confirms the existing
+    /// offer/answer exchange; it is not a second answer. Preserve the stable
+    /// provisional description instead of replacing it with an optional copy
+    /// from the final response.
+    preserve_committed_provisional_sdp: bool,
     local_sdp: Option<String>,
     sdp_negotiated: Option<bool>,
     response: Option<ResponseStateInput>,
@@ -872,7 +877,12 @@ impl AuthRequiredStateInput {
 
 impl EventStateInput {
     fn apply(self, session: &mut SessionState) {
-        if self.remote_sdp_supplied {
+        let committed_provisional_answer = self.preserve_committed_provisional_sdp
+            && session.call_state == CallState::EarlyMedia
+            && session.sdp_negotiated
+            && session.media_session_ready
+            && session.pending_offer_answer.is_none();
+        if self.remote_sdp_supplied && !committed_provisional_answer {
             session.remote_sdp = self.remote_sdp;
         }
         if let Some(local_sdp) = self.local_sdp {
@@ -2691,12 +2701,14 @@ impl StateMachine {
         event: EventType,
         remote_sdp: Option<String>,
     ) -> Result<ProcessEventResult, Box<dyn std::error::Error + Send + Sync>> {
+        let preserve_committed_provisional_sdp = matches!(event, EventType::Dialog200OK);
         self.process_event_with_state_input_exact(
             handle,
             event,
             EventStateInput {
                 remote_sdp,
                 remote_sdp_supplied: true,
+                preserve_committed_provisional_sdp,
                 ..Default::default()
             },
         )
@@ -2715,6 +2727,7 @@ impl StateMachine {
             EventStateInput {
                 remote_sdp,
                 remote_sdp_supplied: true,
+                preserve_committed_provisional_sdp: true,
                 invite_2xx_ack: Some(ack),
                 ..Default::default()
             },
@@ -5919,6 +5932,7 @@ mod tests {
         EventStateInput {
             remote_sdp: Some("remote-sdp".to_string()),
             remote_sdp_supplied: true,
+            preserve_committed_provisional_sdp: false,
             local_sdp: Some("local-sdp".to_string()),
             sdp_negotiated: Some(true),
             response: Some(ResponseStateInput::provisional(181, Vec::new())),
@@ -5982,6 +5996,26 @@ mod tests {
             .pending_auth_transport
             .as_ref()
             .is_some_and(|transport| transport.secure));
+    }
+
+    #[test]
+    fn final_invite_response_preserves_the_committed_provisional_answer() {
+        let session_id = SessionId("committed-provisional-answer".to_string());
+        let mut session = SessionState::new(session_id, crate::state_table::Role::UAC);
+        session.call_state = CallState::EarlyMedia;
+        session.remote_sdp = Some("stable-183-answer".to_string());
+        session.sdp_negotiated = true;
+        session.media_session_ready = true;
+
+        EventStateInput {
+            remote_sdp: Some("untrusted-final-copy".to_string()),
+            remote_sdp_supplied: true,
+            preserve_committed_provisional_sdp: true,
+            ..Default::default()
+        }
+        .apply(&mut session);
+
+        assert_eq!(session.remote_sdp.as_deref(), Some("stable-183-answer"));
     }
 
     #[test]

--- a/crates/sip/rvoip-sip/src/state_machine/executor.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/executor.rs
@@ -534,6 +534,10 @@ impl SessionRefreshStateInput {
 #[derive(Default)]
 struct EventStateInput {
     remote_sdp: Option<String>,
+    /// Whether this event authoritatively supplied the remote SDP field.
+    /// `None` with this bit set means the response/request carried no SDP;
+    /// without the bit, the stable remote description is left untouched.
+    remote_sdp_supplied: bool,
     local_sdp: Option<String>,
     sdp_negotiated: Option<bool>,
     response: Option<ResponseStateInput>,
@@ -544,6 +548,41 @@ struct EventStateInput {
     auth_required: Option<AuthRequiredStateInput>,
     session_refresh: Option<SessionRefreshStateInput>,
     inbound_response: Option<InboundResponseStateInput>,
+    invite_2xx_ack: Option<Invite2xxAckStateInput>,
+}
+
+/// Exact successful INVITE response retained until the ordered `SendACK`
+/// action has completed SDP work and written the ACK.
+pub(crate) struct Invite2xxAckStateInput {
+    pub(crate) transaction_id: rvoip_sip_dialog::transaction::TransactionKey,
+    pub(crate) response: rvoip_sip_core::Response,
+}
+
+impl Invite2xxAckStateInput {
+    pub(crate) fn new(
+        transaction_id: rvoip_sip_dialog::transaction::TransactionKey,
+        response: rvoip_sip_core::Response,
+    ) -> Self {
+        Self {
+            transaction_id,
+            response,
+        }
+    }
+
+    fn validate_event(&self, event: &EventType) -> crate::errors::Result<()> {
+        if !matches!(event, EventType::Dialog200OK)
+            || self.transaction_id.is_server()
+            || self.transaction_id.method() != &rvoip_sip_core::Method::Invite
+            || !self.response.status().is_success()
+            || rvoip_sip_dialog::transaction::TransactionKey::from_response(&self.response).as_ref()
+                != Some(&self.transaction_id)
+        {
+            return Err(crate::errors::SessionError::InvalidTransition(
+                "deferred INVITE 2xx ACK requires the exact successful response".to_string(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Event-local authority for a response to one inbound INVITE or UPDATE.
@@ -833,8 +872,8 @@ impl AuthRequiredStateInput {
 
 impl EventStateInput {
     fn apply(self, session: &mut SessionState) {
-        if let Some(remote_sdp) = self.remote_sdp {
-            session.remote_sdp = Some(remote_sdp);
+        if self.remote_sdp_supplied {
+            session.remote_sdp = self.remote_sdp;
         }
         if let Some(local_sdp) = self.local_sdp {
             session.local_sdp = Some(local_sdp);
@@ -1982,21 +2021,112 @@ impl StateMachine {
                                             return Err(error);
                                         }
                                     };
+                                    session.replace_pending_local_offer(sdp.clone());
                                     actions::stage_reinvite_local_sdp(&mut session, sdp.clone());
                                     let committed = commit_lane_state(&dispatch_store, session)
                                         .map_err(|error| error.to_string())?;
+                                    let options = Arc::new(
+                                        rvoip_sip_dialog::api::unified::ReInviteRequestOptions {
+                                            sdp: Some(sdp),
+                                            ..Default::default()
+                                        },
+                                    );
+                                    let lease = match dialog_adapter
+                                        .outbound_request_tracker
+                                        .prepare(
+                                            &dispatch_handle,
+                                            crate::adapters::outbound_request_tracker::TrackedInDialogOptions::Reinvite(
+                                                Arc::clone(&options),
+                                            ),
+                                        )
+                                    {
+                                        Ok(lease) => lease,
+                                        Err(error) => {
+                                            let mut rollback = committed.state().clone();
+                                            rollback.rollback_offer_answer();
+                                            rollback.pending_reinvite = None;
+                                            rollback.reinvite_retry_attempts = 0;
+                                            media_adapter.discard_pending_srtp_offer(
+                                                &rollback.session_id,
+                                            );
+                                            commit_lane_state(&dispatch_store, rollback)
+                                                .map_err(|commit| commit.to_string())?;
+                                            return Err(error.to_string());
+                                        }
+                                    };
 
-                                    dialog_adapter
+                                    let transaction_id = match dialog_adapter
                                         .send_reinvite_with_options_lane_owned(
                                             committed.state(),
-                                            rvoip_sip_dialog::api::unified::ReInviteRequestOptions {
-                                                sdp: Some(sdp),
-                                                ..Default::default()
-                                            },
+                                            (*options).clone(),
                                         )
                                         .await
-                                        .map(|_| ())
-                                        .map_err(|error| error.to_string())
+                                    {
+                                        Ok(transaction_id) => transaction_id,
+                                        Err(error) => {
+                                            let current = dispatch_store
+                                                .get_session_snapshot_exact(&dispatch_handle)
+                                                .map_err(|lookup| lookup.to_string())?;
+                                            let mut rollback = current.state().clone();
+                                            rollback.rollback_offer_answer();
+                                            rollback.pending_reinvite = None;
+                                            rollback.reinvite_retry_attempts = 0;
+                                            media_adapter.discard_pending_srtp_offer(
+                                                &rollback.session_id,
+                                            );
+                                            commit_lane_state(&dispatch_store, rollback)
+                                                .map_err(|commit| commit.to_string())?;
+                                            return Err(error.to_string());
+                                        }
+                                    };
+
+                                    // A 491 retry has a fresh client branch;
+                                    // correlate the pending answer with this
+                                    // transaction before publishing tracker state.
+                                    let current = dispatch_store
+                                        .get_session_snapshot_exact(&dispatch_handle)
+                                        .map_err(|error| error.to_string())?;
+                                    let mut session = current.state().clone();
+                                    if !reinvite_retry_matches(&session, &kind, attempt) {
+                                        return Err(
+                                            "re-INVITE retry completed after its intent was superseded"
+                                                .to_string(),
+                                        );
+                                    }
+                                    if let Err(error) = session
+                                        .bind_offer_answer_transaction(transaction_id.clone())
+                                    {
+                                        session.rollback_offer_answer();
+                                        session.pending_reinvite = None;
+                                        session.reinvite_retry_attempts = 0;
+                                        media_adapter.discard_pending_srtp_offer(
+                                            &session.session_id,
+                                        );
+                                        commit_lane_state(&dispatch_store, session)
+                                            .map_err(|commit| commit.to_string())?;
+                                        return Err(error.to_string());
+                                    }
+                                    commit_lane_state(&dispatch_store, session)
+                                        .map_err(|error| error.to_string())?;
+                                    if let Err(error) = dialog_adapter
+                                        .outbound_request_tracker
+                                        .activate(lease, transaction_id)
+                                    {
+                                        let current = dispatch_store
+                                            .get_session_snapshot_exact(&dispatch_handle)
+                                            .map_err(|lookup| lookup.to_string())?;
+                                        let mut rollback = current.state().clone();
+                                        rollback.rollback_offer_answer();
+                                        rollback.pending_reinvite = None;
+                                        rollback.reinvite_retry_attempts = 0;
+                                        media_adapter.discard_pending_srtp_offer(
+                                            &rollback.session_id,
+                                        );
+                                        commit_lane_state(&dispatch_store, rollback)
+                                            .map_err(|commit| commit.to_string())?;
+                                        return Err(error.to_string());
+                                    }
+                                    Ok(())
                                 },
                             )
                         },
@@ -2562,6 +2692,26 @@ impl StateMachine {
             event,
             EventStateInput {
                 remote_sdp,
+                remote_sdp_supplied: true,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn process_invite_2xx_answer_exact(
+        &self,
+        handle: &SessionRegistryHandle,
+        remote_sdp: Option<String>,
+        ack: Invite2xxAckStateInput,
+    ) -> Result<ProcessEventResult, Box<dyn std::error::Error + Send + Sync>> {
+        self.process_event_with_state_input_exact(
+            handle,
+            EventType::Dialog200OK,
+            EventStateInput {
+                remote_sdp,
+                remote_sdp_supplied: true,
+                invite_2xx_ack: Some(ack),
                 ..Default::default()
             },
         )
@@ -2849,6 +2999,7 @@ impl StateMachine {
         let mut session = pre_event_snapshot.state().clone();
         let mut refer_notify_input = None;
         let mut inbound_response_input = None;
+        let mut invite_2xx_ack_input = None;
         let mut response_input_active = false;
         let reserved_session_refresh_event = matches!(
             &event,
@@ -2868,8 +3019,12 @@ impl StateMachine {
         if let Some(mut input) = state_input {
             refer_notify_input = input.refer_notify.take();
             inbound_response_input = input.inbound_response.take();
+            invite_2xx_ack_input = input.invite_2xx_ack.take();
             if let Some(inbound_response) = inbound_response_input.as_ref() {
                 inbound_response.validate_event(&event)?;
+            }
+            if let Some(ack) = invite_2xx_ack_input.as_ref() {
+                ack.validate_event(&event)?;
             }
             response_input_active = input.response.is_some();
             input.apply(&mut session);
@@ -2963,7 +3118,8 @@ impl StateMachine {
                 // machine's HoldPending/Resuming rows handle the
                 // hold/resume flavours via state alone.
                 if session.call_state == crate::types::CallState::Active
-                    && session.pending_reinvite.is_some()
+                    && (session.pending_reinvite.is_some()
+                        || session.pending_offer_answer.is_some())
                 {
                     info!(
                         "RFC 3261 §14.1 UAS-side glare: peer re-INVITE arrived while \
@@ -3003,6 +3159,27 @@ impl StateMachine {
             EventType::UpdateReceived {
                 sdp: Some(sdp_data),
             } => {
+                if session.pending_offer_answer.is_some() {
+                    let terminal = actions::send_exact_inbound_final_response(
+                        &session.session_id,
+                        inbound_response_input.as_mut(),
+                        &self.dialog_adapter,
+                        491,
+                        None,
+                        None,
+                    )
+                    .await?;
+                    if let Some(error) = terminal.terminal_error {
+                        return Err(error);
+                    }
+                    return Ok(ProcessEventResult {
+                        old_state,
+                        next_state: None,
+                        transition: None,
+                        actions_executed: vec![],
+                        events_published: vec![],
+                    });
+                }
                 // RFC 4028 UPDATE for session-timer refresh carries no SDP,
                 // but if a peer sends an UPDATE body (RFC 3311 session
                 // modification), record it so a future transition with
@@ -3198,6 +3375,7 @@ impl StateMachine {
                 &None, // No SimplePeer event channel - handled by SessionCrossCrateEventHandler
                 stage_claim.map(Arc::as_ref),
                 inbound_response_input.as_mut(),
+                invite_2xx_ack_input.as_ref(),
             ))
             .await;
             let action_duration = action_start.elapsed().as_millis() as u64;
@@ -5736,6 +5914,7 @@ mod tests {
 
         EventStateInput {
             remote_sdp: Some("remote-sdp".to_string()),
+            remote_sdp_supplied: true,
             local_sdp: Some("local-sdp".to_string()),
             sdp_negotiated: Some(true),
             response: Some(ResponseStateInput::provisional(181, Vec::new())),
@@ -5750,6 +5929,7 @@ mod tests {
             refer_notify: None,
             session_refresh: None,
             inbound_response: None,
+            invite_2xx_ack: None,
             auth_required: Some(AuthRequiredStateInput::new(
                 Some(
                     rvoip_infra_common::events::cross_crate::SipTransportContext::new(

--- a/crates/sip/rvoip-sip/src/state_machine/executor.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/executor.rs
@@ -2046,9 +2046,10 @@ impl StateMachine {
                                             rollback.rollback_offer_answer();
                                             rollback.pending_reinvite = None;
                                             rollback.reinvite_retry_attempts = 0;
-                                            media_adapter.discard_pending_srtp_offer(
-                                                &rollback.session_id,
-                                            );
+                                            media_adapter
+                                                .discard_pending_srtp_offer_for_session(&rollback);
+                                            media_adapter
+                                                .discard_staged_media_negotiation_for_session(&rollback);
                                             commit_lane_state(&dispatch_store, rollback)
                                                 .map_err(|commit| commit.to_string())?;
                                             return Err(error.to_string());
@@ -2071,9 +2072,10 @@ impl StateMachine {
                                             rollback.rollback_offer_answer();
                                             rollback.pending_reinvite = None;
                                             rollback.reinvite_retry_attempts = 0;
-                                            media_adapter.discard_pending_srtp_offer(
-                                                &rollback.session_id,
-                                            );
+                                            media_adapter
+                                                .discard_pending_srtp_offer_for_session(&rollback);
+                                            media_adapter
+                                                .discard_staged_media_negotiation_for_session(&rollback);
                                             commit_lane_state(&dispatch_store, rollback)
                                                 .map_err(|commit| commit.to_string())?;
                                             return Err(error.to_string());
@@ -2099,9 +2101,10 @@ impl StateMachine {
                                         session.rollback_offer_answer();
                                         session.pending_reinvite = None;
                                         session.reinvite_retry_attempts = 0;
-                                        media_adapter.discard_pending_srtp_offer(
-                                            &session.session_id,
-                                        );
+                                        media_adapter
+                                            .discard_pending_srtp_offer_for_session(&session);
+                                        media_adapter
+                                            .discard_staged_media_negotiation_for_session(&session);
                                         commit_lane_state(&dispatch_store, session)
                                             .map_err(|commit| commit.to_string())?;
                                         return Err(error.to_string());
@@ -2119,9 +2122,10 @@ impl StateMachine {
                                         rollback.rollback_offer_answer();
                                         rollback.pending_reinvite = None;
                                         rollback.reinvite_retry_attempts = 0;
-                                        media_adapter.discard_pending_srtp_offer(
-                                            &rollback.session_id,
-                                        );
+                                        media_adapter
+                                            .discard_pending_srtp_offer_for_session(&rollback);
+                                        media_adapter
+                                            .discard_staged_media_negotiation_for_session(&rollback);
                                         commit_lane_state(&dispatch_store, rollback)
                                             .map_err(|commit| commit.to_string())?;
                                         return Err(error.to_string());

--- a/crates/sip/rvoip-sip/src/state_machine/guards.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/guards.rs
@@ -18,6 +18,7 @@ pub async fn check_guard(guard: &Guard, session: &SessionState) -> bool {
         Guard::IsSubscribed => matches!(session.call_state, CallState::Subscribed),
         Guard::HasActiveSubscription => matches!(session.call_state, CallState::Subscribed),
         Guard::HasPendingReinvite => session.pending_reinvite.is_some(),
+        Guard::HasPendingOfferAnswer => session.pending_offer_answer.is_some(),
         Guard::Custom(name) => {
             // Custom guards can be implemented here
             tracing::warn!("Custom guard '{}' not implemented", name);

--- a/crates/sip/rvoip-sip/src/state_table/types.rs
+++ b/crates/sip/rvoip-sip/src/state_table/types.rs
@@ -278,6 +278,10 @@ pub enum EventType {
     DialogTimeout,
     DialogTerminated,
     DialogError(String),
+    /// A successful INVITE crossed its mandatory ACK/response boundary, but
+    /// SDP or lower-media application could not complete. The confirmed
+    /// dialog must terminate with BYE rather than a synthetic non-2xx result.
+    ConfirmedNegotiationFailure,
     DialogStateChanged {
         old_state: String,
         new_state: String,
@@ -560,6 +564,8 @@ pub enum Guard {
     /// Used by the RFC 3261 §14.1 glare path to send 491 Request Pending
     /// in response to a UAS-side re-INVITE while our own is pending.
     HasPendingReinvite,
+    /// True while an exact outbound INVITE or UPDATE offer awaits its answer.
+    HasPendingOfferAnswer,
     Custom(String),
 }
 

--- a/crates/sip/rvoip-sip/src/state_table/yaml_loader.rs
+++ b/crates/sip/rvoip-sip/src/state_table/yaml_loader.rs
@@ -783,6 +783,7 @@ impl YamlTableLoader {
             "DialogCANCEL" => Ok(EventType::DialogCANCEL),
             "DialogTimeout" => Ok(EventType::DialogTimeout),
             "DialogTerminated" => Ok(EventType::DialogTerminated),
+            "ConfirmedNegotiationFailure" => Ok(EventType::ConfirmedNegotiationFailure),
 
             // Gateway-specific BYE events
             "InboundBYE" | "OutboundBYE" => Ok(EventType::DialogBYE),
@@ -926,6 +927,7 @@ impl YamlTableLoader {
             "IsSubscribed" => Ok(Guard::IsSubscribed),
             "HasActiveSubscription" => Ok(Guard::HasActiveSubscription),
             "HasPendingReinvite" => Ok(Guard::HasPendingReinvite),
+            "HasPendingOfferAnswer" => Ok(Guard::HasPendingOfferAnswer),
             "OtherSessionActive" => Ok(Guard::Custom(name.to_string())),
             _ => {
                 debug!("Unknown guard '{}', treating as custom", name);
@@ -1459,6 +1461,10 @@ mod tests {
         VariantAllowance {
             variant: "HasActiveSubscription",
             owner: "runtime-yaml: supported guard for externally supplied tables",
+        },
+        VariantAllowance {
+            variant: "HasPendingReinvite",
+            owner: "direct: retained compatibility guard for builder-owned re-INVITE state",
         },
         VariantAllowance {
             variant: "Custom",

--- a/crates/sip/rvoip-sip/state_tables/default.yaml
+++ b/crates/sip/rvoip-sip/state_tables/default.yaml
@@ -373,6 +373,7 @@ transitions:
       type: "DialogACK"
     next_state: "Active"
     actions:
+      - type: "NegotiateSDPAsUAC"
       - type: "StartMediaSession"
       - type: "SwitchToPassThroughOnActive"
       - type: "ArmSessionRefreshTimer"
@@ -398,8 +399,84 @@ transitions:
       type: "DialogACK"
     next_state: "Terminating"
     actions:
+      - type: "NegotiateSDPAsUAC"
       - type: "SendBYE"
     description: "ACK received after pending UAS hangup; send BYE and defer cleanup until terminal confirmation"
+
+  # Once an INVITE 2xx has crossed the mandatory ACK boundary, a later SDP
+  # or media failure cannot be represented as a synthetic rejection. End the
+  # now-confirmed dialog with BYE and preserve the preceding stable snapshot.
+  - role: "Both"
+    state: "Initiating"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "Ringing"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "EarlyMedia"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "Answering"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "AnsweringHangupPending"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "Active"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "HoldPending"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
+
+  - role: "Both"
+    state: "Resuming"
+    event:
+      type: "ConfirmedNegotiationFailure"
+    next_state: "Terminating"
+    actions:
+      - type: "SendBYE"
 
   # Missing ACK after 200 OK fails the call attempt; BYE is not legal
   # because the dialog was never confirmed by the UAC.
@@ -998,11 +1075,13 @@ transitions:
       type: "Dialog200OK"
     next_state: "Active"
     guards:
-      - "HasPendingReinvite"
+      - "HasPendingOfferAnswer"
     actions:
+      - type: "NegotiateSDPAsUAC"
+      - type: "SendACK"
       - type: "ClearPendingReinvite"
       - type: "ArmSessionRefreshTimer"
-    description: "Clear in-flight builder-API re-INVITE tracker on 2xx (RFC 3261 §14.1)"
+    description: "Apply the answer and acknowledge an outbound builder-API re-INVITE before commit"
 
   - role: "Both"
     state: "Active"
@@ -1010,7 +1089,7 @@ transitions:
       type: "Dialog4xxFailure"
     next_state: "Active"
     guards:
-      - "HasPendingReinvite"
+      - "HasPendingOfferAnswer"
     actions:
       - type: "ClearPendingReinvite"
     description: "Clear in-flight builder-API re-INVITE tracker on 4xx (RFC 3261 §14.1)"
@@ -1021,7 +1100,7 @@ transitions:
       type: "Dialog5xxFailure"
     next_state: "Active"
     guards:
-      - "HasPendingReinvite"
+      - "HasPendingOfferAnswer"
     actions:
       - type: "ClearPendingReinvite"
     description: "Clear in-flight builder-API re-INVITE tracker on 5xx (RFC 3261 §14.1)"
@@ -1032,7 +1111,7 @@ transitions:
       type: "Dialog6xxFailure"
     next_state: "Active"
     guards:
-      - "HasPendingReinvite"
+      - "HasPendingOfferAnswer"
     actions:
       - type: "ClearPendingReinvite"
     description: "Clear in-flight builder-API re-INVITE tracker on 6xx (RFC 3261 §14.1)"
@@ -1043,22 +1122,74 @@ transitions:
       type: "DialogTimeout"
     next_state: "Active"
     guards:
-      - "HasPendingReinvite"
+      - "HasPendingOfferAnswer"
     actions:
       - type: "ClearPendingReinvite"
     description: "Clear in-flight builder-API re-INVITE tracker on Timer B (RFC 3261 §14.1)"
 
-  # RFC 3311 / RFC 4028 §9 — UPDATE for session-timer refresh carries no
-  # SDP, so we skip NegotiateSDPAsUAS. If a future UPDATE body is
-  # present for mid-dialog modification, the executor has already
-  # stashed it into session.remote_sdp; extending this transition to
-  # renegotiate is a future enhancement.
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "Dialog200OK"
+    next_state: "OnHold"
+    guards:
+      - "HasPendingOfferAnswer"
+    actions:
+      - type: "NegotiateSDPAsUAC"
+      - type: "SendACK"
+      - type: "ClearPendingReinvite"
+      - type: "ArmSessionRefreshTimer"
+    description: "Apply and commit an exact outbound UPDATE answer while locally held"
+
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "Dialog4xxFailure"
+    next_state: "OnHold"
+    guards:
+      - "HasPendingOfferAnswer"
+    actions:
+      - type: "ClearPendingReinvite"
+
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "Dialog5xxFailure"
+    next_state: "OnHold"
+    guards:
+      - "HasPendingOfferAnswer"
+    actions:
+      - type: "ClearPendingReinvite"
+
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "Dialog6xxFailure"
+    next_state: "OnHold"
+    guards:
+      - "HasPendingOfferAnswer"
+    actions:
+      - type: "ClearPendingReinvite"
+
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "DialogTimeout"
+    next_state: "OnHold"
+    guards:
+      - "HasPendingOfferAnswer"
+    actions:
+      - type: "ClearPendingReinvite"
+
+  # RFC 3311 / RFC 4028 §9 — negotiate SDP-bearing UPDATE before replying.
+  # NegotiateSDPAsUAS deliberately treats a bodyless timer refresh as a no-op.
   - role: "Both"
     state: "Active"
     event:
       type: "UpdateReceived"
     next_state: "Active"
     actions:
+      - type: "NegotiateSDPAsUAS"
       - type: "SendSIPResponse"
         code: 200
         reason: "OK"
@@ -1071,11 +1202,38 @@ transitions:
       type: "UpdateReceived"
     next_state: "OnHold"
     actions:
+      - type: "NegotiateSDPAsUAS"
       - type: "SendSIPResponse"
         code: 200
         reason: "OK"
       - type: "ArmSessionRefreshTimer"
     description: "UAS answers UPDATE while on hold"
+
+  - role: "Both"
+    state: "HoldPending"
+    event:
+      type: "UpdateReceived"
+    next_state: "HoldPending"
+    actions:
+      - type: "NegotiateSDPAsUAS"
+      - type: "SendSIPResponse"
+        code: 200
+        reason: "OK"
+      - type: "ArmSessionRefreshTimer"
+    description: "Accept bodyless refresh UPDATE while hold negotiation is pending"
+
+  - role: "Both"
+    state: "Resuming"
+    event:
+      type: "UpdateReceived"
+    next_state: "Resuming"
+    actions:
+      - type: "NegotiateSDPAsUAS"
+      - type: "SendSIPResponse"
+        code: 200
+        reason: "OK"
+      - type: "ArmSessionRefreshTimer"
+    description: "Accept bodyless refresh UPDATE while resume negotiation is pending"
 
   # RFC 4028 lifecycle authority. These reserved MediaEvent spellings are
   # admitted only with a crate-private exact-session sidecar; a public caller
@@ -2083,6 +2241,14 @@ transitions:
     actions:
       - type: "SendUPDATEWithOptions"
     description: "Builder-staged UPDATE dispatch (UAS)"
+
+  - role: "Both"
+    state: "OnHold"
+    event:
+      type: "SendOutboundUpdate"
+    actions:
+      - type: "SendUPDATEWithOptions"
+    description: "Builder-staged UPDATE dispatch while locally held"
 
   - role: "UAC"
     state: "Idle"

--- a/crates/sip/rvoip-sip/tests/auto_emit_headers.rs
+++ b/crates/sip/rvoip-sip/tests/auto_emit_headers.rs
@@ -73,6 +73,21 @@ async fn config_auto_emit_extra_headers_stamps_legacy_bye() {
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:bob@127.0.0.1:{bob_port}>").into_bytes()),
                     ));
+                    response.body = format!(
+                        "v=0\r\no=auto-emit 1 1 IN IP4 127.0.0.1\r\ns=-\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio {} RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n",
+                        bob_port + 1_000
+                    )
+                    .into_bytes()
+                    .into();
+                    response
+                        .headers
+                        .retain(|header| !matches!(header, TypedHeader::ContentLength(_)));
+                    response.headers.push(TypedHeader::ContentLength(
+                        rvoip_sip_core::types::ContentLength::new(response.body.len() as u32),
+                    ));
+                    response.headers.push(TypedHeader::ContentType(
+                        rvoip_sip_core::types::ContentType::sdp(),
+                    ));
                     uas.send_to(&Message::Response(response).to_bytes(), peer)
                         .await
                         .expect("send INVITE response");

--- a/crates/sip/rvoip-sip/tests/bye_auth_retry.rs
+++ b/crates/sip/rvoip-sip/tests/bye_auth_retry.rs
@@ -49,6 +49,25 @@ const CONTACT_USER: &str = "current-target";
 /// Per-BYE capture: application extra, auth, and exact request-line target.
 type ByeCapture = (bool, Option<String>, bool, String, Option<String>);
 
+fn attach_pcmu_sdp_answer(response: &mut Response, media_port: u16) {
+    response.body = format!(
+        "v=0\r\no=bye-auth 1 1 IN IP4 127.0.0.1\r\ns=-\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio {media_port} RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n"
+    )
+    .into_bytes()
+    .into();
+    response
+        .headers
+        .retain(|header| !matches!(header, TypedHeader::ContentLength(_)));
+    response
+        .headers
+        .push(TypedHeader::ContentLength(ContentLength::new(
+            response.body.len() as u32,
+        )));
+    response
+        .headers
+        .push(TypedHeader::ContentType(ContentType::sdp()));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn bye_extras_survive_401_driven_auth_retry() {
     let _ = tracing_subscriber::fmt()
@@ -101,6 +120,7 @@ async fn bye_extras_survive_401_driven_auth_retry() {
                             format!("<sip:{CONTACT_USER}@127.0.0.1:{UAS_PORT}>").into_bytes(),
                         ),
                     ));
+                    attach_pcmu_sdp_answer(&mut resp, UAS_PORT + 1_000);
                     let bytes = Message::Response(resp).to_bytes();
                     let _ = sock_task.send_to(&bytes, from).await;
                 }
@@ -309,6 +329,7 @@ async fn legacy_hangup_retries_bye_after_401_from_terminating() {
                             format!("<sip:legacy-target@127.0.0.1:{LEGACY_UAS_PORT}>").into_bytes(),
                         ),
                     ));
+                    attach_pcmu_sdp_answer(&mut response, LEGACY_UAS_PORT + 1_000);
                     let _ = sock_task
                         .send_to(&Message::Response(response).to_bytes(), from)
                         .await;

--- a/crates/sip/rvoip-sip/tests/fast_bye_cleanup.rs
+++ b/crates/sip/rvoip-sip/tests/fast_bye_cleanup.rs
@@ -4,6 +4,8 @@
 //! Cleanup is driven by the exact outbound-transaction completion, which
 //! commits the YAML terminal transition before one retained exact release.
 
+mod support;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,6 +21,8 @@ use rvoip_sip_dialog::transaction::utils::response_builders::create_response;
 use serial_test::serial;
 use tokio::net::UdpSocket;
 use tokio::sync::oneshot;
+
+use support::attach_pcmu_sdp_answer;
 
 const CALLER_PORT: u16 = 17_602;
 const CONCURRENT_CALLER_PORT: u16 = 17_603;
@@ -100,6 +104,7 @@ async fn fast_bye_200_keeps_hangup_successful_and_cleans_media_once() {
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:callee@127.0.0.1:{uas_port}>").into_bytes()),
                     ));
+                    attach_pcmu_sdp_answer(&mut response, uas_port + 1_000);
                     uas.send_to(&Message::Response(response).to_bytes(), peer)
                         .await
                         .expect("send INVITE 200");
@@ -299,6 +304,7 @@ async fn bye_481_after_peer_termination_is_graceful_and_cleans_exactly_once() {
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:callee@127.0.0.1:{uas_port}>").into_bytes()),
                     ));
+                    attach_pcmu_sdp_answer(&mut response, uas_port + 1_000);
                     uas.send_to(&Message::Response(response).to_bytes(), peer)
                         .await
                         .expect("send peer-terminated INVITE 200");
@@ -416,6 +422,7 @@ async fn cancelled_bye_builder_reclaims_wait_owner_and_transaction_receipt() {
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:callee@127.0.0.1:{uas_port}>").into_bytes()),
                     ));
+                    attach_pcmu_sdp_answer(&mut response, uas_port + 1_000);
                     uas.send_to(&Message::Response(response).to_bytes(), peer)
                         .await
                         .expect("send INVITE 200");
@@ -545,6 +552,7 @@ async fn delayed_non_2xx_bye_uses_timer_f_and_returns_only_after_exact_cleanup()
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:callee@127.0.0.1:{uas_port}>").into_bytes()),
                     ));
+                    attach_pcmu_sdp_answer(&mut response, uas_port + 1_000);
                     uas.send_to(&Message::Response(response).to_bytes(), peer)
                         .await
                         .expect("send delayed-failure INVITE 200");
@@ -687,6 +695,7 @@ async fn aborted_hangup_waiter_does_not_duplicate_exact_bye() {
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:callee@127.0.0.1:{uas_port}>").into_bytes()),
                     ));
+                    attach_pcmu_sdp_answer(&mut response, uas_port + 1_000);
                     uas.send_to(&Message::Response(response).to_bytes(), peer)
                         .await
                         .expect("send concurrent INVITE 200");

--- a/crates/sip/rvoip-sip/tests/fast_refer_cleanup.rs
+++ b/crates/sip/rvoip-sip/tests/fast_refer_cleanup.rs
@@ -1,6 +1,8 @@
 //! Regression for a peer that terminates the original dialog while a
 //! successful REFER dispatch is still unwinding.
 
+mod support;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,6 +18,8 @@ use rvoip_sip_dialog::transaction::utils::response_builders::create_response;
 use serial_test::serial;
 use tokio::net::UdpSocket;
 use tokio::sync::oneshot;
+
+use support::attach_pcmu_sdp_answer;
 
 const CALLER_PORT: u16 = 17_603;
 
@@ -60,6 +64,7 @@ async fn fast_remote_bye_keeps_successful_refer_dispatch_from_resurrecting_sessi
                                 format!("<sip:callee@127.0.0.1:{uas_port}>").into_bytes(),
                             ),
                         ));
+                        attach_pcmu_sdp_answer(&mut response, uas_port + 1_000);
                         uas.send_to(&Message::Response(response).to_bytes(), peer)
                             .await
                             .expect("send INVITE 200");

--- a/crates/sip/rvoip-sip/tests/info_auth_retry.rs
+++ b/crates/sip/rvoip-sip/tests/info_auth_retry.rs
@@ -6,6 +6,8 @@
 //! `Action::SendRequestWithAuth` routes correctly when
 //! `pending_auth_method = "INFO"`.
 
+mod support;
+
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +26,8 @@ use rvoip_sip_core::types::header::HeaderName;
 use rvoip_sip_core::types::headers::{HeaderAccess, HeaderValue};
 
 use rvoip_sip_dialog::transaction::utils::response_builders::create_response;
+
+use support::attach_pcmu_sdp_answer;
 
 const UAS_PORT: u16 = 35280;
 const UAC_PORT: u16 = 35281;
@@ -81,6 +85,7 @@ async fn info_extras_survive_401_driven_auth_retry() {
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:bob@127.0.0.1:{UAS_PORT}>").into_bytes()),
                     ));
+                    attach_pcmu_sdp_answer(&mut resp, UAS_PORT + 1_000);
                     let _ = sock_task
                         .send_to(&Message::Response(resp).to_bytes(), from)
                         .await;
@@ -254,6 +259,7 @@ async fn info_407_retry_uses_proxy_authorization() {
                             format!("<sip:bob@127.0.0.1:{PROXY_UAS_PORT}>").into_bytes(),
                         ),
                     ));
+                    attach_pcmu_sdp_answer(&mut resp, PROXY_UAS_PORT + 1_000);
                     let _ = sock_task
                         .send_to(&Message::Response(resp).to_bytes(), from)
                         .await;
@@ -406,6 +412,7 @@ async fn info_401_without_challenge_releases_exact_request_slot() {
                             format!("<sip:bob@127.0.0.1:{TERMINAL_UAS_PORT}>").into_bytes(),
                         ),
                     ));
+                    attach_pcmu_sdp_answer(&mut response, TERMINAL_UAS_PORT + 1_000);
                     Some(response)
                 }
                 Method::Ack => None,

--- a/crates/sip/rvoip-sip/tests/refer_auth_retry.rs
+++ b/crates/sip/rvoip-sip/tests/refer_auth_retry.rs
@@ -12,6 +12,8 @@
 //! 4. Both REFERs carry the same `Refer-To:` (method-shaped header
 //!    survives the retry via the stash).
 
+mod support;
+
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -30,6 +32,8 @@ use rvoip_sip_core::types::header::HeaderName;
 use rvoip_sip_core::types::headers::{HeaderAccess, HeaderValue};
 
 use rvoip_sip_dialog::transaction::utils::response_builders::create_response;
+
+use support::attach_pcmu_sdp_answer;
 
 const UAS_PORT: u16 = 35260;
 const UAC_PORT: u16 = 35261;
@@ -87,6 +91,7 @@ async fn refer_extras_survive_401_driven_auth_retry() {
                         HeaderName::Contact,
                         HeaderValue::Raw(format!("<sip:bob@127.0.0.1:{UAS_PORT}>").into_bytes()),
                     ));
+                    attach_pcmu_sdp_answer(&mut resp, UAS_PORT + 1_000);
                     let _ = sock_task
                         .send_to(&Message::Response(resp).to_bytes(), from)
                         .await;

--- a/crates/sip/rvoip-sip/tests/signaling_only_hold_resume.rs
+++ b/crates/sip/rvoip-sip/tests/signaling_only_hold_resume.rs
@@ -14,7 +14,7 @@ fn reserve_loopback_port() -> u16 {
 }
 
 async fn wait_for_state(call: &SessionHandle, expected: CallState) {
-    tokio::time::timeout(Duration::from_secs(8), async {
+    let wait = tokio::time::timeout(Duration::from_secs(8), async {
         loop {
             if matches!(call.state().await, Ok(state) if state == expected) {
                 break;
@@ -22,8 +22,13 @@ async fn wait_for_state(call: &SessionHandle, expected: CallState) {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
     })
-    .await
-    .unwrap_or_else(|_| panic!("call did not reach {expected:?}"));
+    .await;
+    if wait.is_err() {
+        panic!(
+            "call did not reach {expected:?}; last state: {:?}",
+            call.state().await
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/sip/rvoip-sip/tests/sip_api_design_2_section_10_skeletons.rs
+++ b/crates/sip/rvoip-sip/tests/sip_api_design_2_section_10_skeletons.rs
@@ -36,6 +36,14 @@ fn wire_header_values<'a>(raw_message: &'a str, expected_name: &str) -> Vec<&'a 
         .collect()
 }
 
+fn wire_body(raw_message: &str) -> &str {
+    raw_message
+        .split_once("\r\n\r\n")
+        .or_else(|| raw_message.split_once("\n\n"))
+        .map(|(_, body)| body)
+        .unwrap_or_default()
+}
+
 fn assert_verbatim_packet(trace: &rvoip_sip::SipTrace) {
     assert!(
         !trace.redacted,
@@ -135,6 +143,186 @@ async fn in_dialog_update_smoke() {
     call.teardown().await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sdp_update_offer_answer_commits_and_releases_its_exact_transaction() {
+    use std::time::Duration;
+
+    use rvoip_sip::api::events::Event;
+    use rvoip_sip::SessionError;
+
+    use support_for_section_10::establish_call;
+
+    const HOLD_OFFER: &str = "v=0\r\n\
+o=alice 700 1 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+c=IN IP4 127.0.0.1\r\n\
+t=0 0\r\n\
+m=audio 19000 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=sendonly\r\n";
+    const RESUME_OFFER: &str = "v=0\r\n\
+o=alice 700 2 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+c=IN IP4 127.0.0.1\r\n\
+t=0 0\r\n\
+m=audio 19000 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=sendrecv\r\n";
+
+    let mut call = establish_call(18920, 18930).await;
+    call.alice
+        .update(&call.call_id)
+        .with_sdp(HOLD_OFFER)
+        .send()
+        .await
+        .expect("send SDP-bearing UPDATE offer");
+
+    let hold_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let remaining = hold_deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "bob never committed the UPDATE hold offer"
+        );
+        match tokio::time::timeout(remaining, call.bob_events.next()).await {
+            Ok(Some(Event::RemoteCallOnHold { .. })) => break,
+            Ok(Some(_)) => continue,
+            Ok(None) | Err(_) => panic!("bob never committed the UPDATE hold offer"),
+        }
+    }
+
+    let retry_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match call
+            .alice
+            .update(&call.call_id)
+            .with_sdp(RESUME_OFFER)
+            .send()
+            .await
+        {
+            Ok(()) => break,
+            Err(SessionError::Conflict { .. }) if tokio::time::Instant::now() < retry_deadline => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            Err(error) => panic!("second SDP-bearing UPDATE failed: {error}"),
+        }
+    }
+
+    let resume_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let remaining = resume_deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "bob never committed the UPDATE resume offer"
+        );
+        match tokio::time::timeout(remaining, call.bob_events.next()).await {
+            Ok(Some(Event::RemoteCallResumed { .. })) => break,
+            Ok(Some(_)) => continue,
+            Ok(None) | Err(_) => panic!("bob never committed the UPDATE resume offer"),
+        }
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    while let Ok(Some(event)) =
+        tokio::time::timeout(Duration::from_millis(20), call.alice_events.next()).await
+    {
+        assert!(
+            !matches!(event, Event::RenegotiationFailed { .. }),
+            "valid UPDATE offer/answer unexpectedly failed: {event:?}"
+        );
+    }
+
+    call.teardown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn offerless_initial_invite_answers_the_200_offer_in_ack() {
+    use std::time::Duration;
+
+    use rvoip_sip::api::events::Event;
+    use rvoip_sip::CallState;
+
+    use support_for_section_10::{
+        boot_callback_receiver, boot_unified_caller, wait_for_call_answered,
+        wait_for_inbound_method,
+    };
+
+    let bob = boot_callback_receiver(18970, "bob-delayed-offer").await;
+    let mut bob_trace_events = bob.coord.events().await.expect("bob trace events");
+    let mut bob_state_events = bob.coord.events().await.expect("bob state events");
+    let alice = boot_unified_caller(18960, "alice-delayed-offer").await;
+    let mut alice_events = alice.events().await.expect("alice events");
+
+    let call_id = alice
+        .invite(
+            Some("sip:alice@127.0.0.1:18960".to_string()),
+            "sip:bob@127.0.0.1:18970",
+        )
+        .without_sdp()
+        .send()
+        .await
+        .expect("send offerless INVITE");
+
+    let bob_call_id = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(Event::IncomingCall { call_id, sdp, .. }) = bob_state_events.next().await {
+                assert!(sdp.is_none(), "offerless INVITE exposed an SDP offer");
+                break call_id;
+            }
+        }
+    })
+    .await
+    .expect("bob did not publish the incoming offerless call");
+
+    assert!(
+        wait_for_call_answered(&mut alice_events, &call_id, Duration::from_secs(10)).await,
+        "alice did not commit the delayed-offer answer"
+    );
+
+    let invite = wait_for_inbound_method(&mut bob_trace_events, "INVITE", Duration::from_secs(10))
+        .await
+        .expect("bob did not observe the initial INVITE");
+    assert_verbatim_packet(&invite);
+    assert!(
+        wire_body(&invite.raw_message).is_empty(),
+        "initial INVITE unexpectedly carried an SDP offer:\n{}",
+        invite.raw_message
+    );
+
+    let ack = wait_for_inbound_method(&mut bob_trace_events, "ACK", Duration::from_secs(10))
+        .await
+        .expect("bob did not observe the delayed-offer ACK");
+    assert_verbatim_packet(&ack);
+    assert_eq!(
+        wire_header_values(&ack.raw_message, "Content-Type"),
+        vec!["application/sdp"],
+        "delayed-offer ACK must identify its SDP answer"
+    );
+    let ack_body = wire_body(&ack.raw_message);
+    assert!(
+        ack_body.lines().next() == Some("v=0"),
+        "delayed-offer ACK did not carry an SDP answer:\n{}",
+        ack.raw_message
+    );
+
+    let both_active = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if alice.get_state(&call_id).await.ok() == Some(CallState::Active)
+                && bob.coord.get_state(&bob_call_id).await.ok() == Some(CallState::Active)
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(both_active.is_ok(), "both endpoints did not commit Active");
+
+    let _ = alice.bye(&call_id).send().await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    bob.shutdown().await;
+}
+
 /// §10 #9 — re-INVITE with extras. Drives `coord.reinvite(&session)`
 /// (equivalently `session.reinvite()`) against an established call
 /// and asserts the staged `X-Test: smoke` header reaches the wire on
@@ -191,6 +379,28 @@ m=audio 17000 RTP/AVP 0\r\n";
             "re-INVITE must carry exactly one staged smoke header; wire =\n{}",
             trace.raw_message,
         );
+
+        // Let the exact 200/ACK exchange commit before teardown, then prove
+        // the established call survived without a negotiation failure.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert_eq!(
+            call.alice
+                .get_state(&call.call_id)
+                .await
+                .expect("re-INVITE completion state"),
+            rvoip_sip::CallState::Active
+        );
+        while let Ok(Some(event)) =
+            tokio::time::timeout(Duration::from_millis(20), call.alice_events.next()).await
+        {
+            assert!(
+                !matches!(
+                    event,
+                    rvoip_sip::api::events::Event::RenegotiationFailed { .. }
+                ),
+                "valid re-INVITE unexpectedly failed: {event:?}"
+            );
+        }
 
         call.teardown().await;
     });

--- a/crates/sip/rvoip-sip/tests/state_machine_wiring_manifest.rs
+++ b/crates/sip/rvoip-sip/tests/state_machine_wiring_manifest.rs
@@ -68,6 +68,7 @@ fn every_yaml_event_is_manifested_or_marked_internal() {
         "AcceptCall",
         "AuthRequired",
         "CancelCall",
+        "ConfirmedNegotiationFailure",
         "Dialog180Ringing",
         "Dialog183SessionProgress",
         "Dialog200OK",

--- a/crates/sip/rvoip-sip/tests/state_table_validation_tests.rs
+++ b/crates/sip/rvoip-sip/tests/state_table_validation_tests.rs
@@ -122,6 +122,29 @@ fn active_auth_required_retries_for_uac_and_uas_dialog_roles() {
 }
 
 #[test]
+fn outbound_reinvite_applies_answer_and_acknowledges_before_commit() {
+    let table = load_state_table("default.yaml").expect("Failed to load default.yaml");
+    let transition = table
+        .get(&StateKey {
+            role: Role::Both,
+            state: CallState::Active,
+            event: EventType::Dialog200OK,
+        })
+        .expect("outbound re-INVITE success transition");
+
+    assert_eq!(
+        transition.actions.first(),
+        Some(&Action::NegotiateSDPAsUAC),
+        "the received SDP answer must be applied before pending renegotiation state is committed"
+    );
+    assert_eq!(
+        transition.actions.get(1),
+        Some(&Action::SendACK),
+        "a successful re-INVITE must be acknowledged before its pending state is committed"
+    );
+}
+
+#[test]
 fn test_hold_resume_transitions() {
     let table = load_state_table("default.yaml").expect("Failed to load default.yaml");
 

--- a/crates/sip/rvoip-sip/tests/support/invariants.rs
+++ b/crates/sip/rvoip-sip/tests/support/invariants.rs
@@ -200,7 +200,6 @@ fn endpoint_retained_total(snapshot: &Value) -> u64 {
         "/transaction_manager/server_invite_dialog_keys_by_tx",
         "/transaction_manager/invite_2xx_response_cache",
         "/transaction_manager/invite_2xx_response_due_queue",
-        "/transaction_manager/transaction_destinations",
         "/transaction_manager/subscriber_to_transactions",
         "/transaction_manager/transaction_to_subscribers",
         "/transaction_manager/event_subscribers",
@@ -248,12 +247,17 @@ fn endpoint_retained_total(snapshot: &Value) -> u64 {
 
     let live_lifecycle_entries = metric(snapshot, "/lifecycle/entries")
         .saturating_sub(metric(snapshot, "/lifecycle/terminal_entries"));
+    let orphaned_transaction_destinations = snapshot
+        .pointer("/transaction_manager/orphaned_transaction_destinations")
+        .and_then(Value::as_u64)
+        .expect("perf snapshot exposes orphaned transaction destinations");
 
     POINTERS
         .iter()
         .map(|pointer| metric(snapshot, pointer))
         .sum::<u64>()
         + live_lifecycle_entries
+        + orphaned_transaction_destinations
 }
 
 fn endpoint_global_retained_total(snapshot: &Value) -> u64 {

--- a/crates/sip/rvoip-sip/tests/support/mod.rs
+++ b/crates/sip/rvoip-sip/tests/support/mod.rs
@@ -18,6 +18,7 @@ pub mod handlers;
 pub mod invariants;
 pub mod registrar;
 pub mod ringing_uas;
+pub mod sdp;
 pub mod traces;
 
 pub use auth_uas::{boot_auth_uas, AuthUas, CapturedAuthRequest, ChallengeReply};
@@ -34,6 +35,7 @@ pub use invariants::{
 };
 pub use registrar::{boot_mock_registrar, CapturedRegister, MockRegistrar, RegistrarReply};
 pub use ringing_uas::{boot_ringing_uas, CapturedRequest, RingingUas};
+pub use sdp::attach_pcmu_sdp_answer;
 pub use traces::{
     assert_header_on_wire, receiver_config, wait_for_inbound_method, SMOKE_HEADER_NAME,
     SMOKE_HEADER_VALUE,

--- a/crates/sip/rvoip-sip/tests/support/sdp.rs
+++ b/crates/sip/rvoip-sip/tests/support/sdp.rs
@@ -1,0 +1,21 @@
+use rvoip_sip_core::types::{ContentLength, ContentType, Response, TypedHeader};
+
+/// Attach a minimal valid PCMU answer to a raw-UAS 200 OK fixture.
+pub fn attach_pcmu_sdp_answer(response: &mut Response, media_port: u16) {
+    response.body = format!(
+        "v=0\r\no=test-uas 1 1 IN IP4 127.0.0.1\r\ns=-\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio {media_port} RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n"
+    )
+    .into_bytes()
+    .into();
+    response
+        .headers
+        .retain(|header| !matches!(header, TypedHeader::ContentLength(_)));
+    response
+        .headers
+        .push(TypedHeader::ContentLength(ContentLength::new(
+            response.body.len() as u32,
+        )));
+    response
+        .headers
+        .push(TypedHeader::ContentType(ContentType::sdp()));
+}

--- a/crates/sip/rvoip-sip/tests/update_notify_auth_retry.rs
+++ b/crates/sip/rvoip-sip/tests/update_notify_auth_retry.rs
@@ -4,6 +4,8 @@
 //! must be answered with `Proxy-Authorization`. The retry must preserve the
 //! method-shaped options staged by the public builders.
 
+mod support;
+
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +26,8 @@ use rvoip_sip_core::types::header::HeaderName;
 use rvoip_sip_core::types::headers::{HeaderAccess, HeaderValue};
 
 use rvoip_sip_dialog::transaction::utils::response_builders::create_response;
+
+use support::attach_pcmu_sdp_answer;
 
 const REALM: &str = "testrealm";
 const TRACE_HEADER_NAME: &str = "X-Trace";
@@ -396,6 +400,7 @@ async fn spawn_raw_auth_uas(
                     HeaderName::Contact,
                     HeaderValue::Raw(format!("<sip:bob@127.0.0.1:{port}>").into_bytes()),
                 ));
+                attach_pcmu_sdp_answer(&mut resp, port + 1_000);
                 let _ = sock_task
                     .send_to(&Message::Response(resp).to_bytes(), from)
                     .await;

--- a/crates/sip/sip-dialog/src/api/unified.rs
+++ b/crates/sip/sip-dialog/src/api/unified.rs
@@ -2131,6 +2131,109 @@ impl UnifiedDialogApi {
         .await
     }
 
+    /// Send the SDP-bearing ACK for an offerless initial INVITE, after
+    /// revalidating that the exact client transaction belongs to the session.
+    pub async fn send_delayed_offer_ack_for_session_transaction(
+        &self,
+        session_id: &str,
+        transaction_id: &TransactionKey,
+        response: &Response,
+        sdp_answer: &str,
+    ) -> ApiResult<()> {
+        if transaction_id.is_server()
+            || transaction_id.method() != &Method::Invite
+            || !response.status().is_success()
+            || TransactionKey::from_response(response).as_ref() != Some(transaction_id)
+        {
+            return Err(ApiError::Protocol {
+                message: "Delayed-offer ACK requires the exact successful client INVITE response"
+                    .to_string(),
+            });
+        }
+        let dialog_id = self
+            .manager
+            .core()
+            .session_to_dialog
+            .get(session_id)
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| ApiError::Dialog {
+                message: format!("No dialog found for session {session_id}"),
+            })?;
+        let transaction_dialog = self
+            .manager
+            .core()
+            .find_dialog_for_transaction(transaction_id)
+            .map_err(|_| ApiError::Dialog {
+                message: "Delayed-offer ACK transaction is not owned by the session dialog"
+                    .to_string(),
+            })?;
+        if transaction_dialog != dialog_id {
+            return Err(ApiError::Dialog {
+                message: "Delayed-offer ACK transaction is not owned by the session dialog"
+                    .to_string(),
+            });
+        }
+        self.manager
+            .core()
+            .transaction_manager()
+            .send_ack_for_2xx_with_sdp(transaction_id, response, sdp_answer)
+            .await
+            .map_err(|_| ApiError::Dialog {
+                message: "Delayed-offer ACK transport write failed".to_string(),
+            })
+    }
+
+    /// Send a bodyless ACK for an exact successful INVITE response owned by
+    /// this session dialog.
+    pub async fn send_invite_2xx_ack_for_session_transaction(
+        &self,
+        session_id: &str,
+        transaction_id: &TransactionKey,
+        response: &Response,
+    ) -> ApiResult<()> {
+        if transaction_id.is_server()
+            || transaction_id.method() != &Method::Invite
+            || !response.status().is_success()
+            || TransactionKey::from_response(response).as_ref() != Some(transaction_id)
+        {
+            return Err(ApiError::Protocol {
+                message: "INVITE 2xx ACK requires the exact successful client transaction response"
+                    .to_string(),
+            });
+        }
+        let dialog_id = self
+            .manager
+            .core()
+            .session_to_dialog
+            .get(session_id)
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| ApiError::Dialog {
+                message: format!("No dialog found for session {session_id}"),
+            })?;
+        let transaction_dialog = self
+            .manager
+            .core()
+            .find_dialog_for_transaction(transaction_id)
+            .map_err(|_| ApiError::Dialog {
+                message: "INVITE 2xx ACK transaction is not owned by the session dialog"
+                    .to_string(),
+            })?;
+        if transaction_dialog != dialog_id {
+            return Err(ApiError::Dialog {
+                message: "INVITE 2xx ACK transaction is not owned by the session dialog"
+                    .to_string(),
+            });
+        }
+        self.manager
+            .core()
+            .transaction_manager()
+            .send_ack_for_2xx(transaction_id, response)
+            .await
+            .map_err(|_| ApiError::Dialog {
+                message: "INVITE 2xx ACK transport write failed".to_string(),
+            })
+    }
+
     pub async fn send_response_with_extras_for_session_transaction(
         &self,
         session_id: &str,

--- a/crates/sip/sip-dialog/src/events/event_hub.rs
+++ b/crates/sip/sip-dialog/src/events/event_hub.rs
@@ -534,6 +534,11 @@ impl DialogEventHub {
                                 rvoip_sip_core::Message::Response(response.clone()).to_bytes(),
                             ))
                         });
+                    let response_sdp = if response.body().is_empty() {
+                        None
+                    } else {
+                        String::from_utf8(response.body().to_vec()).ok()
+                    };
                     // The transaction key is the locally-owned correlation
                     // authority. A response CSeq is peer input; transaction
                     // matching has already validated it, but it must not
@@ -771,6 +776,7 @@ impl DialogEventHub {
                                         outcome: OutboundRequestOutcome::FinalResponse {
                                             status_code: response.status_code(),
                                         },
+                                        response_sdp: response_sdp.clone(),
                                     },
                                 ))
                             } else if !is_invite_response {
@@ -813,6 +819,7 @@ impl DialogEventHub {
                                     outcome: OutboundRequestOutcome::FinalResponse {
                                         status_code: code,
                                     },
+                                    response_sdp: response_sdp.clone(),
                                 },
                             ))
                         }
@@ -852,6 +859,7 @@ impl DialogEventHub {
                                 transaction_id: transaction_id.to_string(),
                                 method: method.to_string(),
                                 outcome,
+                                response_sdp: None,
                             },
                         )
                     })
@@ -1394,6 +1402,7 @@ mod safe_diagnostic_tests {
                         outcome: OutboundRequestOutcome::FinalResponse {
                             status_code: mapped_status,
                         },
+                        ..
                     }
                 ) if session_id == "session-terminal-test"
                     && mapped_transaction == &transaction_id.to_string()
@@ -1466,6 +1475,7 @@ mod safe_diagnostic_tests {
                     transaction_id: ref mapped_transaction,
                     ref method,
                     outcome: OutboundRequestOutcome::FinalResponse { status_code: 491 },
+                    ..
                 }
             ) if session_id == "session-terminal-test"
                 && mapped_transaction == &update_transaction.to_string()

--- a/crates/sip/sip-dialog/src/manager/core.rs
+++ b/crates/sip/sip-dialog/src/manager/core.rs
@@ -7894,8 +7894,10 @@ mod outbound_flow_handler_tests {
         )
         .to("Bob", "sip:bob@example.com", Some("bob-delivery-fence"))
         .contact("sip:bob@127.0.0.1:5094", None)
-        .body(bytes::Bytes::from_static(b"v=0\r\n"))
         .build();
+        // Keep this lower-layer retry fixture bodyless so sip-dialog owns the
+        // automatic ACK. SDP-bearing session responses deliberately defer ACK
+        // authority until rvoip-sip validates and applies the answer.
         let success_event = || TransactionEvent::SuccessResponse {
             transaction_id: transaction_id.clone(),
             response: response.clone(),

--- a/crates/sip/sip-dialog/src/manager/transaction_integration.rs
+++ b/crates/sip/sip-dialog/src/manager/transaction_integration.rs
@@ -6468,8 +6468,17 @@ impl DialogManager {
             .await;
         }
 
-        // Handle specific successful response types
         let session_id_for_diag = self.get_session_id(dialog_id);
+        // SDP-bearing INVITE 2xx responses owned by session-core are ACKed
+        // only after that layer validates and applies the exact answer (or
+        // creates the delayed-offer ACK answer). Bodyless refresh responses
+        // and standalone dialog users retain automatic ACK behavior.
+        let deferred_session_ack = session_id_for_diag.is_some()
+            && transaction_id.method() == &rvoip_sip_core::Method::Invite
+            && response.status().is_success()
+            && !response.body().is_empty();
+
+        // Handle specific successful response types
         match response.status_code() {
             status if (200..300).contains(&status) => {
                 // Every 2xx to INVITE is ACKed by the UAC core (RFC 3261
@@ -6479,41 +6488,42 @@ impl DialogManager {
                     if let Some(session_id) = session_id_for_diag.as_deref() {
                         crate::diagnostics::record_call_timing_uac_invite_2xx_response(session_id);
                     }
-                    info!(
-                        status,
-                        dialog=%dialog_id,
-                        "Received successful INVITE response; sending automatic ACK"
-                    );
+                    info!(status, dialog=%dialog_id, deferred_session_ack, "Received successful INVITE response");
 
-                    // Send ACK using transaction-core's send_ack_for_2xx method
-                    crate::diagnostics::record_uac_invite_2xx_ack_attempt();
-                    if let Some(session_id) = session_id_for_diag.as_deref() {
-                        crate::diagnostics::record_call_timing_uac_ack_attempt(session_id);
-                    }
-                    match self
-                        .transaction_manager
-                        .send_ack_for_2xx(transaction_id, &response)
-                        .await
-                    {
-                        Ok(_) => {
-                            crate::diagnostics::record_uac_invite_2xx_ack_success();
-                            if let Some(session_id) = session_id_for_diag.as_deref() {
-                                crate::diagnostics::record_call_timing_uac_ack_success(session_id);
-                            }
-                            info!(status, "Successfully sent automatic ACK for INVITE 2xx");
+                    if !deferred_session_ack {
+                        crate::diagnostics::record_uac_invite_2xx_ack_attempt();
+                        if let Some(session_id) = session_id_for_diag.as_deref() {
+                            crate::diagnostics::record_call_timing_uac_ack_attempt(session_id);
                         }
-                        Err(e) => {
-                            crate::diagnostics::record_uac_invite_2xx_ack_failure();
-                            if let Some(session_id) = session_id_for_diag.as_deref() {
-                                crate::diagnostics::record_call_timing_uac_ack_failure(session_id);
+                        match self
+                            .transaction_manager
+                            .send_ack_for_2xx(transaction_id, &response)
+                            .await
+                        {
+                            Ok(_) => {
+                                crate::diagnostics::record_uac_invite_2xx_ack_success();
+                                if let Some(session_id) = session_id_for_diag.as_deref() {
+                                    crate::diagnostics::record_call_timing_uac_ack_success(
+                                        session_id,
+                                    );
+                                }
+                                info!(status, "Successfully sent automatic ACK for INVITE 2xx");
                             }
-                            warn!(error=%crate::transaction::safe_diagnostics::SafeOpaqueError::new(&e), status, "Failed to send automatic ACK for INVITE 2xx");
-                            return Err(crate::errors::DialogError::TransactionError {
-                                message: safe_operation_failure(
-                                    "automatic_invite_2xx_ack",
-                                    "transaction_error",
-                                ),
-                            });
+                            Err(e) => {
+                                crate::diagnostics::record_uac_invite_2xx_ack_failure();
+                                if let Some(session_id) = session_id_for_diag.as_deref() {
+                                    crate::diagnostics::record_call_timing_uac_ack_failure(
+                                        session_id,
+                                    );
+                                }
+                                warn!(error=%crate::transaction::safe_diagnostics::SafeOpaqueError::new(&e), status, "Failed to send automatic ACK for INVITE 2xx");
+                                return Err(crate::errors::DialogError::TransactionError {
+                                    message: safe_operation_failure(
+                                        "automatic_invite_2xx_ack",
+                                        "transaction_error",
+                                    ),
+                                });
+                            }
                         }
                     }
                 }
@@ -6548,6 +6558,15 @@ impl DialogManager {
                 request_uri: None,
             })
             .await?;
+        }
+
+        if deferred_session_ack {
+            crate::diagnostics::record_uac_invite_2xx_ack_attempt();
+            crate::diagnostics::record_uac_invite_2xx_ack_success();
+            if let Some(session_id) = session_id_for_diag.as_deref() {
+                crate::diagnostics::record_call_timing_uac_ack_attempt(session_id);
+                crate::diagnostics::record_call_timing_uac_ack_success(session_id);
+            }
         }
 
         // Commit immediately after the mandatory ACK write and acknowledged

--- a/crates/sip/sip-dialog/src/transaction/manager/mod.rs
+++ b/crates/sip/sip-dialog/src/transaction/manager/mod.rs
@@ -225,6 +225,35 @@ use crate::transaction::{
     TransactionState, DEFAULT_TRANSACTION_COMMAND_CHANNEL_CAPACITY,
 };
 
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct DelayedOfferAckAnswerKey {
+    transaction_id: TransactionKey,
+    remote_tag: Arc<str>,
+}
+
+impl DelayedOfferAckAnswerKey {
+    fn from_response(transaction_id: &TransactionKey, response: &Response) -> Result<Self> {
+        if !response.status().is_success()
+            || TransactionKey::from_response(response).as_ref() != Some(transaction_id)
+        {
+            return Err(Error::Other(
+                "delayed-offer ACK requires the exact successful INVITE response".into(),
+            ));
+        }
+        let remote_tag = response
+            .to()
+            .and_then(|to| to.tag())
+            .filter(|tag| !tag.is_empty())
+            .ok_or_else(|| {
+                Error::Other("delayed-offer ACK response has no remote dialog tag".into())
+            })?;
+        Ok(Self {
+            transaction_id: transaction_id.clone(),
+            remote_tag: Arc::from(remote_tag),
+        })
+    }
+}
+
 /// Internal first-write classification for one exact CANCEL generation.
 /// Composition failures are immediately safe to retry. A route-preparation
 /// failure is safe after the returned retired generation's terminal event has
@@ -800,6 +829,7 @@ struct RetainedClientDeadlineContext {
     retired_client_deadlines: std::sync::Weak<std::sync::Mutex<RetiredClientDeadlineScheduler>>,
     retired_client_transaction_capacity: Arc<AtomicUsize>,
     retired_client_transaction_count: std::sync::Weak<AtomicUsize>,
+    delayed_offer_ack_answers: std::sync::Weak<DashMap<DelayedOfferAckAnswerKey, Arc<str>>>,
 }
 
 struct RetainedClientDeadlineBatch {
@@ -819,12 +849,14 @@ fn process_retained_client_deadline_batch(
         Some(transaction_destinations),
         Some(retired_client_deadlines),
         Some(retired_client_transaction_count),
+        Some(delayed_offer_ack_answers),
     ) = (
         context.client_completions.upgrade(),
         context.client_completion_deadlines.upgrade(),
         context.transaction_destinations.upgrade(),
         context.retired_client_deadlines.upgrade(),
         context.retired_client_transaction_count.upgrade(),
+        context.delayed_offer_ack_answers.upgrade(),
     )
     else {
         return RetainedClientDeadlineBatch {
@@ -882,6 +914,8 @@ fn process_retained_client_deadline_batch(
             })
             .is_some()
         {
+            delayed_offer_ack_answers
+                .retain(|key, _| &key.transaction_id != deadline.transaction_id.as_ref());
             let _ = retired_client_transaction_count.fetch_update(
                 Ordering::AcqRel,
                 Ordering::Acquire,
@@ -1946,6 +1980,8 @@ pub struct TransactionManager {
     /// retransmitted 2xx responses and retain the request template needed to
     /// ACK them without keeping the transaction runner alive.
     transaction_destinations: Arc<DashMap<Arc<TransactionKey>, ClientResponseRouteState>>,
+    /// Exact SDP answer used for delayed-offer ACK retransmissions.
+    delayed_offer_ack_answers: Arc<DashMap<DelayedOfferAckAnswerKey, Arc<str>>>,
     retired_client_transaction_capacity: Arc<AtomicUsize>,
     retired_client_transaction_count: Arc<AtomicUsize>,
     retired_client_deadlines: Arc<std::sync::Mutex<RetiredClientDeadlineScheduler>>,
@@ -2639,6 +2675,7 @@ impl TransactionManager {
             retired_client_transaction_count: Arc::downgrade(
                 &self.retired_client_transaction_count,
             ),
+            delayed_offer_ack_answers: Arc::downgrade(&self.delayed_offer_ack_answers),
         }
     }
 
@@ -3852,6 +3889,7 @@ impl TransactionManager {
             lifecycle_scheduler: Some(lifecycle_scheduler),
             compact_non_invite_tombstones,
             transaction_destinations,
+            delayed_offer_ack_answers: Arc::new(DashMap::new()),
             retired_client_transaction_capacity: Arc::new(AtomicUsize::new(
                 retired_client_transaction_capacity(index_capacity),
             )),
@@ -4053,6 +4091,7 @@ impl TransactionManager {
             lifecycle_scheduler: Some(lifecycle_scheduler),
             compact_non_invite_tombstones,
             transaction_destinations,
+            delayed_offer_ack_answers: Arc::new(DashMap::new()),
             retired_client_transaction_capacity: Arc::new(AtomicUsize::new(
                 retired_client_transaction_capacity(index_capacity),
             )),
@@ -4507,6 +4546,7 @@ impl TransactionManager {
             lifecycle_scheduler: Some(lifecycle_scheduler),
             compact_non_invite_tombstones,
             transaction_destinations,
+            delayed_offer_ack_answers: Arc::new(DashMap::new()),
             retired_client_transaction_capacity: Arc::new(AtomicUsize::new(
                 retired_client_transaction_capacity(index_capacity),
             )),
@@ -4688,6 +4728,7 @@ impl TransactionManager {
             lifecycle_scheduler: Some(lifecycle_scheduler),
             compact_non_invite_tombstones,
             transaction_destinations,
+            delayed_offer_ack_answers: Arc::new(DashMap::new()),
             retired_client_transaction_capacity: Arc::new(AtomicUsize::new(
                 retired_client_transaction_capacity(index_capacity),
             )),
@@ -4834,6 +4875,7 @@ impl TransactionManager {
             timer_settings,
             running,
             transaction_destinations,
+            delayed_offer_ack_answers: Arc::new(DashMap::new()),
             retired_client_transaction_capacity: Arc::new(AtomicUsize::new(
                 retired_client_transaction_capacity(index_capacity),
             )),
@@ -6552,6 +6594,7 @@ impl TransactionManager {
             scheduler.clear();
         }
         self.transaction_destinations.clear();
+        self.delayed_offer_ack_answers.clear();
         self.compact_non_invite_tombstones.clear();
         self.retired_client_deadlines
             .lock()
@@ -7418,12 +7461,83 @@ impl TransactionManager {
             .admission_lifecycle
             .try_enter_existing()
             .ok_or_else(|| Error::Other("transaction manager is stopping".into()))?;
+        let answer_key = DelayedOfferAckAnswerKey::from_response(invite_tx_id, response)?;
+        let cached_answer = self
+            .delayed_offer_ack_answers
+            .get(&answer_key)
+            .map(|entry| Arc::clone(entry.value()));
         tokio::select! {
             biased;
             _ = self.operation_cancellation.cancelled() => {
                 Err(Error::Other("transaction manager stopped ACK send".into()))
             }
-            result = self.send_ack_for_2xx_within_operation(invite_tx_id, response) => result,
+            result = self.send_ack_for_2xx_within_operation(
+                invite_tx_id,
+                response,
+                cached_answer.as_deref(),
+            ) => result,
+        }
+    }
+
+    /// Send the SDP answer in the ACK for an offerless INVITE whose 2xx
+    /// response supplied the offer (RFC 3261 section 13.2.2.4).
+    pub async fn send_ack_for_2xx_with_sdp(
+        &self,
+        invite_tx_id: &TransactionKey,
+        response: &Response,
+        sdp_answer: &str,
+    ) -> Result<()> {
+        if sdp_answer.trim().is_empty() {
+            return Err(Error::Other(
+                "delayed-offer ACK requires a non-empty SDP answer".into(),
+            ));
+        }
+        let _operation = self
+            .admission_lifecycle
+            .try_enter_existing()
+            .ok_or_else(|| Error::Other("transaction manager is stopping".into()))?;
+        let answer_key = DelayedOfferAckAnswerKey::from_response(invite_tx_id, response)?;
+        let prepared = tokio::select! {
+            biased;
+            _ = self.operation_cancellation.cancelled() => {
+                return Err(Error::Other("transaction manager stopped ACK send".into()));
+            }
+            result = self.prepare_ack_for_2xx_within_operation(
+                invite_tx_id,
+                response,
+                Some(sdp_answer),
+            ) => result?,
+        };
+        let retained_answer: Arc<str> = Arc::from(sdp_answer);
+        match self.delayed_offer_ack_answers.entry(answer_key.clone()) {
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(&retained_answer));
+            }
+            dashmap::mapref::entry::Entry::Occupied(entry)
+                if entry.get().as_ref() == sdp_answer => {}
+            dashmap::mapref::entry::Entry::Occupied(_) => {
+                return Err(Error::Other(
+                    "delayed-offer ACK answer changed for the same INVITE transaction".into(),
+                ));
+            }
+        }
+        // The retained INVITE response route owns the deadline that removes
+        // this cached answer. Revalidate after insertion so expiry racing the
+        // preparation cannot leave an answer without a cleanup owner.
+        if self.transaction_route(invite_tx_id).await.is_none() {
+            self.delayed_offer_ack_answers
+                .remove_if(&answer_key, |_, answer| answer.as_ref() == sdp_answer);
+            return Err(Error::transaction_not_found(
+                invite_tx_id.clone(),
+                "delayed-offer ACK route expired before send",
+            ));
+        }
+        tokio::select! {
+            biased;
+            _ = self.operation_cancellation.cancelled() => {
+                Err(Error::Other("transaction manager stopped ACK send".into()))
+            }
+            result = self.send_prepared_ack_for_2xx_within_operation(prepared) => result,
         }
     }
 
@@ -7431,9 +7545,45 @@ impl TransactionManager {
         &self,
         invite_tx_id: &TransactionKey,
         response: &Response,
+        sdp_answer: Option<&str>,
     ) -> Result<()> {
-        // Create the ACK request
-        let ack_request = self.create_ack_for_2xx(invite_tx_id, response).await?;
+        let prepared = self
+            .prepare_ack_for_2xx_within_operation(invite_tx_id, response, sdp_answer)
+            .await?;
+        self.send_prepared_ack_for_2xx_within_operation(prepared)
+            .await
+    }
+
+    async fn prepare_ack_for_2xx_within_operation(
+        &self,
+        invite_tx_id: &TransactionKey,
+        response: &Response,
+        sdp_answer: Option<&str>,
+    ) -> Result<(Request, TransportRoute)> {
+        if !response.status().is_success()
+            || TransactionKey::from_response(response).as_ref() != Some(invite_tx_id)
+        {
+            return Err(Error::Other(
+                "ACK requires the exact successful INVITE response".into(),
+            ));
+        }
+
+        let mut ack_request = self.create_ack_for_2xx(invite_tx_id, response).await?;
+        if let Some(sdp_answer) = sdp_answer {
+            ack_request.headers.retain(|header| {
+                !matches!(
+                    header,
+                    TypedHeader::ContentLength(_) | TypedHeader::ContentType(_)
+                )
+            });
+            ack_request.headers.push(TypedHeader::ContentType(
+                rvoip_sip_core::types::ContentType::from_type_subtype("application", "sdp"),
+            ));
+            ack_request.headers.push(TypedHeader::ContentLength(
+                rvoip_sip_core::types::ContentLength::new(sdp_answer.len() as u32),
+            ));
+            ack_request.body = bytes::Bytes::copy_from_slice(sdp_answer.as_bytes());
+        }
         let original_route = self.transaction_route(invite_tx_id).await.ok_or_else(|| {
             Error::transaction_not_found(invite_tx_id.clone(), "ACK route lookup failed")
         })?;
@@ -7479,6 +7629,13 @@ impl TransactionManager {
         // preserving the authenticated transport/authority/flow selected by
         // the original INVITE whenever its route remains the next hop.
         rvoip_sip_core::validation::validate_wire_request(&ack_request)?;
+        Ok((ack_request, ack_route))
+    }
+
+    async fn send_prepared_ack_for_2xx_within_operation(
+        &self,
+        (ack_request, ack_route): (Request, TransportRoute),
+    ) -> Result<()> {
         self.transport
             .send_message_via(Message::Request(ack_request), ack_route)
             .await

--- a/crates/sip/sip-dialog/src/transaction/manager/mod.rs
+++ b/crates/sip/sip-dialog/src/transaction/manager/mod.rs
@@ -3170,6 +3170,32 @@ impl TransactionManager {
         }
     }
 
+    /// Count active response routes that no live or compact transaction owns.
+    ///
+    /// Compact client tombstones intentionally retain their authenticated
+    /// response route through the applicable RFC timer. Keep those bounded
+    /// protocol records visible in [`Self::retention_counts`], but do not
+    /// classify them as leaks in post-call release gates.
+    pub fn orphaned_transaction_destination_count(&self) -> usize {
+        self.transaction_destinations
+            .iter()
+            .filter(|entry| {
+                let transaction_id = entry.key();
+                entry.value().is_active()
+                    && !self
+                        .client_transactions
+                        .contains_key(transaction_id.as_ref())
+                    && !self
+                        .server_transactions
+                        .contains_key(transaction_id.as_ref())
+                    && !self
+                        .compact_non_invite_tombstones
+                        .get(transaction_id.as_ref())
+                        .is_some_and(|compact| compact.is_client())
+            })
+            .count()
+    }
+
     /// Number of unexpired INVITE client tombstones retained for authenticated
     /// late-2xx handling. Kept separate from `TransactionManagerRetentionCounts`
     /// so adding this diagnostic does not break downstream exhaustive struct

--- a/crates/sip/sip-dialog/src/transaction/manager/tests.rs
+++ b/crates/sip/sip-dialog/src/transaction/manager/tests.rs
@@ -3411,6 +3411,12 @@ mod tests {
             !manager.client_transactions.contains_key(&tx_id),
             "the heavy client transaction must be released after Timer M handoff"
         );
+        assert_eq!(manager.retention_counts().transaction_destinations, 1);
+        assert_eq!(
+            manager.orphaned_transaction_destination_count(),
+            0,
+            "the compact Timer M generation owns its authenticated response route"
+        );
 
         while event_rx.try_recv().is_ok() {}
         transport_tx
@@ -3493,6 +3499,34 @@ mod tests {
         // Clean up
         manager.shutdown().await;
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn orphaned_transaction_destination_count_reports_unowned_active_routes() -> Result<()> {
+        let transport = Arc::new(MockTransport::new("127.0.0.1:5060"));
+        let (_transport_tx, transport_rx) = mpsc::channel(4);
+        let (manager, _event_rx) =
+            TransactionManager::new(transport, transport_rx, Some(4)).await?;
+        let transaction_id = Arc::new(TransactionKey::new(
+            "z9hG4bK.unowned-route".into(),
+            Method::Options,
+            false,
+        ));
+        let route = TransportRoute::new("192.0.2.201:5060".parse().unwrap())
+            .with_transport_type(TransportType::Udp);
+        manager.transaction_destinations.insert(
+            Arc::clone(&transaction_id),
+            ClientResponseRouteState::active(route, usize::MAX),
+        );
+
+        assert_eq!(manager.retention_counts().transaction_destinations, 1);
+        assert_eq!(manager.orphaned_transaction_destination_count(), 1);
+
+        manager
+            .transaction_destinations
+            .remove(transaction_id.as_ref());
+        manager.shutdown().await;
         Ok(())
     }
 

--- a/crates/sip/sip-dialog/src/transaction/manager/tests.rs
+++ b/crates/sip/sip-dialog/src/transaction/manager/tests.rs
@@ -3125,6 +3125,94 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn delayed_offer_2xx_retransmission_reuses_exact_sdp_ack() -> Result<()> {
+        let transport = Arc::new(MockTransport::new("127.0.0.1:5060"));
+        let (_, transport_rx) = mpsc::channel(10);
+        let (manager, _event_rx) =
+            TransactionManager::new(transport.clone(), transport_rx, Some(10)).await?;
+
+        let invite_request = create_test_invite().map_err(|e| Error::Other(e.to_string()))?;
+        let destination = SocketAddr::from_str("192.168.1.100:5060").unwrap();
+        let tx_id = manager
+            .create_client_transaction(invite_request.clone(), destination)
+            .await?;
+        manager.send_request(&tx_id).await?;
+
+        let mut response = create_test_response(&invite_request, StatusCode::Ok, Some("OK"));
+        let contact_uri = Uri::from_str("sip:bob@192.168.1.2:5060").unwrap();
+        let contact = Contact::new_params(vec![ContactParamInfo {
+            address: Address::new_with_display_name("Bob", contact_uri),
+        }]);
+        response = response.with_header(TypedHeader::Contact(contact));
+        let answer = concat!(
+            "v=0\r\n",
+            "o=- 1 1 IN IP4 127.0.0.1\r\n",
+            "s=delayed-answer\r\n",
+            "c=IN IP4 127.0.0.1\r\n",
+            "t=0 0\r\n",
+            "m=audio 40000 RTP/AVP 0\r\n",
+            "a=rtpmap:0 PCMU/8000\r\n"
+        );
+
+        manager
+            .send_ack_for_2xx_with_sdp(&tx_id, &response, answer)
+            .await?;
+        manager.send_ack_for_2xx(&tx_id, &response).await?;
+        assert!(manager
+            .send_ack_for_2xx_with_sdp(&tx_id, &response, "v=0\r\ns=different\r\n")
+            .await
+            .is_err());
+
+        let sent = transport.get_sent_messages().await;
+        assert_eq!(sent.len(), 3, "INVITE plus two answer-bearing ACKs");
+        for (message, _) in &sent[1..] {
+            let Message::Request(ack) = message else {
+                panic!("expected ACK request");
+            };
+            assert_eq!(ack.method(), Method::Ack);
+            assert_eq!(ack.body(), answer.as_bytes());
+            assert!(matches!(
+                ack.header(&HeaderName::ContentType),
+                Some(TypedHeader::ContentType(content_type))
+                    if content_type.to_string().eq_ignore_ascii_case("application/sdp")
+            ));
+        }
+
+        manager.shutdown().await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn invalid_delayed_offer_ack_cannot_leave_an_unretired_answer() -> Result<()> {
+        let transport = Arc::new(MockTransport::new("127.0.0.1:5060"));
+        let (_, transport_rx) = mpsc::channel(10);
+        let (manager, _event_rx) =
+            TransactionManager::new(transport, transport_rx, Some(10)).await?;
+
+        let invite_request = create_test_invite().map_err(|e| Error::Other(e.to_string()))?;
+        let response = create_test_response(&invite_request, StatusCode::Ok, Some("OK"));
+        let unknown_transaction = TransactionKey::from_response(&response)
+            .expect("response identifies a syntactically valid client INVITE transaction");
+        assert!(!manager.transaction_exists(&unknown_transaction).await);
+
+        assert!(manager
+            .send_ack_for_2xx_with_sdp(
+                &unknown_transaction,
+                &response,
+                "v=0\r\ns=unowned-answer\r\n",
+            )
+            .await
+            .is_err());
+        assert!(
+            manager.delayed_offer_ack_answers.is_empty(),
+            "an answer without a retained transaction route has no cleanup owner"
+        );
+
+        manager.shutdown().await;
+        Ok(())
+    }
+
     /// Test the get_transaction_request utility function
     #[tokio::test]
     async fn test_get_transaction_request() -> Result<()> {


### PR DESCRIPTION
## Summary

- add transaction/CSeq-scoped pending offer-answer state while retaining stable SDP, negotiated media configuration, and directions
- implement inbound and outbound re-INVITE, UPDATE offer-answer, and offerless INVITE / 200 offer / ACK answer flows
- commit only completed valid exchanges; roll back media, SRTP, SDP, and direction changes on failure
- make retransmissions idempotent and prevent stale work from crossing same-ID generation reuse
- preserve signaling-only hold/resume while applying media direction only to exact allocated media resources

## Signaling performance architecture

- uses generation-qualified registry handles for mutable ownership
- holds no DashMap/map guard across await or I/O
- adds no polling loop or new per-call worker task
- keeps pending state compact and transaction-scoped
- includes stale same-ID reuse and rollback regression coverage

## Validation

- `cargo check -p rvoip-rtp-core -p rvoip-media-core -p rvoip-sip --tests --locked`
- `cargo test -p rvoip-sip --lib --locked` (763 passed)
- `cargo test -p rvoip-sip --test signaling_only_hold_resume --locked`
- `cargo test -p rvoip-sip --test state_table_validation_tests --locked` (12 passed)
- delayed-offer retransmission and invalid-ACK dialog tests
- `cargo test -p rvoip-sip --test sip_api_design_2_section_10_skeletons --locked` (16 passed, 12 intentionally ignored)
- targeted SRTP rollback/generation and same-ID reuse regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core SIP offer/answer, media commit ordering, and SRTP key lifecycle at the wire boundary; mistakes could leave calls on wrong keys, plaintext, or inconsistent SDP versus RTP.
> 
> **Overview**
> **Offer/answer is now transaction-scoped and two-phase.** Session state gains `pending_offer_answer` (method + transaction key + stable SDP/media snapshot) with `begin` / `bind` / `commit` / `rollback`, so in-flight renegotiations no longer mutate stable dialog media until the exchange completes.
> 
> **Media commits are deferred and reversible.** `MediaAdapter` validates SDP first, stages negotiated results under generation-qualified keys, then `prepare` / `finalize` / `rollback` applies codec, flow, direction, and SRTP only across the SIP commit boundary. Failed commits restore prior config; failed rollbacks quarantine the lower allocation. Secure downgrade from an established SRTP session is rejected.
> 
> **UDP RTP transport supports reversible SRTP installs.** `replace_srtp_contexts` returns a move-only `SrtpContextRollback` (generation-fenced); drop commits, explicit `rollback_srtp_contexts` restores prior keys. `MediaSessionController` exposes prepare/rollback wrappers used from the adapter.
> 
> **Signaling paths are tightened for mid-dialog and delayed offer.** `OutboundRequestCompleted` carries optional `response_sdp` for UPDATE answers. The session event handler correlates INVITE/UPDATE completions to the pending offer transaction, handles INVITE 2xx retransmissions with ACK, delayed-offer 200/ACK flows, inbound offer validation (488), auth failures on tracked re-INVITE/UPDATE, and publishes new `RenegotiationFailed` while using `ConfirmedNegotiationFailure` where the call stays up. Outbound calls can use `without_sdp()` for offerless INVITE.
> 
> **Tests and harness fixes** add SDP bodies to several adapter BYE scenarios and broaden regression coverage for generation reuse, SRTP rollback, and failed public UAS commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af808f12686ead21f97caf48c10e903fb34d6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->