### PR TITLE
chore(rtc): satisfy strict 0.3.5 release lint

### DIFF
--- a/crates/webrtc/rvoip-rtc/src/peer_connection/configuration/sdp_semantics.rs
+++ b/crates/webrtc/rvoip-rtc/src/peer_connection/configuration/sdp_semantics.rs
@@ -130,12 +130,12 @@ mod test {
     fn extract_ssrc_list(md: &MediaDescription) -> Vec<String> {
         let mut ssrcs = HashSet::new();
         for attr in &md.attributes {
-            if attr.key == ATTR_KEY_SSRC {
-                if let Some(value) = &attr.value {
-                    let fields: Vec<&str> = value.split_whitespace().collect();
-                    if let Some(ssrc) = fields.first() {
-                        ssrcs.insert(*ssrc);
-                    }
+            if attr.key == ATTR_KEY_SSRC
+                && let Some(value) = &attr.value
+            {
+                let fields: Vec<&str> = value.split_whitespace().collect();
+                if let Some(ssrc) = fields.first() {
+                    ssrcs.insert(*ssrc);
                 }
             }
         }

--- a/crates/webrtc/rvoip-rtc/src/peer_connection/internal.rs
+++ b/crates/webrtc/rvoip-rtc/src/peer_connection/internal.rs
@@ -987,12 +987,11 @@ where
                                 }
                             }
                         }
-                        RTCSdpType::Answer => {
+                        RTCSdpType::Answer
                             if m.attribute(transceiver.direction().to_string().as_str())
-                                .is_none()
-                            {
-                                return true;
-                            }
+                                .is_none() =>
+                        {
+                            return true;
                         }
                         _ => {}
                     };

--- a/crates/webrtc/rvoip-rtc/src/peer_connection/state/signaling_state.rs
+++ b/crates/webrtc/rvoip-rtc/src/peer_connection/state/signaling_state.rs
@@ -337,32 +337,24 @@ pub(crate) fn check_next_signaling_state(
             if op == StateChangeOp::SetRemote {
                 match sdp_type {
                     // have-local-offer->SetRemote(answer)->stable
-                    RTCSdpType::Answer => {
-                        if next == RTCSignalingState::Stable {
-                            return Ok(next);
-                        }
+                    RTCSdpType::Answer if next == RTCSignalingState::Stable => {
+                        return Ok(next);
                     }
                     // have-local-offer->SetRemote(pranswer)->have-remote-pranswer
-                    RTCSdpType::Pranswer => {
-                        if next == RTCSignalingState::HaveRemotePranswer {
-                            return Ok(next);
-                        }
+                    RTCSdpType::Pranswer if next == RTCSignalingState::HaveRemotePranswer => {
+                        return Ok(next);
                     }
                     _ => {}
                 }
             } else if op == StateChangeOp::SetLocal {
                 match sdp_type {
                     // have-local-offer->SetLocal(offer)->have-local-offer (reoffer)
-                    RTCSdpType::Offer => {
-                        if next == RTCSignalingState::HaveLocalOffer {
-                            return Ok(next);
-                        }
+                    RTCSdpType::Offer if next == RTCSignalingState::HaveLocalOffer => {
+                        return Ok(next);
                     }
                     // have-local-offer->SetLocal(rollback)->stable
-                    RTCSdpType::Rollback => {
-                        if next == RTCSignalingState::Stable {
-                            return Ok(next);
-                        }
+                    RTCSdpType::Rollback if next == RTCSignalingState::Stable => {
+                        return Ok(next);
                     }
                     _ => {}
                 }
@@ -380,16 +372,12 @@ pub(crate) fn check_next_signaling_state(
             if op == StateChangeOp::SetLocal {
                 match sdp_type {
                     // have-remote-offer->SetLocal(answer)->stable
-                    RTCSdpType::Answer => {
-                        if next == RTCSignalingState::Stable {
-                            return Ok(next);
-                        }
+                    RTCSdpType::Answer if next == RTCSignalingState::Stable => {
+                        return Ok(next);
                     }
                     // have-remote-offer->SetLocal(pranswer)->have-local-pranswer
-                    RTCSdpType::Pranswer => {
-                        if next == RTCSignalingState::HaveLocalPranswer {
-                            return Ok(next);
-                        }
+                    RTCSdpType::Pranswer if next == RTCSignalingState::HaveLocalPranswer => {
+                        return Ok(next);
                     }
                     _ => {}
                 }

--- a/crates/webrtc/rvoip-rtc/src/statistics/accumulator/rtp_stream/outbound.rs
+++ b/crates/webrtc/rvoip-rtc/src/statistics/accumulator/rtp_stream/outbound.rs
@@ -536,11 +536,12 @@ mod tests {
 
     #[test]
     fn test_quality_limitation_tracking() {
-        let mut acc = OutboundRtpStreamAccumulator::default();
-
-        acc.quality_limitation_reason = RTCQualityLimitationReason::Bandwidth;
-        acc.quality_limitation_resolution_changes = 3;
-        acc.target_bitrate = 1_500_000.0;
+        let acc = OutboundRtpStreamAccumulator {
+            quality_limitation_reason: RTCQualityLimitationReason::Bandwidth,
+            quality_limitation_resolution_changes: 3,
+            target_bitrate: 1_500_000.0,
+            ..Default::default()
+        };
 
         let now = Instant::now();
         let stats = acc.snapshot(now, "test");

--- a/crates/webrtc/rvoip-rtc/src/statistics/accumulator/transport.rs
+++ b/crates/webrtc/rvoip-rtc/src/statistics/accumulator/transport.rs
@@ -326,8 +326,10 @@ mod tests {
 
     #[test]
     fn test_snapshot() {
-        let mut acc = TransportStatsAccumulator::default();
-        acc.transport_id = "RTCTransport_0".to_string();
+        let mut acc = TransportStatsAccumulator {
+            transport_id: "RTCTransport_0".to_string(),
+            ..Default::default()
+        };
         acc.on_packet_sent(100);
         acc.on_packet_received(80);
         acc.on_ice_state_changed(RTCIceTransportState::Connected);

--- a/crates/webrtc/rvoip-rtc/tests/data_channels_close_by_rtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/data_channels_close_by_rtc_interop.rs
@@ -269,23 +269,23 @@ async fn test_data_channel_close_interop() -> Result<()> {
         // Send periodic messages from RTC side
         if rtc_connected && webrtc_connected && rtc_data_channel_opened {
             let elapsed = Instant::now().duration_since(last_message_time);
-            if elapsed >= message_interval {
-                if let Some(dc_id) = &rtc_dc_id {
-                    let mut dc = rtc_pc
-                        .data_channel(*dc_id)
-                        .expect("data channel should exist");
+            if elapsed >= message_interval
+                && let Some(dc_id) = &rtc_dc_id
+            {
+                let mut dc = rtc_pc
+                    .data_channel(*dc_id)
+                    .expect("data channel should exist");
 
-                    if messages_to_send > 0 {
-                        let message = format!("Message #{}", 4 - messages_to_send);
-                        log::info!("RTC sending: '{}'", message);
-                        dc.send_text(message)?;
-                        last_message_time = Instant::now();
+                if messages_to_send > 0 {
+                    let message = format!("Message #{}", 4 - messages_to_send);
+                    log::info!("RTC sending: '{}'", message);
+                    dc.send_text(message)?;
+                    last_message_time = Instant::now();
 
-                        messages_to_send -= 1;
-                    } else {
-                        log::info!("RTC finished sending messages, exiting to close connection");
-                        dc.close()?;
-                    }
+                    messages_to_send -= 1;
+                } else {
+                    log::info!("RTC finished sending messages, exiting to close connection");
+                    dc.close()?;
                 }
             }
         }

--- a/crates/webrtc/rvoip-rtc/tests/data_channels_create_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/data_channels_create_interop.rs
@@ -231,20 +231,17 @@ async fn test_data_channel_create_rtc_to_webrtc() -> Result<()> {
                 }
                 RTCPeerConnectionEvent::OnDataChannel(dc_event) => {
                     log::info!("RTC data channel event: {:?}", dc_event);
-                    match dc_event {
-                        RTCDataChannelEvent::OnOpen(channel_id) => {
-                            let dc = rtc_pc
-                                .data_channel(channel_id)
-                                .expect("data channel should exist");
-                            log::info!(
-                                "RTC data channel opened: {} (id: {})",
-                                dc.label(),
-                                channel_id
-                            );
-                            rtc_data_channel_opened = true;
-                            rtc_dc_id = Some(channel_id);
-                        }
-                        _ => {}
+                    if let RTCDataChannelEvent::OnOpen(channel_id) = dc_event {
+                        let dc = rtc_pc
+                            .data_channel(channel_id)
+                            .expect("data channel should exist");
+                        log::info!(
+                            "RTC data channel opened: {} (id: {})",
+                            dc.label(),
+                            channel_id
+                        );
+                        rtc_data_channel_opened = true;
+                        rtc_dc_id = Some(channel_id);
                     }
                 }
                 _ => {}

--- a/crates/webrtc/rvoip-rtc/tests/data_channels_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/data_channels_interop.rs
@@ -213,19 +213,16 @@ async fn test_data_channel_rtc_to_webrtc() -> Result<()> {
                 }
                 RTCPeerConnectionEvent::OnDataChannel(dc_event) => {
                     log::info!("RTC data channel event: {:?}", dc_event);
-                    match dc_event {
-                        RTCDataChannelEvent::OnOpen(channel_id) => {
-                            let dc = rtc_pc
-                                .data_channel(channel_id)
-                                .expect("data channel should exist");
-                            log::info!(
-                                "RTC data channel opened: {} (id: {})",
-                                dc.label(),
-                                channel_id
-                            );
-                            data_channel_opened = true;
-                        }
-                        _ => {}
+                    if let RTCDataChannelEvent::OnOpen(channel_id) = dc_event {
+                        let dc = rtc_pc
+                            .data_channel(channel_id)
+                            .expect("data channel should exist");
+                        log::info!(
+                            "RTC data channel opened: {} (id: {})",
+                            dc.label(),
+                            channel_id
+                        );
+                        data_channel_opened = true;
                     }
                 }
                 _ => {}

--- a/crates/webrtc/rvoip-rtc/tests/ice_candidate_events_test.rs
+++ b/crates/webrtc/rvoip-rtc/tests/ice_candidate_events_test.rs
@@ -138,8 +138,7 @@ fn test_multiple_candidates_events() {
         .expect("Failed to create peer connection");
 
     // Add multiple candidates
-    let candidates = vec![
-        RTCIceCandidateInit {
+    let candidates = [RTCIceCandidateInit {
             candidate: "candidate:1 1 udp 2130706431 192.168.1.100 54321 typ host".to_string(),
             sdp_mid: Some("0".to_string()),
             sdp_mline_index: Some(0),
@@ -152,8 +151,7 @@ fn test_multiple_candidates_events() {
             sdp_mline_index: Some(0),
             username_fragment: Some("test".to_string()),
             url: Some("stun:stun.example.com:3478".to_string()),
-        },
-    ];
+        }];
 
     println!("🔍 Adding {} candidates", candidates.len());
     for (i, candidate) in candidates.iter().enumerate() {

--- a/crates/webrtc/rvoip-rtc/tests/ice_restart_by_rtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/ice_restart_by_rtc_interop.rs
@@ -253,14 +253,13 @@ async fn test_ice_restart_by_rtc_interop() -> Result<()> {
                 }
                 Ok(Command::SendMessage(msg)) => {
                     log::info!("RTC: Sending message: {}", msg);
-                    if let Some(channel_id) = dc_id {
-                        if let Some(mut dc) = rtc_pc.data_channel(channel_id) {
-                            if let Err(e) = dc.send_text(msg) {
-                                resp_tx
-                                    .send(Response::Error(format!("Failed to send message: {}", e)))
-                                    .ok();
-                            }
-                        }
+                    if let Some(channel_id) = dc_id
+                        && let Some(mut dc) = rtc_pc.data_channel(channel_id)
+                        && let Err(e) = dc.send_text(msg)
+                    {
+                        resp_tx
+                            .send(Response::Error(format!("Failed to send message: {}", e)))
+                            .ok();
                     }
                 }
                 Ok(Command::RestartIce) => {
@@ -453,14 +452,13 @@ async fn test_ice_restart_by_rtc_interop() -> Result<()> {
                             resp_tx.send(Response::Connected).ok();
                         }
                     }
-                    RTCPeerConnectionEvent::OnDataChannel(dc_event) => match dc_event {
-                        RTCDataChannelEvent::OnOpen(data_channel_id) => {
-                            log::info!("RTC: Data channel {} opened", data_channel_id);
-                            dc_id = Some(data_channel_id);
-                            resp_tx.send(Response::DataChannelOpen).ok();
-                        }
-                        _ => {}
-                    },
+                    RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(
+                        data_channel_id,
+                    )) => {
+                        log::info!("RTC: Data channel {} opened", data_channel_id);
+                        dc_id = Some(data_channel_id);
+                        resp_tx.send(Response::DataChannelOpen).ok();
+                    }
                     _ => {}
                 }
             }
@@ -571,11 +569,11 @@ async fn test_ice_restart_by_rtc_interop() -> Result<()> {
     // Wait for message to be received
     let deadline = Instant::now() + DEFAULT_TIMEOUT_DURATION;
     loop {
-        if let Some(msg) = webrtc_message_received.lock().await.as_ref() {
-            if msg == TEST_MESSAGE {
-                log::info!("Initial message received: {}", msg);
-                break;
-            }
+        if let Some(msg) = webrtc_message_received.lock().await.as_ref()
+            && msg == TEST_MESSAGE
+        {
+            log::info!("Initial message received: {}", msg);
+            break;
         }
         if Instant::now() > deadline {
             anyhow::bail!("Timeout waiting for initial message");
@@ -660,11 +658,11 @@ async fn test_ice_restart_by_rtc_interop() -> Result<()> {
     // Wait for message to be received
     let deadline = Instant::now() + DEFAULT_TIMEOUT_DURATION;
     loop {
-        if let Some(msg) = webrtc_message_received.lock().await.as_ref() {
-            if msg == TEST_MESSAGE_AFTER_RESTART {
-                log::info!("Message received after ICE restart: {}", msg);
-                break;
-            }
+        if let Some(msg) = webrtc_message_received.lock().await.as_ref()
+            && msg == TEST_MESSAGE_AFTER_RESTART
+        {
+            log::info!("Message received after ICE restart: {}", msg);
+            break;
         }
         if Instant::now() > deadline {
             anyhow::bail!("Timeout waiting for message after ICE restart");

--- a/crates/webrtc/rvoip-rtc/tests/ice_restart_by_webrtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/ice_restart_by_webrtc_interop.rs
@@ -240,15 +240,14 @@ async fn test_ice_restart_interop() -> Result<()> {
                         rtc_connected = true;
                     }
                 }
-                RTCPeerConnectionEvent::OnDataChannel(dc_event) => match dc_event {
-                    RTCDataChannelEvent::OnOpen(channel_id) => {
-                        if let Some(dc) = rtc_pc.data_channel(channel_id) {
-                            log::info!("RTC data channel '{}'-'{}' opened", dc.label(), dc.id());
-                            rtc_dc_id = Some(channel_id);
-                        }
+                RTCPeerConnectionEvent::OnDataChannel(dc_event) => {
+                    if let RTCDataChannelEvent::OnOpen(channel_id) = dc_event
+                        && let Some(dc) = rtc_pc.data_channel(channel_id)
+                    {
+                        log::info!("RTC data channel '{}'-'{}' opened", dc.label(), dc.id());
+                        rtc_dc_id = Some(channel_id);
                     }
-                    _ => {}
-                },
+                }
                 _ => {}
             }
         }
@@ -329,11 +328,10 @@ async fn test_ice_restart_interop() -> Result<()> {
         while let Some(event) = rtc_pc.poll_event() {
             if let RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) =
                 event
+                && let Some(dc) = rtc_pc.data_channel(channel_id)
             {
-                if let Some(dc) = rtc_pc.data_channel(channel_id) {
-                    log::info!("RTC data channel '{}'-'{}' opened", dc.label(), dc.id());
-                    rtc_dc_id = Some(channel_id);
-                }
+                log::info!("RTC data channel '{}'-'{}' opened", dc.label(), dc.id());
+                rtc_dc_id = Some(channel_id);
             }
         }
 
@@ -419,11 +417,11 @@ async fn test_ice_restart_interop() -> Result<()> {
     }
 
     // Send from rtc to webrtc
-    if let Some(channel_id) = rtc_dc_id {
-        if let Some(mut dc) = rtc_pc.data_channel(channel_id) {
-            dc.send_text(ECHO_MESSAGE_1.to_owned())?;
-            log::info!("RTC sent: {}", ECHO_MESSAGE_1);
-        }
+    if let Some(channel_id) = rtc_dc_id
+        && let Some(mut dc) = rtc_pc.data_channel(channel_id)
+    {
+        dc.send_text(ECHO_MESSAGE_1.to_owned())?;
+        log::info!("RTC sent: {}", ECHO_MESSAGE_1);
     }
 
     // Process echo
@@ -533,9 +531,7 @@ async fn test_ice_restart_interop() -> Result<()> {
                         rtc_connected = true;
                     }
                 }
-                RTCPeerConnectionEvent::OnDataChannel(dc_event) => match dc_event {
-                    _ => {}
-                },
+                RTCPeerConnectionEvent::OnDataChannel(_dc_event) => {}
                 _ => {}
             }
         }
@@ -654,11 +650,11 @@ async fn test_ice_restart_interop() -> Result<()> {
     }
 
     // Send from rtc to webrtc
-    if let Some(channel_id) = rtc_dc_id {
-        if let Some(mut dc) = rtc_pc.data_channel(channel_id) {
-            dc.send_text(ECHO_MESSAGE_2.to_owned())?;
-            log::info!("RTC sent after restart: {}", ECHO_MESSAGE_2);
-        }
+    if let Some(channel_id) = rtc_dc_id
+        && let Some(mut dc) = rtc_pc.data_channel(channel_id)
+    {
+        dc.send_text(ECHO_MESSAGE_2.to_owned())?;
+        log::info!("RTC sent after restart: {}", ECHO_MESSAGE_2);
     }
 
     // Process echo

--- a/crates/webrtc/rvoip-rtc/tests/interceptor_rtcp_reports_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/interceptor_rtcp_reports_interop.rs
@@ -80,7 +80,6 @@ async fn test_custom_interceptor_registry_with_rtcp_reports() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -248,11 +247,9 @@ async fn test_custom_interceptor_registry_with_rtcp_reports() -> Result<()> {
                         log::info!("✅ RTC peer connected!");
                     }
                 }
-                RTCPeerConnectionEvent::OnTrack(track_event) => {
-                    if let RTCTrackEvent::OnOpen(init) = track_event {
-                        log::info!("RTC got track opened: {}", init.track_id);
-                        track_id2_receiver_id.insert(init.track_id, init.receiver_id);
-                    }
+                RTCPeerConnectionEvent::OnTrack(RTCTrackEvent::OnOpen(init)) => {
+                    log::info!("RTC got track opened: {}", init.track_id);
+                    track_id2_receiver_id.insert(init.track_id, init.receiver_id);
                 }
                 _ => {}
             }
@@ -399,7 +396,6 @@ async fn test_sender_report_generation_on_rtp_send() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -530,11 +526,11 @@ async fn test_sender_report_generation_on_rtp_send() -> Result<()> {
 
         // Process events
         while let Some(event) = rtc_pc.poll_event() {
-            if let RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) = event {
-                if state == RTCPeerConnectionState::Connected {
-                    rtc_connected = true;
-                    log::info!("✅ RTC peer connected!");
-                }
+            if let RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) = event
+                && state == RTCPeerConnectionState::Connected
+            {
+                rtc_connected = true;
+                log::info!("✅ RTC peer connected!");
             }
         }
 
@@ -675,7 +671,6 @@ async fn test_register_default_interceptors_helper() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -806,11 +801,11 @@ async fn test_register_default_interceptors_helper() -> Result<()> {
         }
 
         while let Some(event) = rtc_pc.poll_event() {
-            if let RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) = event {
-                if state == RTCPeerConnectionState::Connected {
-                    rtc_connected = true;
-                    log::info!("✅ RTC peer connected!");
-                }
+            if let RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) = event
+                && state == RTCPeerConnectionState::Connected
+            {
+                rtc_connected = true;
+                log::info!("✅ RTC peer connected!");
             }
         }
 

--- a/crates/webrtc/rvoip-rtc/tests/media_rejection_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/media_rejection_interop.rs
@@ -333,7 +333,7 @@ async fn test_video_only_webrtc_offerer_rtc_answerer() -> Result<()> {
         while let Some(message) = rtc_pc.poll_read() {
             if let RTCMessage::RtpPacket(_track_id, rtp_packet) = message {
                 video_packets_received += 1;
-                if video_packets_received == 1 || video_packets_received % 10 == 0 {
+                if video_packets_received == 1 || video_packets_received.is_multiple_of(10) {
                     log::info!(
                         "RTC received RTP packet #{} (seq: {}, ssrc: {})",
                         video_packets_received,

--- a/crates/webrtc/rvoip-rtc/tests/offer_answer_rtc2rtc.rs
+++ b/crates/webrtc/rvoip-rtc/tests/offer_answer_rtc2rtc.rs
@@ -215,13 +215,10 @@ async fn test_offer_answer_rtc_to_rtc() -> Result<()> {
                         offer_connected = true;
                     }
                 }
-                RTCPeerConnectionEvent::OnDataChannel(dc_event) => match dc_event {
-                    RTCDataChannelEvent::OnOpen(channel_id) => {
-                        log::info!("Offer data channel {} opened", channel_id);
-                        offer_dc_id = Some(channel_id);
-                    }
-                    _ => {}
-                },
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
+                    log::info!("Offer data channel {} opened", channel_id);
+                    offer_dc_id = Some(channel_id);
+                }
                 _ => {}
             }
         }
@@ -272,12 +269,9 @@ async fn test_offer_answer_rtc_to_rtc() -> Result<()> {
                         answer_connected = true;
                     }
                 }
-                RTCPeerConnectionEvent::OnDataChannel(dc_event) => match dc_event {
-                    RTCDataChannelEvent::OnOpen(channel_id) => {
-                        log::info!("Answer data channel {} opened", channel_id);
-                    }
-                    _ => {}
-                },
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
+                    log::info!("Answer data channel {} opened", channel_id);
+                }
                 _ => {}
             }
         }
@@ -293,30 +287,30 @@ async fn test_offer_answer_rtc_to_rtc() -> Result<()> {
                     msgs.push(msg_str.clone());
 
                     // Echo back
-                    if !echo_sent {
-                        if let Some(mut dc) = answer_pc.data_channel(channel_id) {
-                            log::info!("Answer echoing: '{}'", ECHO_MESSAGE);
-                            dc.send_text(ECHO_MESSAGE.to_string())?;
-                            echo_sent = true;
-                        }
+                    if !echo_sent && let Some(mut dc) = answer_pc.data_channel(channel_id) {
+                        log::info!("Answer echoing: '{}'", ECHO_MESSAGE);
+                        dc.send_text(ECHO_MESSAGE.to_string())?;
+                        echo_sent = true;
                     }
                 }
             }
         }
 
         // Send test message from offer once connected
-        if offer_connected && offer_dc_id.is_some() && !message_sent {
-            if let Some(mut dc) = offer_pc.data_channel(offer_dc_id.unwrap()) {
-                log::info!("Offer sending message: '{}'", TEST_MESSAGE);
-                dc.send_text(TEST_MESSAGE.to_string())?;
-                message_sent = true;
-            }
+        if offer_connected
+            && offer_dc_id.is_some()
+            && !message_sent
+            && let Some(mut dc) = offer_pc.data_channel(offer_dc_id.unwrap())
+        {
+            log::info!("Offer sending message: '{}'", TEST_MESSAGE);
+            dc.send_text(TEST_MESSAGE.to_string())?;
+            message_sent = true;
         }
 
         // Check if test is complete
         let offer_msgs = offer_received_messages.lock().await;
         let answer_msgs = answer_received_messages.lock().await;
-        if offer_msgs.len() >= 1 && answer_msgs.len() >= 1 {
+        if !offer_msgs.is_empty() && !answer_msgs.is_empty() {
             log::info!("Test complete - both peers received messages");
             break;
         }

--- a/crates/webrtc/rvoip-rtc/tests/one_media_section_rtc_to_rtc_simulcast.rs
+++ b/crates/webrtc/rvoip-rtc/tests/one_media_section_rtc_to_rtc_simulcast.rs
@@ -69,7 +69,6 @@ async fn test_one_media_section_rtc_to_rtc_simulcast() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     answerer_media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -204,9 +203,9 @@ async fn test_one_media_section_rtc_to_rtc_simulcast() -> Result<()> {
     }
 
     let output_track = MediaStreamTrack::new(
-        format!("rtc-rs_simulcast"),
-        format!("video_simulcast"),
-        format!("video_simulcast"),
+        "rtc-rs_simulcast".to_string(),
+        "video_simulcast".to_string(),
+        "video_simulcast".to_string(),
         RtpCodecKind::Video,
         codings,
     );
@@ -365,10 +364,9 @@ async fn test_one_media_section_rtc_to_rtc_simulcast() -> Result<()> {
             match message {
                 RTCMessage::RtpPacket(track_id, rtp_packet) => {
                     // Get the receiver for this track
-                    let receiver_id = track_id2_receiver_id
+                    let receiver_id = *track_id2_receiver_id
                         .get(&track_id)
-                        .ok_or(Error::ErrRTPReceiverNotExisted)?
-                        .clone();
+                        .ok_or(Error::ErrRTPReceiverNotExisted)?;
 
                     let rtp_receiver = answerer_pc
                         .rtp_receiver(receiver_id)

--- a/crates/webrtc/rvoip-rtc/tests/one_media_section_rtc_to_rtc_unicast.rs
+++ b/crates/webrtc/rvoip-rtc/tests/one_media_section_rtc_to_rtc_unicast.rs
@@ -68,7 +68,6 @@ async fn test_one_media_section_rtc_to_rtc_unicast() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     answerer_media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -146,9 +145,9 @@ async fn test_one_media_section_rtc_to_rtc_unicast() -> Result<()> {
     log::info!("✅ Offerer added track with SSRC: {}", ssrc);
 
     let output_track = MediaStreamTrack::new(
-        format!("rtc-rs_unicast"),
-        format!("video_unicast"),
-        format!("video_unicast"),
+        "rtc-rs_unicast".to_string(),
+        "video_unicast".to_string(),
+        "video_unicast".to_string(),
         RtpCodecKind::Video,
         codings,
     );
@@ -307,10 +306,9 @@ async fn test_one_media_section_rtc_to_rtc_unicast() -> Result<()> {
             match message {
                 RTCMessage::RtpPacket(track_id, rtp_packet) => {
                     // Get the receiver for this track
-                    let receiver_id = track_id2_receiver_id
+                    let receiver_id = *track_id2_receiver_id
                         .get(&track_id)
-                        .ok_or(Error::ErrRTPReceiverNotExisted)?
-                        .clone();
+                        .ok_or(Error::ErrRTPReceiverNotExisted)?;
 
                     let rtp_receiver = answerer_pc
                         .rtp_receiver(receiver_id)

--- a/crates/webrtc/rvoip-rtc/tests/play_from_disk_rtc_set_remote_before_add_track_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/play_from_disk_rtc_set_remote_before_add_track_interop.rs
@@ -197,7 +197,6 @@ async fn test_play_from_disk_rtc_set_remote_before_add_track() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 120,
-        ..Default::default()
     };
 
     let video_codec = RTCRtpCodecParameters {
@@ -209,7 +208,6 @@ async fn test_play_from_disk_rtc_set_remote_before_add_track() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(audio_codec.clone(), RtpCodecKind::Audio)?;

--- a/crates/webrtc/rvoip-rtc/tests/play_from_disk_vpx_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/play_from_disk_vpx_interop.rs
@@ -197,7 +197,6 @@ async fn test_play_from_disk_vpx_rtc_to_webrtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 120,
-        ..Default::default()
     };
 
     let video_codec = RTCRtpCodecParameters {
@@ -209,7 +208,6 @@ async fn test_play_from_disk_vpx_rtc_to_webrtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(audio_codec.clone(), RtpCodecKind::Audio)?;

--- a/crates/webrtc/rvoip-rtc/tests/reflect_rtc_to_webrtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/reflect_rtc_to_webrtc_interop.rs
@@ -89,7 +89,6 @@ async fn test_reflect_rtc_to_webrtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;

--- a/crates/webrtc/rvoip-rtc/tests/reflect_webrtc_to_rtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/reflect_webrtc_to_rtc_interop.rs
@@ -157,7 +157,6 @@ async fn test_reflect_webrtc_to_rtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -297,10 +296,9 @@ async fn test_reflect_webrtc_to_rtc() -> Result<()> {
         while let Some(message) = rtc_pc.poll_read() {
             match message {
                 RTCMessage::RtpPacket(track_id, mut rtp_packet) => {
-                    let receiver_id = track_id2_receiver_id
+                    let receiver_id = *track_id2_receiver_id
                         .get(&track_id)
-                        .ok_or(Error::ErrRTPReceiverNotExisted)?
-                        .clone();
+                        .ok_or(Error::ErrRTPReceiverNotExisted)?;
                     let rtp_receiver = rtc_pc
                         .rtp_receiver(receiver_id)
                         .ok_or(Error::ErrRTPReceiverNotExisted)?;

--- a/crates/webrtc/rvoip-rtc/tests/save_to_disk_vpx_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/save_to_disk_vpx_interop.rs
@@ -151,7 +151,6 @@ async fn test_save_to_disk_vpx_webrtc_to_rtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 111,
-        ..Default::default()
     };
 
     let video_codec = RTCRtpCodecParameters {
@@ -163,7 +162,6 @@ async fn test_save_to_disk_vpx_webrtc_to_rtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(audio_codec.clone(), RtpCodecKind::Audio)?;
@@ -370,9 +368,11 @@ async fn test_save_to_disk_vpx_webrtc_to_rtc() -> Result<()> {
 
                         // Record the track kind for this receiver on first packet
                         let mut kind_map = receiver_id_to_kind.lock().await;
-                        if !kind_map.contains_key(&receiver_id) {
+                        if let std::collections::hash_map::Entry::Vacant(e) =
+                            kind_map.entry(receiver_id)
+                        {
                             let kind = track.kind();
-                            kind_map.insert(receiver_id, kind);
+                            e.insert(kind);
 
                             let codec = track
                                 .codec(
@@ -395,13 +395,13 @@ async fn test_save_to_disk_vpx_webrtc_to_rtc() -> Result<()> {
                         match kind_map.get(&receiver_id) {
                             Some(RtpCodecKind::Audio) => {
                                 audio_received += 1;
-                                if audio_received % 10 == 0 {
+                                if audio_received.is_multiple_of(10) {
                                     log::info!("RTC received audio RTP packet #{}", audio_received);
                                 }
                             }
                             Some(RtpCodecKind::Video) => {
                                 video_received += 1;
-                                if video_received % 10 == 0 {
+                                if video_received.is_multiple_of(10) {
                                     log::info!("RTC received video RTP packet #{}", video_received);
                                 }
                             }

--- a/crates/webrtc/rvoip-rtc/tests/simulcast_rtc_to_rtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/simulcast_rtc_to_rtc_interop.rs
@@ -72,7 +72,6 @@ async fn test_simulcast_rtc_to_rtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     let audio_codec = RTCRtpCodecParameters {
@@ -84,7 +83,6 @@ async fn test_simulcast_rtc_to_rtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 120,
-        ..Default::default()
     };
 
     answerer_media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -221,9 +219,9 @@ async fn test_simulcast_rtc_to_rtc() -> Result<()> {
     }
 
     let output_track = MediaStreamTrack::new(
-        format!("rtc-rs_simulcast"),
-        format!("video_simulcast"),
-        format!("video_simulcast"),
+        "rtc-rs_simulcast".to_string(),
+        "video_simulcast".to_string(),
+        "video_simulcast".to_string(),
         RtpCodecKind::Video,
         codings,
     );
@@ -390,10 +388,9 @@ async fn test_simulcast_rtc_to_rtc() -> Result<()> {
             match message {
                 RTCMessage::RtpPacket(track_id, rtp_packet) => {
                     // Get the receiver for this track
-                    let receiver_id = track_id2_receiver_id
+                    let receiver_id = *track_id2_receiver_id
                         .get(&track_id)
-                        .ok_or(Error::ErrRTPReceiverNotExisted)?
-                        .clone();
+                        .ok_or(Error::ErrRTPReceiverNotExisted)?;
 
                     let rtp_receiver = answerer_pc
                         .rtp_receiver(receiver_id)

--- a/crates/webrtc/rvoip-rtc/tests/simulcast_rtc_to_webrtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/simulcast_rtc_to_webrtc_interop.rs
@@ -150,7 +150,6 @@ async fn test_simulcast_rtc_to_webrtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     let audio_codec = RTCRtpCodecParameters {
@@ -162,7 +161,6 @@ async fn test_simulcast_rtc_to_webrtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 120,
-        ..Default::default()
     };
 
     media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -227,9 +225,9 @@ async fn test_simulcast_rtc_to_webrtc() -> Result<()> {
     }
 
     let output_track = MediaStreamTrack::new(
-        format!("webrtc-rs_simulcast"),
-        format!("video_simulcast"),
-        format!("video_simulcast"),
+        "webrtc-rs_simulcast".to_string(),
+        "video_simulcast".to_string(),
+        "video_simulcast".to_string(),
         RtpCodecKind::Video,
         codings,
     );

--- a/crates/webrtc/rvoip-rtc/tests/simulcast_webrtc_to_rtc_interop.rs
+++ b/crates/webrtc/rvoip-rtc/tests/simulcast_webrtc_to_rtc_interop.rs
@@ -211,7 +211,6 @@ async fn test_simulcast_webrtc_to_rtc() -> Result<()> {
             rtcp_feedback: vec![],
         },
         payload_type: 96,
-        ..Default::default()
     };
 
     media_engine.register_codec(video_codec.clone(), RtpCodecKind::Video)?;
@@ -465,10 +464,9 @@ async fn test_simulcast_webrtc_to_rtc() -> Result<()> {
             match message {
                 RTCMessage::RtpPacket(track_id, rtp_packet) => {
                     // Get the receiver for this track
-                    let receiver_id = track_id2_receiver_id
+                    let receiver_id = *track_id2_receiver_id
                         .get(&track_id)
-                        .ok_or(Error::ErrRTPReceiverNotExisted)?
-                        .clone();
+                        .ok_or(Error::ErrRTPReceiverNotExisted)?;
 
                     let rtp_receiver = rtc_pc
                         .rtp_receiver(receiver_id)

--- a/crates/webrtc/rvoip-rtc/tests/statistics_rtc_to_rtc.rs
+++ b/crates/webrtc/rvoip-rtc/tests/statistics_rtc_to_rtc.rs
@@ -185,10 +185,10 @@ async fn test_data_channel_statistics_collection() -> Result<()> {
         // Process offer peer events
         while let Some(event) = runner.offer_pc.poll_event() {
             match event {
-                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) => {
-                    if state == RTCPeerConnectionState::Connected {
-                        offer_connected = true;
-                    }
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => {
+                    offer_connected = true;
                 }
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
                     offer_dc_id = Some(channel_id);
@@ -215,10 +215,10 @@ async fn test_data_channel_statistics_collection() -> Result<()> {
         // Process answer peer events
         while let Some(event) = runner.answer_pc.poll_event() {
             match event {
-                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) => {
-                    if state == RTCPeerConnectionState::Connected {
-                        answer_connected = true;
-                    }
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => {
+                    answer_connected = true;
                 }
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
                     _answer_dc_id = Some(channel_id);
@@ -235,12 +235,14 @@ async fn test_data_channel_statistics_collection() -> Result<()> {
         }
 
         // Send messages from offer once connected
-        if offer_connected && offer_dc_id.is_some() && offer_messages_sent < messages_to_send {
-            if let Some(mut dc) = runner.offer_pc.data_channel(offer_dc_id.unwrap()) {
-                let msg = "x".repeat(message_size);
-                dc.send_text(msg)?;
-                offer_messages_sent += 1;
-            }
+        if offer_connected
+            && offer_dc_id.is_some()
+            && offer_messages_sent < messages_to_send
+            && let Some(mut dc) = runner.offer_pc.data_channel(offer_dc_id.unwrap())
+        {
+            let msg = "x".repeat(message_size);
+            dc.send_text(msg)?;
+            offer_messages_sent += 1;
         }
 
         // Check if test is complete


### PR DESCRIPTION
## Summary

- clear Rust 1.95 strict Clippy findings across rvoip-rtc production code and integration tests
- keep changes behavior-equivalent: pattern simplification, explicit initialization, and removal of redundant operations
- isolate this release-gate cleanup from the Chromium negotiation repair

## Validation

- `cargo clippy -p rvoip-rtc --all-targets --all-features --no-deps --locked -- -D warnings`
- `cargo test -p rvoip-rtc --all-features --locked`
- 168 library tests passed
- full RTC integration suite passed
- 248 doc tests passed; 16 intentionally ignored
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors are mechanical lint fixes with full test/clippy validation; no new features or negotiation logic changes.
> 
> **Overview**
> Clears **strict Clippy** warnings across `rvoip-rtc` with **no intended behavior change**—style and idioms only, separate from negotiation fixes.
> 
> **Production code** refactors nested `if`/`match` into **`let`-chains** and **match guards** (e.g. SSRC extraction in SDP semantics, answer SDP checks in `internal.rs`, signaling transitions in `signaling_state.rs`).
> 
> **Tests** apply the same patterns in interop loops (data channels, ICE restart, offer/answer), drop redundant `..Default::default()` on fully specified codec structs, use **`is_multiple_of`**, **`HashMap::Entry::Vacant`**, and small cleanups (`format!` → `to_string`, deref instead of clone, `!vec.is_empty()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9cc5e0206f78f7e63795ffa4a34d770483350c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->