### PR TITLE
release: prepare rvoip 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@
 
 No changes yet.
 
+## 0.3.5 — 2026-07-30
+
+This coordinated 44-crate patch release hardens security and media state,
+completes transactional SIP renegotiation, exposes symmetric-RTP NAT policy on
+the high-level APIs, and makes Tokio the sole WebRTC runtime.
+
+### Security and media
+
+- Fail closed for placeholder AES-GCM profiles and unsupported DTLS
+  construction; incomplete profiles cannot be advertised or negotiated.
+- Correct RTP padding and RFC 8285 extensions, RTCP LSR/compound parsing, and
+  loss/jitter accounting across rollover, gaps, duplicates, and reordering.
+- Separate inbound/outbound and per-SSRC SRTP/SRTCP state, authenticate before
+  committing replay state, and cover the result with RFC vectors and pinned
+  libSRTP interoperability.
+- Generate directional SDES answer keys and accept safely unpadded AES-256 key
+  material in compatible mode with secret-safe diagnostics (issue #46).
+
+### SIP, codecs, and WebRTC
+
+- Make hold/resume, re-INVITE, UPDATE, delayed offers, authentication retries,
+  retransmissions, rollback, and media application transactional and
+  exact-generation owned.
+- Expose `SipNatConfig` and `SymmetricRtpPolicy` through `EndpointBuilder` and
+  `StreamPeerBuilder` (issue #50).
+- Use the real Opus backend, make codec names ASCII case-insensitive, and stop
+  advertising unavailable Opus or G.722 implementations.
+- Remove Smol/async-std runtime support from WebRTC and correct the confirmed
+  Chromium audio/SSRC/simulcast SDP regression.
+- Preserve bounded, sharded, keyed/no-scan SIP lifecycle paths and make the
+  registrar and coordinated workspace pass strict release linting.
+
+### Qualification
+
+`0.3.5` requires a fresh, source-bound strict full-beta PASS. Historical
+`0.3.2` exception and `0.3.4` carry-forward evidence do not qualify it.
+
 ## 0.3.4 — 2026-07-29
 
 This coordinated 44-crate patch release adds exact inbound-admission terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-No changes yet.
-
 ## 0.3.5 — 2026-07-30
 
 This coordinated 44-crate patch release hardens security and media state,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -6667,7 +6667,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-amazon-connect"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6700,7 +6700,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-audio-device"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "cpal",
@@ -6711,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-audit"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6725,7 +6725,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-auth-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6756,7 +6756,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-client"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6778,7 +6778,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-codec-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "criterion",
  "opus",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6823,7 +6823,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core-traits"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6839,7 +6839,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-harness"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-identity"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "rvoip-core",
@@ -6858,7 +6858,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-ims-aka"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aes",
  "async-trait",
@@ -6877,7 +6877,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-infra-common"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-keycloak"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -6919,7 +6919,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-ldap"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "ldap3",
@@ -6931,7 +6931,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-media-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "apodize",
@@ -6965,7 +6965,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-native"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-relay"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-transport"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "bytes",
  "futures",
@@ -7069,7 +7069,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-oidc"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-quic"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7108,7 +7108,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-redis"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7124,7 +7124,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtc"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtp-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7200,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-saml"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7215,7 +7215,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-scim"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -7234,7 +7234,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7301,7 +7301,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7320,7 +7320,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-dialog"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7347,7 +7347,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-proxy"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -7364,7 +7364,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-registrar"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7385,7 +7385,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-transport"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7417,7 +7417,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-stir-shaken"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-uctp"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7481,7 +7481,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-users-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7523,7 +7523,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vapi"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -7548,7 +7548,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7569,7 +7569,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon-postgres"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7586,7 +7586,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webauthn"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -7603,7 +7603,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -7657,7 +7657,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc-stack"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7678,7 +7678,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-websocket"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webtransport"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ default-members = [
 [workspace.package]
 # Every publishable workspace crate ships at this one version. Feature-level
 # maturity and non-claims remain documented independently of package SemVer.
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/eisenzopf/rvoip"
@@ -213,55 +213,55 @@ collapsible_else_if = "allow"
 # the in-repo directory changed. See the grouped [workspace] members above.
 # All publishable workspace crates and internal registry requirements move
 # together in one dependency-ordered release.
-rvoip-sip-core      = { path = "crates/sip/sip-core", version = "0.3.4" }
-rvoip-sip-transport = { path = "crates/sip/sip-transport", version = "0.3.4" }
-rvoip-sip-dialog    = { path = "crates/sip/sip-dialog", version = "0.3.4" }
-rvoip-sip-proxy     = { path = "crates/sip/sip-proxy", version = "0.3.4" }
-rvoip-sip-registrar = { path = "crates/sip/sip-registrar", version = "0.3.4" }
-rvoip-rtp-core      = { path = "crates/media/rtp-core", version = "0.3.4" }
-rvoip-media-core    = { path = "crates/media/media-core", version = "0.3.4" }
-rvoip-sip           = { path = "crates/sip/rvoip-sip", version = "0.3.4" }
-rvoip-core          = { path = "crates/foundation/rvoip-core", version = "0.3.4" }
-rvoip-codec-core    = { path = "crates/media/codec-core", version = "0.3.4" }
-rvoip-infra-common  = { path = "crates/foundation/infra-common", version = "0.3.4" }
-rvoip-auth-core     = { path = "crates/identity/auth-core", version = "0.3.4" }
-rvoip-core-traits   = { path = "crates/foundation/rvoip-core-traits", version = "0.3.4" }
-rvoip-users-core    = { path = "crates/identity/users-core", version = "0.3.4" }
+rvoip-sip-core      = { path = "crates/sip/sip-core", version = "0.3.5" }
+rvoip-sip-transport = { path = "crates/sip/sip-transport", version = "0.3.5" }
+rvoip-sip-dialog    = { path = "crates/sip/sip-dialog", version = "0.3.5" }
+rvoip-sip-proxy     = { path = "crates/sip/sip-proxy", version = "0.3.5" }
+rvoip-sip-registrar = { path = "crates/sip/sip-registrar", version = "0.3.5" }
+rvoip-rtp-core      = { path = "crates/media/rtp-core", version = "0.3.5" }
+rvoip-media-core    = { path = "crates/media/media-core", version = "0.3.5" }
+rvoip-sip           = { path = "crates/sip/rvoip-sip", version = "0.3.5" }
+rvoip-core          = { path = "crates/foundation/rvoip-core", version = "0.3.5" }
+rvoip-codec-core    = { path = "crates/media/codec-core", version = "0.3.5" }
+rvoip-infra-common  = { path = "crates/foundation/infra-common", version = "0.3.5" }
+rvoip-auth-core     = { path = "crates/identity/auth-core", version = "0.3.5" }
+rvoip-core-traits   = { path = "crates/foundation/rvoip-core-traits", version = "0.3.5" }
+rvoip-users-core    = { path = "crates/identity/users-core", version = "0.3.5" }
 
 # Optional and top-of-stack crates are part of the same release. Facade and
 # core packages list extension crates such as rvoip-vcon, rvoip-harness, and
 # rvoip-vapi as optional runtime dependencies, so their versions must resolve
 # on crates.io regardless of feature activation.
-rvoip-vcon          = { path = "crates/extensions/rvoip-vcon", version = "0.3.4" }
-rvoip-vcon-postgres = { path = "crates/extensions/rvoip-vcon-postgres", version = "0.3.4" }
-rvoip-harness       = { path = "crates/extensions/rvoip-harness", version = "0.3.4" }
-rvoip-vapi          = { path = "crates/extensions/rvoip-vapi", version = "0.3.4" }
-rvoip               = { path = "crates/rvoip", version = "0.3.4" }
-rvoip-uctp          = { path = "crates/uctp/rvoip-uctp", version = "0.3.4" }
-rvoip-quic          = { path = "crates/uctp/rvoip-quic", version = "0.3.4" }
-rvoip-webtransport  = { path = "crates/uctp/rvoip-webtransport", version = "0.3.4" }
-rvoip-websocket     = { path = "crates/uctp/rvoip-websocket", version = "0.3.4" }
-rvoip-moq-transport = { path = "crates/moq/rvoip-moq-transport", version = "0.3.4" }
-rvoip-moq-native    = { path = "crates/moq/rvoip-moq-native", version = "0.3.4" }
-rvoip-moq-relay     = { path = "crates/moq/rvoip-moq-relay", version = "0.3.4", default-features = false }
-rvoip-moq           = { path = "crates/moq/rvoip-moq", version = "0.3.4" }
-rvoip-rtc           = { path = "crates/webrtc/rvoip-rtc", version = "0.3.4" }
-rvoip-webrtc-stack  = { path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.4" }
-rvoip-webrtc        = { path = "crates/webrtc/rvoip-webrtc", version = "0.3.4" }
-rvoip-identity      = { path = "crates/identity/rvoip-identity", version = "0.3.4" }
-rvoip-client        = { path = "crates/rvoip-client", version = "0.3.4" }
-rvoip-audio-device  = { path = "crates/media/rvoip-audio-device", version = "0.3.4" }
-rvoip-stir-shaken   = { path = "crates/extensions/rvoip-stir-shaken", version = "0.3.4" }
-rvoip-keycloak      = { path = "crates/extensions/rvoip-keycloak", version = "0.3.4" }
-rvoip-redis         = { path = "crates/extensions/rvoip-redis", version = "0.3.4" }
-rvoip-audit         = { path = "crates/extensions/rvoip-audit", version = "0.3.4" }
-rvoip-oidc          = { path = "crates/extensions/rvoip-oidc", version = "0.3.4" }
-rvoip-ldap          = { path = "crates/extensions/rvoip-ldap", version = "0.3.4" }
-rvoip-scim          = { path = "crates/extensions/rvoip-scim", version = "0.3.4" }
-rvoip-saml          = { path = "crates/extensions/rvoip-saml", version = "0.3.4" }
-rvoip-webauthn      = { path = "crates/extensions/rvoip-webauthn", version = "0.3.4" }
-rvoip-ims-aka       = { path = "crates/extensions/rvoip-ims-aka", version = "0.3.4" }
-rtc = { package = "rvoip-rtc", path = "crates/webrtc/rvoip-rtc", version = "0.3.4" }
+rvoip-vcon          = { path = "crates/extensions/rvoip-vcon", version = "0.3.5" }
+rvoip-vcon-postgres = { path = "crates/extensions/rvoip-vcon-postgres", version = "0.3.5" }
+rvoip-harness       = { path = "crates/extensions/rvoip-harness", version = "0.3.5" }
+rvoip-vapi          = { path = "crates/extensions/rvoip-vapi", version = "0.3.5" }
+rvoip               = { path = "crates/rvoip", version = "0.3.5" }
+rvoip-uctp          = { path = "crates/uctp/rvoip-uctp", version = "0.3.5" }
+rvoip-quic          = { path = "crates/uctp/rvoip-quic", version = "0.3.5" }
+rvoip-webtransport  = { path = "crates/uctp/rvoip-webtransport", version = "0.3.5" }
+rvoip-websocket     = { path = "crates/uctp/rvoip-websocket", version = "0.3.5" }
+rvoip-moq-transport = { path = "crates/moq/rvoip-moq-transport", version = "0.3.5" }
+rvoip-moq-native    = { path = "crates/moq/rvoip-moq-native", version = "0.3.5" }
+rvoip-moq-relay     = { path = "crates/moq/rvoip-moq-relay", version = "0.3.5", default-features = false }
+rvoip-moq           = { path = "crates/moq/rvoip-moq", version = "0.3.5" }
+rvoip-rtc           = { path = "crates/webrtc/rvoip-rtc", version = "0.3.5" }
+rvoip-webrtc-stack  = { path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.5" }
+rvoip-webrtc        = { path = "crates/webrtc/rvoip-webrtc", version = "0.3.5" }
+rvoip-identity      = { path = "crates/identity/rvoip-identity", version = "0.3.5" }
+rvoip-client        = { path = "crates/rvoip-client", version = "0.3.5" }
+rvoip-audio-device  = { path = "crates/media/rvoip-audio-device", version = "0.3.5" }
+rvoip-stir-shaken   = { path = "crates/extensions/rvoip-stir-shaken", version = "0.3.5" }
+rvoip-keycloak      = { path = "crates/extensions/rvoip-keycloak", version = "0.3.5" }
+rvoip-redis         = { path = "crates/extensions/rvoip-redis", version = "0.3.5" }
+rvoip-audit         = { path = "crates/extensions/rvoip-audit", version = "0.3.5" }
+rvoip-oidc          = { path = "crates/extensions/rvoip-oidc", version = "0.3.5" }
+rvoip-ldap          = { path = "crates/extensions/rvoip-ldap", version = "0.3.5" }
+rvoip-scim          = { path = "crates/extensions/rvoip-scim", version = "0.3.5" }
+rvoip-saml          = { path = "crates/extensions/rvoip-saml", version = "0.3.5" }
+rvoip-webauthn      = { path = "crates/extensions/rvoip-webauthn", version = "0.3.5" }
+rvoip-ims-aka       = { path = "crates/extensions/rvoip-ims-aka", version = "0.3.5" }
+rtc = { package = "rvoip-rtc", path = "crates/webrtc/rvoip-rtc", version = "0.3.5" }
 
 # External dependencies
 tokio = { version = "1.36", features = ["full"] }
@@ -334,15 +334,15 @@ tokio-util = { version = "0.7", features = ["codec", "compat"] }
 metrics = "0.23"
 # Qualified, attributed MOQT draft-19 forks. Package aliases retain the
 # upstream Rust crate names while the registry identities remain rvoip-owned.
-moq-transport = { package = "rvoip-moq-transport", path = "crates/moq/rvoip-moq-transport", version = "0.3.4" }
-moq-native-ietf = { package = "rvoip-moq-native", path = "crates/moq/rvoip-moq-native", version = "0.3.4" }
-moq-relay-ietf = { package = "rvoip-moq-relay", path = "crates/moq/rvoip-moq-relay", version = "0.3.4", default-features = false }
+moq-transport = { package = "rvoip-moq-transport", path = "crates/moq/rvoip-moq-transport", version = "0.3.5" }
+moq-native-ietf = { package = "rvoip-moq-native", path = "crates/moq/rvoip-moq-native", version = "0.3.5" }
+moq-relay-ietf = { package = "rvoip-moq-relay", path = "crates/moq/rvoip-moq-relay", version = "0.3.5", default-features = false }
 # rvoip-websocket signaling + media. tokio-tungstenite for the WebSocket
 # transport, webrtc for the co-located PeerConnection media plane.
 # webrtc is pre-1.0 and API-volatile — pinned strictly. Bumping requires
 # verifying the WebRtcMediaBridge still compiles.
 tokio-tungstenite = "0.29"
-webrtc = { package = "rvoip-webrtc-stack", path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.4" }
+webrtc = { package = "rvoip-webrtc-stack", path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.5" }
 hickory-resolver = { version = "0.26.1", default-features = false, features = ["tokio", "system-config"] }
 tracing-appender = "0.2"
 env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@
 ---
 
 > [!IMPORTANT]
-> **Unified `0.3.4` release.** All 44 publishable workspace crates ship on the
-> same version. This release uses an explicit owner-approved carry-forward
-> qualification: the `0.3.4` full beta suite, four-peer interoperability
-> matrix, and long soaks were **not rerun**. Current evidence consists of the
-> complete workspace verification and one clean, revision-bound canonical
-> 65,000-call real-media run. The immutable `0.3.2` owner-approved exception is
-> retained as historical background and is not relabeled as a `0.3.4` beta
-> pass. The SIP product is the release-gated beta surface. WebRTC,
+> **Unified `0.3.5` release train.** All 44 publishable workspace crates ship on
+> the same version. Publication requires a fresh, strict full-beta run bound to
+> the exact release source: no skipped gates, no carry-forward qualification,
+> and passing workspace, security, four-peer interoperability, performance,
+> resiliency, and long-soak evidence. The generated beta report is authoritative
+> for the exact tested versions and results. The SIP product is the
+> release-gated beta surface. WebRTC,
 > UCTP, MoQ, the cross-transport APIs, Amazon Connect, and extension crates are
 > available today as developer-preview surfaces unless their own documentation
 > states a narrower qualification. Available does not mean API-stable or
@@ -117,7 +116,7 @@ Add the SIP product:
 
 ```toml
 [dependencies]
-rvoip-sip = "0.3.4"
+rvoip-sip = "0.3.5"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -222,7 +221,7 @@ RTP-over-QUIC has shipped.
 
 ## Extensions
 
-All 14 extension crates ship at `0.3.4`. They are first-class workspace
+All 14 extension crates ship at `0.3.5`. They are first-class workspace
 capabilities, but remain optional so protocol crates depend on provider
 contracts rather than deployment-specific services.
 
@@ -244,22 +243,22 @@ The supporting contracts live in
 The facade exposes the conversation-model extensions together:
 
 ```toml
-rvoip = { version = "0.3.4", features = ["voip-3"] }
+rvoip = { version = "0.3.5", features = ["voip-3"] }
 ```
 
 `voip-3` enables SIP, WebRTC, UCTP, vCon, the identity provider surface, and
 the AI harness. Vapi and STIR/SHAKEN have separate facade features:
 
 ```toml
-rvoip = { version = "0.3.4", features = ["sip", "vapi", "sip-stir-shaken"] }
+rvoip = { version = "0.3.5", features = ["sip", "vapi", "sip-stir-shaken"] }
 ```
 
 Deployment-specific extensions are direct dependencies:
 
 ```toml
-rvoip-keycloak = "0.3.4"
-rvoip-redis = "0.3.4"
-rvoip-audit = "0.3.4"
+rvoip-keycloak = "0.3.5"
+rvoip-redis = "0.3.5"
+rvoip-audit = "0.3.5"
 ```
 
 The facade's `full` feature does **not** enable every workspace extension,
@@ -336,14 +335,12 @@ product's implementation:
   unified release identity, source compatibility notes, and attestation
   provenance.
 
-The `0.3.4` release receipt uses
-`rvoip-release-carry-forward-attestation-v1`. It records
-`beta_suite: NOT-RERUN`, inherits only the unchanged `0.3.2`
-`OWNER-APPROVED-EXCEPTION` background, and requires both current workspace
-verification and one clean canonical 2,000-CPS/65,000-call PASS bound to the
-exact release commit and source fingerprint. This is deliberately narrower
-than a full beta rerun and does not establish a new universal proxy-conformance
-or interoperability claim.
+The `0.3.5` release requires a fresh strict full-beta report bound to one clean,
+unchanged release source fingerprint. The gate admits no skipped checks and
+includes the workspace, SIP/media, public API, security, PBX, SIPp, strict-UA,
+proxy interoperability, performance, resiliency, and long-soak scopes. The
+historical `0.3.4` carry-forward receipt remains immutable release history; it
+does not qualify `0.3.5`.
 
 ### SIP interoperability attestation
 
@@ -352,7 +349,7 @@ independently managed peers below. The report generator binds every row to the
 tested source tree, exact peer identity and configuration, selected matrix,
 and hashed evidence; it refuses to produce a strict release-candidate report
 if a required peer is missing, skipped, ambiguous, unpinned, or failing. This
-four-peer matrix was not rerun for the `0.3.4` carry-forward release.
+four-peer matrix is mandatory for the `0.3.5` strict release gate.
 
 | Peer | Attested boundary | Required release evidence |
 | --- | --- | --- |

--- a/crates/foundation/rvoip-core-traits/README.md
+++ b/crates/foundation/rvoip-core-traits/README.md
@@ -29,7 +29,7 @@ implementing your own adapter and want only the trait surface:
 
 ```toml
 [dependencies]
-rvoip-core-traits = "0.3.2"
+rvoip-core-traits = "0.3.5"
 ```
 
 ## License

--- a/crates/foundation/rvoip-core/README.md
+++ b/crates/foundation/rvoip-core/README.md
@@ -39,7 +39,7 @@ along transitively.
 
 ```toml
 [dependencies]
-rvoip-core = "0.3.3"
+rvoip-core = "0.3.5"
 ```
 
 ## Examples

--- a/crates/identity/auth-core/README.md
+++ b/crates/identity/auth-core/README.md
@@ -24,7 +24,7 @@ restructure is planned.
 
 ```toml
 [dependencies]
-rvoip-auth-core = "0.3.2"
+rvoip-auth-core = "0.3.5"
 ```
 
 ## Where to start

--- a/crates/media/codec-core/README.md
+++ b/crates/media/codec-core/README.md
@@ -25,7 +25,7 @@ isolation:
 
 ```toml
 [dependencies]
-rvoip-codec-core = "0.3.2"
+rvoip-codec-core = "0.3.5"
 ```
 
 ## License

--- a/crates/rvoip/README.md
+++ b/crates/rvoip/README.md
@@ -11,11 +11,12 @@ transport adapters. It always provides the transport-independent
 applications opt into WebRTC, UCTP, Vapi voice agents, client,
 application-builder, and conversation-extension surfaces.
 
-> **Unified `0.3.3` release.** The `sip` feature is the release-gated beta
+> **Unified `0.3.5` release train.** The `sip` feature is the release-gated beta
 > surface. Other facade features are available today as developer previews:
 > they are implemented and published, but API-unstable or outside the SIP beta
-> attestation. The vCon-only targeted delta reuses the immutable 0.3.2 SIP
-> evidence as unchanged-subsystem background; it is not a new beta run.
+> attestation. Publication requires fresh strict full-beta evidence bound to
+> the exact clean `0.3.5` release source; historical exception and
+> carry-forward reports do not qualify this train.
 > Breaking changes remain possible before `1.0`.
 
 ## Quick start
@@ -24,7 +25,7 @@ The default feature is `sip`:
 
 ```toml
 [dependencies]
-rvoip = "0.3.3"
+rvoip = "0.3.5"
 ```
 
 The shared orchestrator is available with every feature combination:
@@ -74,13 +75,13 @@ Examples:
 
 ```toml
 # Shared conversation model plus SIP, WebRTC, UCTP, vCon, identity, and AI.
-rvoip = { version = "0.3.3", features = ["voip-3"] }
+rvoip = { version = "0.3.5", features = ["voip-3"] }
 
 # High-level cross-transport application builder.
-rvoip = { version = "0.3.3", features = ["app"] }
+rvoip = { version = "0.3.5", features = ["app"] }
 
 # Every facade-owned feature.
-rvoip = { version = "0.3.3", features = ["full"] }
+rvoip = { version = "0.3.5", features = ["full"] }
 ```
 
 `full` means every **facade feature**, not every crate in the rvoip workspace.
@@ -121,15 +122,15 @@ For example:
 
 ```toml
 [dependencies]
-rvoip = { version = "0.3.3", features = ["sip"] }
-rvoip-keycloak = "0.3.3"
-rvoip-redis = "0.3.3"
-rvoip-audit = "0.3.3"
+rvoip = { version = "0.3.5", features = ["sip"] }
+rvoip-keycloak = "0.3.5"
+rvoip-redis = "0.3.5"
+rvoip-audit = "0.3.5"
 ```
 
 ## Specialized workspace products
 
-These products ship in the unified `0.3.3` train but are intentionally not
+These products ship in the unified `0.3.5` train but are intentionally not
 facade feature flags:
 
 | Product | Crate | Why it stays separate |
@@ -145,7 +146,7 @@ Enable `app` to declare transports, roles, assignment, and callbacks through
 one builder:
 
 ```toml
-rvoip = { version = "0.3.3", features = ["app"] }
+rvoip = { version = "0.3.5", features = ["app"] }
 ```
 
 ```rust,no_run

--- a/crates/sip/rvoip-sip/README.md
+++ b/crates/sip/rvoip-sip/README.md
@@ -13,14 +13,13 @@ DTMF, hold/resume, custom SIP headers, and app-visible events so Rust
 applications can behave like programmable SIP endpoints without owning SIP
 transaction or RTP details directly.
 
-The workspace is preparing a strict-gate `0.3.4` release candidate. The
-current published SIP qualification remains the `0.3.2` **beta release
-approved with one documented performance exception** for bounded SIP client,
-server, PBX, gateway, and B2BUA scenarios.
-The strict automated result remains NON-RC; see the
-[release exception](docs/BETA_RELEASE_EXCEPTION.md). It is intended for
-developers who want a Rust-native SIP control surface with runnable examples
-and explicit interop evidence.
+The workspace is preparing the strict-gate `0.3.5` release candidate. It can
+publish only after a fresh full-beta run passes without skipped gates and is
+bound to the exact clean release source. The generated
+[beta release report](docs/BETA_RELEASE_REPORT.md) is authoritative for the
+tested PBX, proxy, SIPp, strict-UA, security, performance, and soak boundaries.
+Historical exception and carry-forward reports remain immutable history and
+do not qualify `0.3.5`.
 
 ## At a glance
 
@@ -46,7 +45,7 @@ is **Rust 1.88**.
 
 ```toml
 [dependencies]
-rvoip-sip = "0.3.4"
+rvoip-sip = "0.3.5"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -139,10 +138,10 @@ is documented in [`examples/sip_client/README.md`](examples/sip_client/README.md
 
 ## Interoperability status
 
-The `0.3.4` candidate requires revision-bound PASS evidence for Asterisk,
+The `0.3.5` candidate requires revision-bound PASS evidence for Asterisk,
 FreeSWITCH, Kamailio, and OpenSIPS. Kamailio and OpenSIPS must each pass both
-adjacency orders over UDP, TCP, and verified TLS. Until that report is green,
-the historical status below remains the latest published SIP attestation.
+adjacency orders over UDP, TCP, and verified TLS. Publication remains blocked
+unless the generated report records the complete required matrix as PASS.
 
 The 0.3.2 full release run passed all 16 selected PBX and interoperability
 gates. Asterisk and FreeSWITCH were executed as external PBX peers; Kamailio

--- a/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
+++ b/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
@@ -4,8 +4,8 @@ This document defines the promotion procedure. It does not duplicate a
 candidate's results. The versioned reporting and selection authority is
 `config/beta-release-policy.yaml`; current outcomes are generated from evidence:
 
-Current candidate and runtime crate version: `0.3.4`.
-The `0.3.4` candidate requires the strict full gate; the historical `0.3.2`
+Current candidate and runtime crate version: `0.3.5`.
+The `0.3.5` candidate requires the strict full gate; the historical `0.3.2`
 exception path cannot qualify it.
 
 - [Beta Release Candidate Report](BETA_RELEASE_REPORT.md)

--- a/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
+++ b/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
@@ -28,8 +28,8 @@ failure rather than a skip.
 | Asterisk `res_pjsip` | PBX interop | Required release gate. |
 | FreeSWITCH Sofia | PBX/B2BUA interop | Required release gate. |
 | PJSIP or baresip | Strict SIP user agent | Required release gate. |
-| Kamailio | Transaction-stateful proxy interoperability peer | Required for the `0.3.4` proxy release gate. |
-| OpenSIPS | Independent transaction-stateful proxy interoperability peer | Required for the `0.3.4` proxy release gate. |
+| Kamailio | Transaction-stateful proxy interoperability peer | Required for the `0.3.5` proxy release gate. |
+| OpenSIPS | Independent transaction-stateful proxy interoperability peer | Required for the `0.3.5` proxy release gate. |
 
 ## Current Automation Status
 
@@ -132,7 +132,7 @@ Asterisk/FreeSWITCH lifecycle pattern: it owns startup, readiness, isolated
 configuration, packet capture, logs, exact version/image provenance, teardown,
 and restoration of any process that was running before the gate.
 
-| Scenario | Required for `0.3.4` |
+| Scenario | Required for `0.3.5` |
 |----------|----------------------|
 | UDP, TCP, and TLS/SIPS forwarding | Yes |
 | Matched and unmatched CANCEL | Yes |
@@ -165,7 +165,7 @@ Each interop run should store:
 ## Release-Gate Policy
 
 - A failure in SIPp, Asterisk, FreeSWITCH, Kamailio, or OpenSIPS blocks the
-  `0.3.4` proxy release candidate.
+  `0.3.5` proxy release candidate.
 - The proxy matrix must contain exactly both pinned peers, both adjacency
   orders, and UDP/TCP/verified-TLS rows. Its global scenario inventory and
   per-row core scenario set are validated independently while generating the

--- a/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
+++ b/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
@@ -63,8 +63,9 @@ runtime.
   support remains available, but codec factories and negotiation report it as
   unsupported until a complete codec exists.
 - The standalone WebRTC stack is Tokio-only; Smol and async-std runtime support
-  and dependencies are removed. CI checks default, all-feature, and
-  no-default-feature graphs for alternate runtime dependencies.
+  and dependencies are removed. CI exercises default, all-feature, and
+  no-default-feature configurations and scans the complete all-features graph
+  for forbidden alternate runtime dependencies.
 - The confirmed Chromium SDP regression is corrected for codec-specific audio
   selection, primary SSRC handling, and empty simulcast output.
 

--- a/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
+++ b/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
@@ -82,6 +82,12 @@ runtime.
 - AES-GCM, end-to-end SIP DTLS-SRTP, MIKEY, ZRTP, and G.722 codec negotiation
   remain explicit non-claims. The new ICE/NAT architecture and unrelated
   WebRTC additions from PR #35 are not part of this repair release.
+- General-user 10,000 CPS full-media capability is not claimed. The strict SIP
+  beta envelope remains bounded by its recorded 2,000-CPS real-media profile,
+  exact host configuration, peer matrix, workloads, and soak durations.
+- Browser/WebRTC edge qualification remains separate from the SIP beta claim;
+  the exact Chromium repair tests do not broaden that claim to untested
+  browsers, ICE/TURN deployments, or network topologies.
 
 ## Qualification
 

--- a/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
+++ b/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
@@ -1,121 +1,95 @@
-# rvoip 0.3.4 Release Notes
+# rvoip 0.3.5 Release Candidate Notes
 
-Date: 2026-07-29
+Date: 2026-07-30
 
-These notes describe the coordinated `0.3.4` release. The project owner
-approved a transparent carry-forward qualification rather than a new strict
-full-beta run. The release does not represent inherited evidence as current
-evidence.
+These notes describe the coordinated 44-crate `0.3.5` release candidate.
+Publication requires a fresh strict full-beta qualification bound to the exact
+clean release source. No `0.3.4` carry-forward evidence qualifies this release.
 
 ## Headline
 
-All 44 publishable crates move together to `0.3.4`. The release adds an exact
-inbound-admission terminal signal, completes the RFC 6026 INVITE transaction
-updates used by the SIP stack, and introduces a bounded RFC 3261
-transaction-stateful proxy profile updated by RFC 4320 and RFC 6026.
+`0.3.5` is a security, media-correctness, and SIP-lifecycle release. It makes
+incomplete security features fail closed, repairs RTP/RTCP and SRTP/SRTCP
+state, replaces simulated codec behavior, completes transactional SIP
+renegotiation, closes issues #46 and #50, and makes Tokio the sole WebRTC
+runtime.
 
-## Added
+## Security and media correctness
 
-- `InboundAdmissionTermination` and exact-generation `watch` receivers notify
-  applications of cancellation, remote end, or failure without polling or a
-  global event subscription.
-- Private INVITE client/server Accepted lifecycles retain matching 2xx traffic
-  through Timer M and Timer L while preserving the public transaction enum.
-- Timer M/L retention now uses compact records in the existing sharded
-  lifecycle indexes and one manager-owned deadline scheduler. Active runners,
-  timer factories, transports, and 128-slot command queues are released at the
-  Accepted handoff; due work is generation-protected and capped at 1,024
-  records per batch.
-- Accepted M/L records and teardown J/K records use independent lazy bounded
-  capacity lanes, so an accepted INVITE cannot consume the only slot required
-  to process its own BYE.
-- Stateful proxy response contexts support matched and unmatched CANCEL,
-  cancellation latching, forked and late 2xx responses, ACK ownership,
-  response aggregation, Timer C, strict/loose routing, SIPS, and exact response
-  flow handling.
-- The strict beta tooling now makes Kamailio and OpenSIPS mandatory
-  real-process interoperability peers in both adjacency orders over UDP, TCP,
-  and verified TLS. That matrix was not rerun for this carry-forward release.
-- The beta report generator records revision-bound Asterisk, FreeSWITCH,
-  Kamailio, and OpenSIPS attestations and fails closed on missing or skipped
-  required rows.
+- Placeholder AEAD AES-GCM SRTP profiles retain their public identities but
+  cannot be configured, advertised, selected, or negotiated. DTLS construction
+  returns a typed unsupported-feature error instead of panicking.
+- RTP padding and RFC 8285 one-byte/two-byte header extensions now serialize
+  and parse with strict length, padding, reserved-ID, and alignment handling.
+- RTP loss and jitter tracking handles sequence rollover, duplicates, gaps, and
+  reordered packets without corrupting the timing reference. RTCP LSR uses the
+  complete middle 32 bits of the NTP timestamp, and compound RTCP ingress
+  preserves well-formed unknown packet types while rejecting malformed input.
+- SRTP maintains independent local outbound and remote inbound keys and
+  per-SSRC rollover/replay state. Incoming packets are authenticated before
+  replay state commits. SRTCP uses monotonic per-SSRC indexes and derives each
+  IV from the real SSRC and index. RFC vectors, rollover/reordering, replay,
+  multi-SSRC, failed-authentication, and pinned libSRTP interoperability are
+  covered.
+- Low-level SDES answers generate fresh directional key material. AES-256 SDES
+  accepts safely unpadded key material in compatible mode, keeps strict mode
+  canonical, validates decoded lengths, and emits secret-safe negotiation and
+  authentication diagnostics. This closes issue #46.
 
-## Fixed
+## SIP signaling and lifecycle
 
-- Renamed workspace dependencies, including the WebRTC and MOQT package
-  aliases, are updated and validated during coordinated release preparation.
-- Transactionless ACK transport metadata is bounded and eligible for exact
-  cleanup after the protocol retention horizon.
-- Transaction timer callback and state transition delivery is atomic and
-  schedule-generation protected, eliminating the channel-saturation race that
-  could strand an otherwise expired transaction.
-- Stateless protocol-retention overload responses now inherit the configured
-  server `Retry-After` policy across already-running transaction-manager
-  worker clones.
-- Server Timer L absorbs retransmitted INVITEs without driving cached 2xx
-  replay, while later TU-supplied 2xx responses and matching ACK delivery
-  remain available through the compact retained indexes.
-- Client Timer M forwards every matching or additional 2xx without owning its
-  ACK; proxy routes expire at M and endpoint routes promote in place to the
-  existing compact late-2xx compatibility horizon.
-- Via `received`/`rport`, packed Via popping, body preservation, route-set
-  processing, and RFC 3263 failover paths have dedicated packet-level tests.
-- The existing SCIM, vCon, Vapi, WebRTC, MOQT, and extension behavior from
-  `0.3.2` and `0.3.3` remains part of the coordinated workspace.
+- Signaling-only and media-enabled hold/resume share transactional stable-state
+  handling. Repeated hold and resume operations are idempotent.
+- Re-INVITE, UPDATE, delayed-offer INVITE/200/ACK, authentication retry,
+  retransmission, rollback, and media application paths use exact transaction
+  and CSeq ownership. Invalid or incomplete negotiation cannot corrupt the
+  established dialog.
+- Failed 2xx SDP negotiation is ACKed, terminates exactly once, and produces an
+  application-visible negotiation failure without exposing key material.
+- `EndpointBuilder`, `StreamPeer`, and `StreamPeerBuilder` now accept
+  `SipNatConfig` and `SymmetricRtpPolicy`, allowing high-level applications to
+  tune symmetric-RTP rebinding for real NAT deployments. This closes issue
+  #50.
+- BYE, redirect, admission, and retry cleanup retains one terminal fact,
+  exact-generation ownership, bounded retention, and keyed/no-scan hot paths.
+  Registrar and SIP crates pass the strict release lint policy.
 
-## Proxy Claim Boundary
+## Codecs and WebRTC
 
-The implementation is described as a bounded “RFC 3261
-transaction-stateful proxy profile, updated by RFC 4320 and RFC 6026.” The
-`0.3.4` carry-forward qualification makes no new universal proxy-conformance
-claim and does not claim a fresh peer-interoperability matrix.
+- Audio/video codec-name classification is ASCII case-insensitive. Opus uses
+  the real codec backend through the canonical codec-core implementation;
+  `opus-sim` remains only as a deprecated alias to that backend.
+- Feature-disabled builds do not advertise Opus. G.722 low-level RTP payload
+  support remains available, but codec factories and negotiation report it as
+  unsupported until a complete codec exists.
+- The standalone WebRTC stack is Tokio-only; Smol and async-std runtime support
+  and dependencies are removed. CI checks default, all-feature, and
+  no-default-feature graphs for alternate runtime dependencies.
+- The confirmed Chromium SDP regression is corrected for codec-specific audio
+  selection, primary SSRC handling, and empty simulcast output.
 
-- Recursive 3xx Contact processing is not part of the claimed profile.
-- Loop detection is disabled unless it can distinguish loops from spirals.
-- Asymmetric Record-Route rewriting is outside the claim unless separately
-  qualified.
-- The claim does not cover every SIP extension, topology, or peer version.
+## Architecture and compatibility
 
-## Compatibility
+- SIP signaling changes preserve the sharded, exact-key, generation-protected,
+  bounded-retention architecture in
+  [`SIGNALING_PERFORMANCE_ARCHITECTURE.md`](SIGNALING_PERFORMANCE_ARCHITECTURE.md).
+  They do not introduce per-transaction sleeper tasks, unbounded histories, or
+  global hot-path scans.
+- Public compatibility is compared with the documented `0.3.4` baseline.
+  Typed unsupported errors replace behavior that previously panicked or
+  implied unavailable security/codec support.
+- AES-GCM, end-to-end SIP DTLS-SRTP, MIKEY, ZRTP, and G.722 codec negotiation
+  remain explicit non-claims. The new ICE/NAT architecture and unrelated
+  WebRTC additions from PR #35 are not part of this repair release.
 
-- Public source compatibility is compared against `v0.3.3`.
-- RFC 6026 Accepted state remains private protocol state so exhaustive matches
-  over the public `TransactionState` remain compatible.
-- The admission terminal APIs are additive.
-- Stateful proxy wire behavior changes are externally observable but ship as
-  `0.3.4` by owner decision within the pre-1.0 release train.
+## Qualification
 
-## Limitations and non-claims
+The release candidate must pass the one-command full beta gate from a clean,
+committed `0.3.5` source tree. Required evidence includes three fresh canonical
+2,000-CPS runs; workspace, public-API, security, parser, PBX, SIPp, strict-UA,
+Kamailio, and OpenSIPS gates; full-media performance and resiliency matrices;
+and both one-hour monolithic and split soaks. The generated report package and
+its source fingerprint are verified before crates.io publication.
 
-- General-user 10,000 CPS full-media capability is not claimed. The supported
-  beta envelope remains bounded by the revision-specific 2,000-CPS real-media
-  evidence and its documented runtime profile.
-- Browser/WebRTC edge behavior remains outside the SIP beta claim; component
-  availability does not imply qualified browser, ICE/TURN, or DTLS-SRTP
-  interoperability.
-- The proxy claim remains limited to the explicitly tested profile below.
-
-## Carry-forward qualification
-
-The exact release commit is qualified under
-`rvoip-release-carry-forward-attestation-v1` with this recorded disposition:
-
-- `beta_suite: NOT-RERUN`;
-- `inherited_beta_background: 0.3.2 OWNER-APPROVED-EXCEPTION`;
-- `current_workspace_verification: PASS`;
-- `current_canonical_2k: PASS`; and
-- `disposition: OWNER-APPROVED-CARRY-FORWARD`.
-
-One clean canonical 2,000-CPS/65,000-call real-media pass is bound to the exact
-`0.3.4` commit, tree, source fingerprint, report, persisted acceptance result,
-performance audit, and executable hash. The release verifier separately runs
-the current workspace compile, library, target, integration, example, and
-doctest checks plus all 44 package-manifest checks.
-
-The full `0.3.4` beta gate, Asterisk/FreeSWITCH/Kamailio/OpenSIPS matrix, SIPp
-ladder, and long soaks were not rerun. The immutable `0.3.2` exception remains
-historical background with strict status `NON-RC`; it is not a `0.3.4` PASS.
-
-Historical `0.3.2` disposition and evidence remain unchanged in
-[`BETA_RELEASE_EXCEPTION.md`](BETA_RELEASE_EXCEPTION.md) and its immutable
-release archive.
+Historical `0.3.2` exception and `0.3.4` carry-forward attestations remain
+unchanged release history. They are not presented as current `0.3.5` evidence.

--- a/crates/sip/rvoip-sip/docs/TOPOLOGY_PROFILES.md
+++ b/crates/sip/rvoip-sip/docs/TOPOLOGY_PROFILES.md
@@ -17,8 +17,8 @@ run `20260724T231400Z`, generated from clean tested commit `8d44fb35`.
 | Basic SIP server | Supported | `CallbackPeer` inbound call, reject/accept, DTMF, BYE cleanup. |
 | Asterisk PBX | Interop tested | UDP/TLS registration and calls, digest auth, SDES-SRTP where claimed. |
 | FreeSWITCH PBX | Interop tested | Mirrors the Asterisk matrix where feasible. |
-| Kamailio transaction-stateful proxy | `0.3.4` release gate | Real-process UDP/TCP/TLS, routing, CANCEL, forking, ACK, response, and cleanup matrix. |
-| OpenSIPS transaction-stateful proxy | `0.3.4` release gate | Independent real-process execution of the same proxy matrix. |
+| Kamailio transaction-stateful proxy | `0.3.5` release gate | Real-process UDP/TCP/TLS, routing, CANCEL, forking, ACK, response, and cleanup matrix. |
+| OpenSIPS transaction-stateful proxy | `0.3.5` release gate | Independent real-process execution of the same proxy matrix. |
 | SIPp UAC/UAS | Release gate | Standalone load matrix at 30, 100, 300, 1,000, and 2,000 CPS. |
 | baresip strict-UA | Interop tested | Strict-UA INVITE, 200 OK, ACK, established call, BYE, and rvoip accept checks. |
 | Signaling-only B2BUA/gateway | Supported with limits | Multi-leg signaling tests and clear media relay caveats. |
@@ -29,7 +29,7 @@ run `20260724T231400Z`, generated from clean tested commit `8d44fb35`.
 | Profile | Status | Reason |
 |---------|--------|--------|
 | Tuned high-CPS above 2,000 CPS | Advanced | Requires explicit tuning, hardware notes, and topology caveats. |
-| RTPengine media relay | Investigation | Media-relay integration is separate from the `0.3.4` signaling-proxy conformance claim. |
+| RTPengine media relay | Investigation | Media-relay integration is separate from the `0.3.5` signaling-proxy conformance claim. |
 | Carrier SBC certification | Post-beta | Requires carrier-specific certification and security audit. |
 | Browser/WebRTC edge | Post-beta | DTLS-SRTP, ICE, TURN, and browser interop are outside beta. |
 | ICE/TURN NAT traversal | Post-beta | Current STUN support is limited address discovery, not ICE. |

--- a/crates/sip/rvoip-sip/scripts/full_beta_release.sh
+++ b/crates/sip/rvoip-sip/scripts/full_beta_release.sh
@@ -30,7 +30,7 @@ BARESIP_MODULE_PATH="$HOMEBREW_PREFIX/lib/baresip/modules"
 export PATH="$HOMEBREW_PREFIX/opt/docker/bin:$HOMEBREW_PREFIX/opt/docker-compose/bin:$HOMEBREW_PREFIX/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export DOCKER_CLI_PLUGIN_EXTRA_DIRS="$HOMEBREW_PREFIX/lib/docker/cli-plugins"
 
-EXPECTED_RELEASE_VERSION="0.3.4"
+EXPECTED_RELEASE_VERSION="0.3.5"
 EXPECTED_PUBLIC_API_VERSION="cargo-public-api 0.52.0"
 EXPECTED_NIGHTLY_VERSION="rustc 1.97.0-nightly (e22c616e4 2026-04-19)"
 COLIMA_CPUS=8

--- a/crates/sip/rvoip-sip/scripts/test_beta_attestation.py
+++ b/crates/sip/rvoip-sip/scripts/test_beta_attestation.py
@@ -1395,17 +1395,18 @@ class BetaAttestationTests(unittest.TestCase):
         release_notes = (
             WORKSPACE_ROOT / "crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md"
         ).read_text(encoding="utf-8")
-        self.assertEqual(self.workspace_version, "0.3.4")
+        self.assertEqual(self.workspace_version, "0.3.5")
         self.assertRegex(
             crate_manifest,
             r"(?m)^version\.workspace\s*=\s*true(?:\s*(?:#.*)?)?$",
         )
         marker = f"Current candidate and runtime crate version: `{self.workspace_version}`"
         self.assertIn(marker, checklist)
-        self.assertIn("0.3.4 Release Candidate Notes", release_notes)
-        self.assertIn("current crates.io release\n> remains `0.3.3`", (
-            WORKSPACE_ROOT / "README.md"
-        ).read_text(encoding="utf-8"))
+        self.assertIn("0.3.5 Release Candidate Notes", release_notes)
+        self.assertIn(
+            "**Unified `0.3.5` release train.**",
+            (WORKSPACE_ROOT / "README.md").read_text(encoding="utf-8"),
+        )
 
 
 if __name__ == "__main__":

--- a/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
+++ b/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
@@ -392,7 +392,7 @@ class BetaGateCompatibilitySourceTests(unittest.TestCase):
             (WORKSPACE_ROOT / "Cargo.toml").read_text(encoding="utf-8")
         )
         version = root_manifest["workspace"]["package"]["version"]
-        self.assertEqual(version, "0.3.4")
+        self.assertEqual(version, "0.3.5")
 
         active_files = [
             WORKSPACE_ROOT / "README.md",

--- a/crates/sip/rvoip-sip/tests/single_authority_architecture.rs
+++ b/crates/sip/rvoip-sip/tests/single_authority_architecture.rs
@@ -1276,7 +1276,8 @@ fn typed_dialog_ingress_and_in_dialog_tracker_are_generation_fenced() {
         &handler,
         "async fn publish_and_release_session",
     ));
-    assert!(terminal.contains("get_session_snapshot_exact(&handle)"));
+    assert!(terminal.contains("has_exact_terminal_fact(&handle)"));
+    assert!(!terminal.contains("get_session_snapshot_exact("));
     assert!(!terminal.contains("lifecycle_handle("));
 
     let flow = compact(function_source(

--- a/crates/sip/sip-core/README.md
+++ b/crates/sip/sip-core/README.md
@@ -418,7 +418,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rvoip-sip-core = "0.3.2"
+rvoip-sip-core = "0.3.5"
 bytes = "1.4"  # For handling raw message data
 tokio = { version = "1.0", features = ["full"] }  # For async examples
 ```

--- a/crates/sip/sip-proxy/README.md
+++ b/crates/sip/sip-proxy/README.md
@@ -12,12 +12,13 @@ and Via handling consumed by the
 
 ## Status
 
-**Partial RFC 3261 stateful-proxy implementation.** Published `0.3.3`
-does not carry a bounded proxy-conformance claim. The coordinated
-`0.3.4` candidate adds support for
+**Bounded RFC 3261 transaction-stateful proxy profile, updated by RFC 4320 and
+RFC 6026.** The coordinated `0.3.5` candidate includes
 transaction-stateful forwarding, parallel/sequential forking, Via and
 Max-Forwards processing, response aggregation, CANCEL propagation, and
-Timer C. Those features do not yet constitute a qualified RFC profile.
+Timer C. The claim is limited to the behaviors and real-peer matrix named in
+the conformance documents and becomes releasable only when the strict beta
+gate passes.
 
 The applicable normative behavior, known gaps, and executable evidence
 required for a bounded claim are tracked in
@@ -35,7 +36,7 @@ you want the raw transaction-layer primitives:
 
 ```toml
 [dependencies]
-rvoip-sip-proxy = "0.3.4"
+rvoip-sip-proxy = "0.3.5"
 ```
 
 ## License

--- a/crates/webrtc/rvoip-rtc/RVOIP_PATCHES.md
+++ b/crates/webrtc/rvoip-rtc/RVOIP_PATCHES.md
@@ -25,6 +25,20 @@ Applied fixes:
    carries an exact negotiated MID and payload type, without requiring a RID.
    This preserves the primary coding and gives RFC 4733's separately-clocked
    telephone-event SSRC one deterministic RFC 8843 BUNDLE binding.
+4. The BridgeFu exact-Chromium candidate originated in
+   `eisenzopf/rtc@1e5b7d4be6d94850694f2519f4c235d16c871d53`
+   (`patch-id 478b7da63ea6d195f446a9abce4c56e62129a86e`). The reviewed
+   rvoip integration is the six-file RTC subset
+   (`patch-id 04f06567b162464eaf4185bfa3f5d037bec603a7`); unrelated
+   `rvoip-webrtc` DTMF changes are not part of it. The integration
+   distinguishes codec-specific audio bindings from RID simulcast, advertises
+   only the primary audio SSRC, never emits an empty `a=simulcast` attribute,
+   selects supplemental payload types by complete codec identity, groups
+   declared SSRCs onto one receiver track, and admits an un-signaled
+   supplemental SSRC only through an authoritative MID/payload binding or a
+   uniquely negotiated audio payload type. The authoritative-MID path remains
+   media-kind neutral, and the established sole-video/no-extension fallback is
+   preserved.
 
 The offer fix is applied inside `generate_matched_sdp`, where offer media
 sections are owned. The supplemental-SSRC fix is applied at the receive
@@ -33,5 +47,5 @@ SDP or add a parallel renegotiation/signaling path.
 
 Original authorship belongs to Rain Liu and the WebRTC.rs contributors. rvoip
 changes are documented above and in the retained source history. Remove this
-fork only after one immutable upstream release or commit contains all three
-behaviors and passes the full rvoip beta gate.
+fork only after one immutable upstream release or commit contains all
+documented behaviors and passes the full rvoip beta gate.

--- a/crates/webrtc/rvoip-rtc/RVOIP_PATCHES.md
+++ b/crates/webrtc/rvoip-rtc/RVOIP_PATCHES.md
@@ -25,12 +25,12 @@ Applied fixes:
    carries an exact negotiated MID and payload type, without requiring a RID.
    This preserves the primary coding and gives RFC 4733's separately-clocked
    telephone-event SSRC one deterministic RFC 8843 BUNDLE binding.
-4. The BridgeFu exact-Chromium candidate originated in
+4. The BridgeFu exact-Chromium working-tree candidate was based on
    `eisenzopf/rtc@1e5b7d4be6d94850694f2519f4c235d16c871d53`
-   (`patch-id 478b7da63ea6d195f446a9abce4c56e62129a86e`). The reviewed
-   rvoip integration is the six-file RTC subset
-   (`patch-id 04f06567b162464eaf4185bfa3f5d037bec603a7`); unrelated
-   `rvoip-webrtc` DTMF changes are not part of it. The integration
+   (working-tree `patch-id 478b7da63ea6d195f446a9abce4c56e62129a86e`).
+   The reviewed six-file RTC subset was extracted from historical rvoip commit
+   `ace18056` (`patch-id 04f06567b162464eaf4185bfa3f5d037bec603a7`).
+   Unrelated `rvoip-webrtc` DTMF changes are not part of it. The integration
    distinguishes codec-specific audio bindings from RID simulcast, advertises
    only the primary audio SSRC, never emits an empty `a=simulcast` attribute,
    selects supplemental payload types by complete codec identity, groups

--- a/crates/webrtc/rvoip-rtc/src/peer_connection/handler/endpoint.rs
+++ b/crates/webrtc/rvoip-rtc/src/peer_connection/handler/endpoint.rs
@@ -11,8 +11,12 @@ use crate::media_stream::track::MediaStreamTrackId;
 use crate::peer_connection::configuration::media_engine::MediaEngine;
 use crate::peer_connection::event::track_event::{RTCTrackEvent, RTCTrackEventInit};
 use crate::rtp_transceiver::rtp_receiver::internal::RTCRtpReceiverInternal;
-use crate::rtp_transceiver::rtp_sender::{RTCRtpCodingParameters, RTCRtpHeaderExtensionCapability};
-use crate::rtp_transceiver::{RTCRtpReceiverId, SSRC, internal::RTCRtpTransceiverInternal};
+use crate::rtp_transceiver::rtp_sender::{
+    RTCRtpCodingParameters, RTCRtpHeaderExtensionCapability, RtpCodecKind,
+};
+use crate::rtp_transceiver::{
+    PayloadType, RTCRtpReceiverId, SSRC, internal::RTCRtpTransceiverInternal,
+};
 use crate::statistics::accumulator::RTCStatsAccumulator;
 use interceptor::{Interceptor, Packet};
 use log::{debug, trace, warn};
@@ -40,6 +44,89 @@ where
     media_engine: &'a MediaEngine,
     interceptor: &'a mut I,
     stats: &'a mut RTCStatsAccumulator,
+}
+
+/// Select the receiver that can own an un-signaled SSRC. An explicit MID is
+/// authoritative for every media kind. Without a MID, payload type may select
+/// a unique audio receiver so codec-distinct supplemental audio (notably RFC
+/// 4733) can join its primary stream. The historical sole-transceiver fallback
+/// remains available for audio or video when that receiver has no RID codings.
+///
+/// This deliberately refuses ambiguous ownership instead of routing media to
+/// whichever transceiver happens to appear first.
+fn unique_receiver_index(mut matches: impl Iterator<Item = usize>) -> Option<usize> {
+    let selected = matches.next()?;
+    matches.next().is_none().then_some(selected)
+}
+
+fn undeclared_receiver_index<I: Interceptor>(
+    rtp_transceivers: &[RTCRtpTransceiverInternal<I>],
+    payload_type: PayloadType,
+    signaled_mid: Option<&str>,
+) -> Option<usize> {
+    let signaled_mid = signaled_mid.filter(|mid| !mid.is_empty());
+    let matches_payload = |transceiver: &RTCRtpTransceiverInternal<I>| {
+        transceiver.direction().has_recv()
+            && !transceiver.stopped()
+            && transceiver.receiver().as_ref().is_some_and(|receiver| {
+                receiver
+                    .get_codec_preferences()
+                    .iter()
+                    .any(|codec| codec.payload_type == payload_type)
+            })
+    };
+    if let Some(mid) = signaled_mid {
+        return unique_receiver_index(
+            rtp_transceivers
+                .iter()
+                .enumerate()
+                .filter(|(_, transceiver)| {
+                    transceiver.mid().as_deref() == Some(mid) && matches_payload(transceiver)
+                })
+                .map(|(index, _)| index),
+        );
+    }
+
+    if let Some(index) = unique_receiver_index(
+        rtp_transceivers
+            .iter()
+            .enumerate()
+            .filter(|(_, transceiver)| {
+                transceiver.kind() == RtpCodecKind::Audio && matches_payload(transceiver)
+            })
+            .map(|(index, _)| index),
+    ) {
+        return Some(index);
+    }
+
+    let [transceiver] = rtp_transceivers else {
+        return None;
+    };
+    (matches_payload(transceiver)
+        && transceiver
+            .receiver()
+            .as_ref()
+            .is_some_and(|receiver| receiver.track().codings().is_empty()))
+    .then_some(0)
+}
+
+/// Add an un-signaled SSRC without discarding the receiver's SDP-declared
+/// primary, RTX, FEC, or earlier supplemental codings. Returns whether a new
+/// coding was inserted so retransmitted packets reuse the existing route.
+fn append_undeclared_coding(receive_codings: &mut Vec<RTCRtpCodingParameters>, ssrc: SSRC) -> bool {
+    if receive_codings
+        .iter()
+        .any(|coding| coding.ssrc == Some(ssrc))
+    {
+        return false;
+    }
+    receive_codings.push(RTCRtpCodingParameters {
+        rid: String::new(),
+        ssrc: Some(ssrc),
+        rtx: None,
+        fec: None,
+    });
+    true
 }
 
 impl<'a, I> EndpointHandler<'a, I>
@@ -408,25 +495,23 @@ where
         ssrc: SSRC,
         rtp_header: &rtp::Header,
     ) -> Option<MediaStreamTrackId> {
-        // If the remote SDP was only one media section the ssrc doesn't have to be explicitly declared
-        let track_id = self.handle_undeclared_ssrc(rtp_header);
-        if track_id.is_some() {
-            return track_id;
-        }
+        let (mid, rid, rrid) = self
+            .get_rtp_header_extension_ids(rtp_header)
+            .unwrap_or_default();
 
-        let (mid, rid, rrid) =
-            if let Some((mid, rid, rrid)) = self.get_rtp_header_extension_ids(rtp_header) {
-                // MID alone is sufficient to bind a negotiated supplemental
-                // SSRC (for example RFC 4733 telephone-event) to its exact
-                // BUNDLE media section. RID/RRID remain required only for
-                // identifying encodings within a simulcast stream.
-                if mid.is_empty() {
-                    return None;
-                }
-                (mid, rid, rrid)
-            } else {
-                return None;
-            };
+        // RFC 8834 requires WebRTC receivers to accept SSRCs that were not
+        // signaled in SDP. Codec-distinct supplemental audio (notably RFC
+        // 4733) has no RID, so bind it to an explicit MID when available or
+        // to the unique audio receiver that negotiated its payload type. The
+        // same path retains the sole-transceiver fallback for un-signaled
+        // video RTP without header extensions.
+        if rid.is_empty() && rrid.is_empty() {
+            return self
+                .handle_undeclared_ssrc(rtp_header, (!mid.is_empty()).then_some(mid.as_str()));
+        }
+        if mid.is_empty() {
+            return None;
+        }
 
         // If rtp header extension has valid mid, find receiver based on mid, instead of rid,
         // since rid is not unique across m= lines
@@ -454,23 +539,7 @@ where
                 if !rrid.is_empty() {
                     //TODO: Add support of handling repair rtp stream id (rrid) #12
                 } else {
-                    let mid_only = rid.is_empty();
-                    if mid_only {
-                        // Preserve every SDP-declared coding and append this
-                        // exact MID/PT/SSRC binding. Replacing the empty-RID
-                        // primary coding would make subsequent primary RTP
-                        // disappear when a supplemental SSRC arrives first.
-                        let mut receive_codings = receiver.get_coding_parameters().to_vec();
-                        receive_codings.push(RTCRtpCodingParameters {
-                            rid: String::new(),
-                            ssrc: Some(ssrc),
-                            rtx: None,
-                            fec: None,
-                        });
-                        receiver.set_coding_parameters(receive_codings);
-                    } else if let Some(coding) =
-                        receiver.get_coding_parameter_mut_by_rid(rid.as_str())
-                    {
+                    if let Some(coding) = receiver.get_coding_parameter_mut_by_rid(rid.as_str()) {
                         coding.ssrc = Some(ssrc);
                     }
 
@@ -484,16 +553,11 @@ where
                         &parameters.rtp_parameters.header_extensions,
                     );
 
-                    let new_entry = if mid_only {
+                    let new_entry =
                         receiver
                             .track_mut()
-                            .set_codec_by_ssrc(codec.rtp_codec, ssrc)
-                    } else {
-                        receiver
-                            .track_mut()
-                            .set_codec_ssrc_by_rid(codec.rtp_codec, ssrc, &rid)
-                    };
-                    assert_eq!(new_entry, mid_only);
+                            .set_codec_ssrc_by_rid(codec.rtp_codec, ssrc, &rid);
+                    assert!(!new_entry);
 
                     let track_id = receiver.track().track_id().to_owned();
 
@@ -525,7 +589,7 @@ where
                                     track_id: track_id.clone(),
                                     stream_ids: vec![receiver.track().stream_id().to_owned()],
                                     ssrc,
-                                    rid: (!rid.is_empty()).then_some(rid),
+                                    rid: Some(rid),
                                 },
                             )),
                         ));
@@ -536,86 +600,73 @@ where
         None
     }
 
-    fn handle_undeclared_ssrc(&mut self, rtp_header: &rtp::Header) -> Option<MediaStreamTrackId> {
-        if self.rtp_transceivers.len() != 1 {
-            // it is multi-media-section case, let's use find_track_id_by_rid
-            return None;
+    fn handle_undeclared_ssrc(
+        &mut self,
+        rtp_header: &rtp::Header,
+        signaled_mid: Option<&str>,
+    ) -> Option<MediaStreamTrackId> {
+        let receiver_index = undeclared_receiver_index(
+            self.rtp_transceivers,
+            rtp_header.payload_type,
+            signaled_mid,
+        )?;
+        let transceiver = &mut self.rtp_transceivers[receiver_index];
+        let kind = transceiver.kind();
+        let mid = transceiver.mid().clone().unwrap_or_default();
+        let receiver = transceiver.receiver_mut().as_mut()?;
+        let codec = receiver
+            .get_codec_preferences()
+            .iter()
+            .find(|codec| codec.payload_type == rtp_header.payload_type)
+            .cloned()?;
+
+        let mut receive_codings = receiver.get_coding_parameters().to_vec();
+        if !append_undeclared_coding(&mut receive_codings, rtp_header.ssrc) {
+            // The normal SSRC lookup owns established routes. This branch is
+            // defensive against a repeated packet racing route publication.
+            return Some(receiver.track().track_id().to_owned());
+        }
+        receiver.set_coding_parameters(receive_codings);
+
+        let parameters = receiver.get_parameters(self.media_engine);
+        RTCRtpReceiverInternal::interceptor_remote_stream_op(
+            self.interceptor,
+            true,
+            rtp_header.ssrc,
+            codec.payload_type,
+            &codec.rtp_codec,
+            &parameters.rtp_parameters.header_extensions,
+        );
+
+        let new_entry = receiver
+            .track_mut()
+            .set_codec_by_ssrc(codec.rtp_codec, rtp_header.ssrc);
+        if !new_entry {
+            return Some(receiver.track().track_id().to_owned());
         }
 
-        if let Some(transceiver) = self.rtp_transceivers.first()
-            && let Some(receiver) = transceiver.receiver()
-            && !receiver.track().codings().is_empty()
-        {
-            // it is rid-based, let's use find_track_id_by_rid
-            return None;
-        }
-
-        if let Some(transceiver) = self.rtp_transceivers.first_mut() {
-            // Get kind and mid before borrowing receiver mutably
-            let kind = transceiver.kind();
-            let mid = transceiver.mid().clone().unwrap_or_default();
-
-            if let Some(receiver) = transceiver.receiver_mut()
-                && let Some(codec) = receiver
-                    .get_codec_preferences()
-                    .iter()
-                    .find(|codec| codec.payload_type == rtp_header.payload_type) //TODO: what about RTX/FEC stream?
-                    .cloned()
-            {
-                let receive_codings = vec![RTCRtpCodingParameters {
-                    rid: "".to_string(),
-                    ssrc: Some(rtp_header.ssrc),
-                    rtx: None,
-                    fec: None,
-                }];
-                receiver.set_coding_parameters(receive_codings);
-
-                let parameters = receiver.get_parameters(self.media_engine);
-                RTCRtpReceiverInternal::interceptor_remote_stream_op(
-                    self.interceptor,
-                    true,
-                    rtp_header.ssrc,
-                    codec.payload_type,
-                    &codec.rtp_codec,
-                    &parameters.rtp_parameters.header_extensions,
-                );
-
-                // assert it inserts a new entry
-                let new_entry = receiver
-                    .track_mut()
-                    .set_codec_by_ssrc(codec.rtp_codec, rtp_header.ssrc);
-                assert!(new_entry);
-
-                let track_id = receiver.track().track_id().to_owned();
-
-                // Create inbound stream accumulator before firing OnOpen event
-                // Note: undeclared SSRC case doesn't have RTX/FEC info
-                self.stats.get_or_create_inbound_rtp_streams(
-                    rtp_header.ssrc,
-                    kind,
-                    &track_id,
-                    &mid,
-                    None,
-                    None,
-                    0, // Undeclared SSRC is always for the first transceiver
-                );
-
-                // Fire RTCTrackEvent::OnOpen event when received the first RTP packet for such ssrc stream
-                self.ctx
-                    .event_outs
-                    .push_back(RTCEventInternal::RTCPeerConnectionEvent(
-                        RTCPeerConnectionEvent::OnTrack(RTCTrackEvent::OnOpen(RTCTrackEventInit {
-                            receiver_id: RTCRtpReceiverId(0),
-                            track_id: track_id.clone(),
-                            stream_ids: vec![receiver.track().stream_id().to_owned()],
-                            ssrc: rtp_header.ssrc,
-                            rid: None,
-                        })),
-                    ));
-                return Some(track_id);
-            }
-        }
-        None
+        let track_id = receiver.track().track_id().to_owned();
+        self.stats.get_or_create_inbound_rtp_streams(
+            rtp_header.ssrc,
+            kind,
+            &track_id,
+            &mid,
+            None,
+            None,
+            receiver_index,
+        );
+        self.ctx
+            .event_outs
+            .push_back(RTCEventInternal::RTCPeerConnectionEvent(
+                RTCPeerConnectionEvent::OnTrack(RTCTrackEvent::OnOpen(RTCTrackEventInit {
+                    receiver_id: RTCRtpReceiverId(receiver_index),
+                    track_id: track_id.clone(),
+                    stream_ids: vec![receiver.track().stream_id().to_owned()],
+                    ssrc: rtp_header.ssrc,
+                    rid: None,
+                })),
+            ));
+        Some(track_id)
     }
 
     fn get_rtp_header_extension_ids(
@@ -637,11 +688,12 @@ where
         }
 
         // Get RID extension ID
-        let (rid_extension_id, rid_audio_supported, rid_video_supported) = self
+        let (rid_extension_id, audio_supported, video_supported) = self
             .media_engine
             .get_header_extension_id(RTCRtpHeaderExtensionCapability {
                 uri: ::sdp::extmap::SDES_RTP_STREAM_ID_URI.to_owned(),
             });
+        let rid_supported = audio_supported || video_supported;
 
         // Get RRID extension ID
         let (rrid_extension_id, rrid_audio_supported, rrid_video_supported) = self
@@ -649,6 +701,7 @@ where
             .get_header_extension_id(RTCRtpHeaderExtensionCapability {
                 uri: ::sdp::extmap::SDES_REPAIR_RTP_STREAM_ID_URI.to_owned(),
             });
+        let rrid_supported = rrid_audio_supported || rrid_video_supported;
 
         let mid = if let Some(payload) = rtp_header.get_extension(mid_extension_id as u8) {
             String::from_utf8(payload.to_vec()).unwrap_or_default()
@@ -656,24 +709,170 @@ where
             String::new()
         };
 
-        let rid = if rid_audio_supported || rid_video_supported {
-            rtp_header
-                .get_extension(rid_extension_id as u8)
-                .map(|payload| String::from_utf8(payload.to_vec()).unwrap_or_default())
-                .unwrap_or_default()
+        let rid = if rid_supported
+            && let Some(payload) = rtp_header.get_extension(rid_extension_id as u8)
+        {
+            String::from_utf8(payload.to_vec()).unwrap_or_default()
         } else {
             String::new()
         };
 
-        let rrid = if rrid_audio_supported || rrid_video_supported {
-            rtp_header
-                .get_extension(rrid_extension_id as u8)
-                .map(|payload| String::from_utf8(payload.to_vec()).unwrap_or_default())
-                .unwrap_or_default()
+        let rrid = if rrid_supported
+            && let Some(payload) = rtp_header.get_extension(rrid_extension_id as u8)
+        {
+            String::from_utf8(payload.to_vec()).unwrap_or_default()
         } else {
             String::new()
         };
 
         Some((mid, rid, rrid))
+    }
+}
+
+#[cfg(test)]
+mod undeclared_ssrc_tests {
+    use super::{
+        RTCRtpCodingParameters, RTCRtpTransceiverInternal, RtpCodecKind, append_undeclared_coding,
+        undeclared_receiver_index,
+    };
+    use crate::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpCodecParameters};
+    use crate::rtp_transceiver::{RTCRtpTransceiverDirection, RTCRtpTransceiverInit};
+    use interceptor::NoopInterceptor;
+
+    fn receiver(
+        kind: RtpCodecKind,
+        mid: &str,
+        payload_types: &[u8],
+    ) -> RTCRtpTransceiverInternal<NoopInterceptor> {
+        let mut transceiver = RTCRtpTransceiverInternal::new(
+            kind,
+            None,
+            RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Recvonly,
+                ..Default::default()
+            },
+        );
+        transceiver.set_mid(mid.to_owned()).expect("unique MID");
+        transceiver
+            .receiver_mut()
+            .as_mut()
+            .expect("receive-capable transceiver")
+            .set_codec_preferences(
+                payload_types
+                    .iter()
+                    .copied()
+                    .map(|payload_type| RTCRtpCodecParameters {
+                        rtp_codec: RTCRtpCodec {
+                            mime_type: match kind {
+                                RtpCodecKind::Audio if payload_type == 111 => {
+                                    "audio/opus".to_owned()
+                                }
+                                RtpCodecKind::Audio => "audio/telephone-event".to_owned(),
+                                RtpCodecKind::Video => "video/VP8".to_owned(),
+                                RtpCodecKind::Unspecified => String::new(),
+                            },
+                            clock_rate: 48_000,
+                            channels: 1,
+                            ..Default::default()
+                        },
+                        payload_type,
+                    })
+                    .collect(),
+            );
+        transceiver
+    }
+
+    #[test]
+    fn payload_type_requires_unique_receiver_unless_mid_selects_one() {
+        let transceivers = vec![
+            receiver(RtpCodecKind::Audio, "audio-0", &[111, 110]),
+            receiver(RtpCodecKind::Audio, "audio-1", &[111, 110]),
+            receiver(RtpCodecKind::Audio, "audio-2", &[126]),
+        ];
+
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 126, None),
+            Some(2),
+            "a unique negotiated payload type identifies its receiver"
+        );
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 110, None),
+            None,
+            "an ambiguous payload type must not use vector order as ownership"
+        );
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 110, Some("audio-1")),
+            Some(1),
+            "a negotiated MID disambiguates equal payload types"
+        );
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 126, Some("audio-1")),
+            None,
+            "MID selection still requires that receiver to negotiate the payload type"
+        );
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 110, Some("unknown")),
+            None,
+            "an unknown MID cannot escape its signaling context"
+        );
+    }
+
+    #[test]
+    fn mid_only_video_routes_to_its_authoritative_receiver() {
+        let transceivers = vec![
+            receiver(RtpCodecKind::Audio, "audio-0", &[111]),
+            receiver(RtpCodecKind::Video, "video-0", &[96]),
+        ];
+
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 96, Some("video-0")),
+            Some(1),
+            "an explicit MID must route an undeclared video SSRC"
+        );
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 96, Some("audio-0")),
+            None,
+            "the payload type cannot escape its authoritative MID"
+        );
+    }
+
+    #[test]
+    fn sole_video_without_header_extensions_uses_generic_fallback() {
+        let transceivers = vec![receiver(RtpCodecKind::Video, "video-0", &[96])];
+
+        assert_eq!(
+            undeclared_receiver_index(&transceivers, 96, None),
+            Some(0),
+            "a sole video receiver with no RID codings accepts an undeclared SSRC"
+        );
+
+        let bundled = vec![
+            receiver(RtpCodecKind::Video, "video-0", &[96]),
+            receiver(RtpCodecKind::Audio, "audio-0", &[111]),
+        ];
+        assert_eq!(
+            undeclared_receiver_index(&bundled, 96, None),
+            None,
+            "without MID, a video receiver is not selected from multiple media sections"
+        );
+    }
+
+    #[test]
+    fn supplemental_coding_is_appended_once_without_replacing_primary() {
+        let mut codings = vec![RTCRtpCodingParameters {
+            rid: String::new(),
+            ssrc: Some(1001),
+            rtx: None,
+            fec: None,
+        }];
+
+        assert!(append_undeclared_coding(&mut codings, 2002));
+        assert_eq!(codings.len(), 2);
+        assert_eq!(codings[0].ssrc, Some(1001));
+        assert_eq!(codings[1].ssrc, Some(2002));
+        assert!(!append_undeclared_coding(&mut codings, 2002));
+        assert!(!append_undeclared_coding(&mut codings, 1001));
+        assert_eq!(codings.len(), 2, "repeated packets reuse their coding");
+        assert_eq!(codings[0].ssrc, Some(1001));
     }
 }

--- a/crates/webrtc/rvoip-rtc/src/peer_connection/internal.rs
+++ b/crates/webrtc/rvoip-rtc/src/peer_connection/internal.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::peer_connection::event::{RTCPeerConnectionEvent, RTCPeerConnectionIceEvent};
 use crate::peer_connection::sdp::{
-    MediaSection, PopulateSdpParams, add_candidates_to_media_descriptions, get_by_mid,
-    get_peer_direction, get_rids, have_data_channel, is_ext_map_allow_mixed_set,
+    MediaSection, PopulateSdpParams, TrackDetails, add_candidates_to_media_descriptions,
+    get_by_mid, get_peer_direction, get_rids, have_data_channel, is_ext_map_allow_mixed_set,
     rtp_extensions_from_media_description, track_details_from_sdp,
 };
 use crate::peer_connection::state::signaling_state::check_next_signaling_state;
@@ -21,6 +21,24 @@ use crate::statistics::accumulator::IceCandidateAccumulator;
 use ::sdp::description::session::*;
 use ::sdp::util::ConnectionRole;
 use std::collections::HashSet;
+
+fn group_track_details_by_media_stream(tracks: Vec<TrackDetails>) -> Vec<Vec<TrackDetails>> {
+    let mut groups: Vec<Vec<TrackDetails>> = Vec::new();
+    for track in tracks {
+        if let Some(group) = groups.iter_mut().find(|group| {
+            let first = &group[0];
+            first.mid == track.mid
+                && first.kind == track.kind
+                && first.stream_id == track.stream_id
+                && first.track_id == track.track_id
+        }) {
+            group.push(track);
+        } else {
+            groups.push(vec![track]);
+        }
+    }
+    groups
+}
 
 impl<I> RTCPeerConnection<I>
 where
@@ -683,10 +701,12 @@ where
         } else {
             vec![]
         };
+        let incoming_track_groups = group_track_details_by_media_stream(incoming_tracks);
 
         let only_one_rtp_transceiver = self.rtp_transceivers.len() == 1;
 
-        for incoming_track in incoming_tracks.into_iter() {
+        for incoming_track_group in incoming_track_groups {
+            let incoming_track = incoming_track_group[0].clone();
             if let Some(transceiver) = self.rtp_transceivers.iter_mut().find(|transceiver| {
                 transceiver.mid().as_ref() == Some(&incoming_track.mid)
                     && incoming_track.kind == transceiver.kind()
@@ -724,30 +744,42 @@ where
                         incoming_track.kind,
                         codings,
                     ));
-                } else if let Some(ssrc) = incoming_track.ssrc {
-                    let rtp_coding_parameters = RTCRtpCodingParameters {
-                        rid: "".to_string(),
-                        ssrc: Some(ssrc),
-                        rtx: incoming_track
-                            .rtx_ssrc
-                            .map(|rtx_ssrc| RTCRtpRtxParameters { ssrc: rtx_ssrc }),
-                        fec: incoming_track
-                            .fec_ssrc
-                            .map(|fec_ssrc| RTCRtpFecParameters { ssrc: fec_ssrc }),
-                    };
+                } else if incoming_track_group
+                    .iter()
+                    .any(|track| track.ssrc.is_some())
+                {
+                    let mut codings = Vec::new();
+                    for declared_track in incoming_track_group {
+                        let Some(ssrc) = declared_track.ssrc else {
+                            continue;
+                        };
+                        let rtp_coding_parameters = RTCRtpCodingParameters {
+                            rid: "".to_string(),
+                            ssrc: Some(ssrc),
+                            rtx: declared_track
+                                .rtx_ssrc
+                                .map(|rtx_ssrc| RTCRtpRtxParameters { ssrc: rtx_ssrc }),
+                            fec: declared_track
+                                .fec_ssrc
+                                .map(|fec_ssrc| RTCRtpFecParameters { ssrc: fec_ssrc }),
+                        };
 
-                    receive_codings.push(rtp_coding_parameters.clone());
+                        receive_codings.push(rtp_coding_parameters.clone());
+                        codings.push(RTCRtpEncodingParameters {
+                            rtp_coding_parameters,
+                            // Defer each SSRC's codec until its first RTP
+                            // packet supplies the negotiated payload type.
+                            codec: Default::default(),
+                            ..Default::default()
+                        });
+                    }
 
                     receiver.set_track(MediaStreamTrack::new(
                         incoming_track.stream_id,
                         incoming_track.track_id,
                         format!("remote-{}-{}", incoming_track.kind, math_rand_alpha(16)), //TODO:// Label
                         incoming_track.kind,
-                        vec![RTCRtpEncodingParameters {
-                            rtp_coding_parameters,
-                            codec: Default::default(), // Defer receiver's track's codec until received the first RTP packet with payload_type in endpoint handler
-                            ..Default::default()
-                        }],
+                        codings,
                     ));
 
                     receiver.interceptor_remote_streams_op(
@@ -1325,5 +1357,40 @@ where
 
         // Clean up unreferenced codecs
         self.pipeline_context.stats.cleanup_unreferenced_codecs();
+    }
+}
+
+#[cfg(test)]
+mod supplemental_receiver_tests {
+    use super::{TrackDetails, group_track_details_by_media_stream};
+    use crate::rtp_transceiver::rtp_sender::RtpCodecKind;
+
+    fn track(track_id: &str, ssrc: u32) -> TrackDetails {
+        TrackDetails {
+            mid: "audio".to_owned(),
+            kind: RtpCodecKind::Audio,
+            stream_id: "stream".to_owned(),
+            track_id: track_id.to_owned(),
+            ssrc: Some(ssrc),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn same_msid_track_ssrcs_are_grouped_for_one_receiver_track() {
+        let groups = group_track_details_by_media_stream(vec![
+            track("shared", 1001),
+            track("shared", 2002),
+            track("other", 3003),
+        ]);
+
+        assert_eq!(groups.len(), 2);
+        let shared = groups
+            .iter()
+            .find(|group| group[0].track_id == "shared")
+            .expect("shared media track group");
+        assert_eq!(shared.len(), 2);
+        assert_eq!(shared[0].ssrc, Some(1001));
+        assert_eq!(shared[1].ssrc, Some(2002));
     }
 }

--- a/crates/webrtc/rvoip-rtc/src/peer_connection/sdp/mod.rs
+++ b/crates/webrtc/rvoip-rtc/src/peer_connection/sdp/mod.rs
@@ -164,6 +164,7 @@ use crate::peer_connection::transport::ice::parameters::RTCIceParameters;
 use crate::rtp_transceiver::direction::RTCRtpTransceiverDirection;
 use crate::rtp_transceiver::rtp_sender::rtp_codec::{RTCRtpCodec, RtpCodecKind};
 use crate::rtp_transceiver::rtp_sender::rtp_codec_parameters::RTCRtpCodecParameters;
+use crate::rtp_transceiver::rtp_sender::rtp_encoding_parameters::RTCRtpEncodingParameters;
 use crate::rtp_transceiver::{
     PayloadType, RtpStreamId, SSRC, internal::RTCRtpTransceiverInternal,
     rtp_sender::rtcp_parameters::RTCPFeedback,
@@ -825,6 +826,7 @@ where
         write_ssrc_attributes_for_simulcast: bool,
     ) -> (MediaDescription, Vec<RtpStreamId>) {
         let mut send_rids = vec![];
+        let media_kind = transceiver.kind();
 
         if let Some(sender) = transceiver.sender_mut() {
             let (encodings, track) = (
@@ -832,7 +834,23 @@ where
                 sender.track(),
             );
 
-            let is_simulcast = encodings.len() > 1;
+            // Multiple codec-distinct SSRCs on one audio sender are internal
+            // supplemental RTP bindings (for example Opus plus RFC 4733), not
+            // simulcast or additional MediaStreamTracks. RID simulcast
+            // requires multiple non-empty RIDs and a common codec identity.
+            let is_simulcast = encodings_are_rid_simulcast(&encodings);
+            let advertised_encoding_count =
+                if media_kind == RtpCodecKind::Audio && encodings.len() > 1 && !is_simulcast {
+                    // Unified Plan permits one MediaStreamTrack per audio
+                    // m-section. Advertising every codec-specific binding with
+                    // the same msid/track creates duplicate track ownership that
+                    // Chromium rejects. Only the first (primary) audio source is
+                    // SDP-signaled; RFC 8834 requires receivers to accept later
+                    // RTP from otherwise valid, un-signaled SSRCs.
+                    1
+                } else {
+                    encodings.len()
+                };
 
             media = media.with_property_attribute(format!(
                 "msid:{} {}",
@@ -841,7 +859,7 @@ where
             ));
 
             if write_ssrc_attributes_for_simulcast || !is_simulcast {
-                for encoding in &encodings {
+                for encoding in encodings.iter().take(advertised_encoding_count) {
                     if let Some(&ssrc) = encoding.rtp_coding_parameters.ssrc.as_ref() {
                         if let Some(rtx) = encoding.rtp_coding_parameters.rtx.as_ref() {
                             media = media.with_value_attribute(
@@ -1475,6 +1493,121 @@ pub(crate) fn has_ice_trickle_option(desc: &SessionDescription) -> bool {
     }
 
     false
+}
+
+fn encodings_are_rid_simulcast(encodings: &[RTCRtpEncodingParameters]) -> bool {
+    let Some(first) = encodings.first() else {
+        return false;
+    };
+    encodings.len() > 1
+        && encodings
+            .iter()
+            .all(|encoding| !encoding.rtp_coding_parameters.rid.is_empty())
+        && encodings
+            .iter()
+            .all(|encoding| encoding.codec == first.codec)
+}
+
+#[cfg(test)]
+mod supplemental_encoding_tests {
+    use super::*;
+    use crate::media_stream::track::MediaStreamTrack;
+    use crate::peer_connection::configuration::media_engine::{
+        MIME_TYPE_OPUS, MIME_TYPE_TELEPHONE_EVENT,
+    };
+    use crate::rtp_transceiver::RTCRtpTransceiverInit;
+    use crate::rtp_transceiver::rtp_sender::{RTCRtpCodingParameters, RTCRtpEncodingParameters};
+    use interceptor::NoopInterceptor;
+
+    fn encoding(
+        ssrc: u32,
+        rid: &str,
+        mime_type: &str,
+        clock_rate: u32,
+        channels: u16,
+    ) -> RTCRtpEncodingParameters {
+        RTCRtpEncodingParameters {
+            rtp_coding_parameters: RTCRtpCodingParameters {
+                rid: rid.to_owned(),
+                ssrc: Some(ssrc),
+                ..Default::default()
+            },
+            codec: RTCRtpCodec {
+                mime_type: mime_type.to_owned(),
+                clock_rate,
+                channels,
+                sdp_fmtp_line: String::new(),
+                rtcp_feedback: vec![],
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn codec_distinct_audio_encodings_are_not_rid_simulcast() {
+        let encodings = vec![
+            encoding(1001, "", MIME_TYPE_OPUS, 48_000, 2),
+            encoding(2002, "", MIME_TYPE_TELEPHONE_EVENT, 48_000, 1),
+        ];
+        assert!(!encodings_are_rid_simulcast(&encodings));
+
+        let simulcast = vec![
+            encoding(3003, "h", MIME_TYPE_OPUS, 48_000, 2),
+            encoding(4004, "l", MIME_TYPE_OPUS, 48_000, 2),
+        ];
+        assert!(encodings_are_rid_simulcast(&simulcast));
+    }
+
+    #[test]
+    fn supplemental_audio_encodings_signal_only_the_primary_track_ssrc() {
+        let encodings = vec![
+            encoding(1001, "", MIME_TYPE_OPUS, 48_000, 2),
+            encoding(2002, "", MIME_TYPE_TELEPHONE_EVENT, 48_000, 1),
+        ];
+        let track = MediaStreamTrack::new(
+            "stream".to_owned(),
+            "track".to_owned(),
+            "audio".to_owned(),
+            RtpCodecKind::Audio,
+            encodings.clone(),
+        );
+        let mut transceiver = RTCRtpTransceiverInternal::<NoopInterceptor>::new(
+            RtpCodecKind::Audio,
+            Some(track),
+            RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Sendrecv,
+                streams: vec![],
+                send_encodings: encodings,
+            },
+        );
+
+        let (media, send_rids) = RTCPeerConnection::<NoopInterceptor>::add_sender_sdp(
+            MediaDescription::default(),
+            &MediaEngine::default(),
+            &mut transceiver,
+            false,
+        );
+
+        let ssrc_values = media
+            .attributes
+            .iter()
+            .filter(|attribute| attribute.key == ATTR_KEY_SSRC)
+            .filter_map(|attribute| attribute.value.as_deref())
+            .collect::<Vec<_>>();
+        assert!(ssrc_values.iter().any(|value| value.starts_with("1001 ")));
+        assert!(
+            ssrc_values.iter().all(|value| !value.starts_with("2002 ")),
+            "supplemental codec bindings must not masquerade as another copy of the track"
+        );
+        assert!(send_rids.is_empty());
+        assert!(
+            media
+                .attributes
+                .iter()
+                .all(|attribute| attribute.key != SDP_ATTRIBUTE_RID
+                    && attribute.key != SDP_ATTRIBUTE_SIMULCAST)
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/webrtc/rvoip-rtc/src/peer_connection/sdp/mod.rs
+++ b/crates/webrtc/rvoip-rtc/src/peer_connection/sdp/mod.rs
@@ -1476,3 +1476,81 @@ pub(crate) fn has_ice_trickle_option(desc: &SessionDescription) -> bool {
 
     false
 }
+
+#[cfg(test)]
+mod supplemental_encoding_regression_tests {
+    use super::*;
+    use crate::media_stream::track::MediaStreamTrack;
+    use crate::peer_connection::configuration::media_engine::{
+        MIME_TYPE_OPUS, MIME_TYPE_TELEPHONE_EVENT,
+    };
+    use crate::rtp_transceiver::RTCRtpTransceiverInit;
+    use crate::rtp_transceiver::rtp_sender::{RTCRtpCodingParameters, RTCRtpEncodingParameters};
+    use interceptor::NoopInterceptor;
+
+    fn encoding(
+        ssrc: u32,
+        mime_type: &str,
+        clock_rate: u32,
+        channels: u16,
+    ) -> RTCRtpEncodingParameters {
+        RTCRtpEncodingParameters {
+            rtp_coding_parameters: RTCRtpCodingParameters {
+                ssrc: Some(ssrc),
+                ..Default::default()
+            },
+            codec: RTCRtpCodec {
+                mime_type: mime_type.to_owned(),
+                clock_rate,
+                channels,
+                sdp_fmtp_line: String::new(),
+                rtcp_feedback: vec![],
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn supplemental_audio_signals_primary_ssrc_without_empty_simulcast() {
+        let encodings = vec![
+            encoding(1001, MIME_TYPE_OPUS, 48_000, 2),
+            encoding(2002, MIME_TYPE_TELEPHONE_EVENT, 48_000, 1),
+        ];
+        let track = MediaStreamTrack::new(
+            "stream".to_owned(),
+            "track".to_owned(),
+            "audio".to_owned(),
+            RtpCodecKind::Audio,
+            encodings.clone(),
+        );
+        let mut transceiver = RTCRtpTransceiverInternal::<NoopInterceptor>::new(
+            RtpCodecKind::Audio,
+            Some(track),
+            RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Sendrecv,
+                streams: vec![],
+                send_encodings: encodings,
+            },
+        );
+
+        let (media, send_rids) = RTCPeerConnection::<NoopInterceptor>::add_sender_sdp(
+            MediaDescription::default(),
+            &MediaEngine::default(),
+            &mut transceiver,
+            false,
+        );
+
+        let ssrc_values = media
+            .attributes
+            .iter()
+            .filter(|attribute| attribute.key == ATTR_KEY_SSRC)
+            .filter_map(|attribute| attribute.value.as_deref())
+            .collect::<Vec<_>>();
+        assert!(ssrc_values.iter().any(|value| value.starts_with("1001 ")));
+        assert!(ssrc_values.iter().all(|value| !value.starts_with("2002 ")));
+        assert!(send_rids.is_empty());
+        assert!(media.attributes.iter().all(|attribute| {
+            attribute.key != SDP_ATTRIBUTE_RID && attribute.key != SDP_ATTRIBUTE_SIMULCAST
+        }));
+    }
+}

--- a/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/internal.rs
+++ b/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/internal.rs
@@ -406,3 +406,123 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RTCRtpSenderInternal;
+    use crate::media_stream::track::MediaStreamTrack;
+    use crate::peer_connection::configuration::media_engine::{
+        MIME_TYPE_OPUS, MIME_TYPE_TELEPHONE_EVENT, MediaEngine,
+    };
+    use crate::rtp_transceiver::rtp_sender::{
+        RTCRtpCodec, RTCRtpCodecParameters, RTCRtpCodingParameters, RTCRtpEncodingParameters,
+        RtpCodecKind,
+    };
+    use interceptor::{Interceptor, NoopInterceptor, StreamInfo, TaggedPacket, interceptor};
+    use shared::error::Error;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Interceptor)]
+    struct RecordingInterceptor<P: Interceptor> {
+        #[next]
+        inner: P,
+        bound_local: Arc<Mutex<Vec<StreamInfo>>>,
+    }
+
+    #[interceptor]
+    impl<P: Interceptor> RecordingInterceptor<P> {
+        #[overrides]
+        fn bind_local_stream(&mut self, info: &StreamInfo) {
+            self.bound_local
+                .lock()
+                .expect("recording interceptor mutex")
+                .push(info.clone());
+            self.inner.bind_local_stream(info);
+        }
+    }
+
+    fn codec(mime_type: &str, clock_rate: u32, channels: u16) -> RTCRtpCodec {
+        RTCRtpCodec {
+            mime_type: mime_type.to_owned(),
+            clock_rate,
+            channels,
+            sdp_fmtp_line: if mime_type.eq_ignore_ascii_case(MIME_TYPE_TELEPHONE_EVENT) {
+                "0-15".to_owned()
+            } else {
+                "minptime=10;useinbandfec=1".to_owned()
+            },
+            rtcp_feedback: vec![],
+        }
+    }
+
+    fn encoding(ssrc: u32, codec: RTCRtpCodec) -> RTCRtpEncodingParameters {
+        RTCRtpEncodingParameters {
+            rtp_coding_parameters: RTCRtpCodingParameters {
+                ssrc: Some(ssrc),
+                ..Default::default()
+            },
+            codec,
+            ..Default::default()
+        }
+    }
+
+    fn codec_parameters(payload_type: u8, codec: RTCRtpCodec) -> RTCRtpCodecParameters {
+        RTCRtpCodecParameters {
+            rtp_codec: codec,
+            payload_type,
+        }
+    }
+
+    #[test]
+    fn one_audio_sender_binds_primary_and_telephone_event_encodings_by_codec_identity() {
+        let opus_ssrc = 0x0102_0304;
+        let dtmf_ssrc = 0x0506_0708;
+        let opus = codec(MIME_TYPE_OPUS, 48_000, 2);
+        let telephone_event_48khz = codec(MIME_TYPE_TELEPHONE_EVENT, 48_000, 1);
+        let codings = vec![
+            encoding(opus_ssrc, opus.clone()),
+            encoding(dtmf_ssrc, telephone_event_48khz.clone()),
+        ];
+        let track = MediaStreamTrack::new(
+            "stream".to_owned(),
+            "track".to_owned(),
+            "audio".to_owned(),
+            RtpCodecKind::Audio,
+            codings.clone(),
+        );
+        let mut sender = RTCRtpSenderInternal::<RecordingInterceptor<NoopInterceptor>>::new(
+            RtpCodecKind::Audio,
+            track,
+            vec![],
+            codings,
+        );
+        sender.set_codec_preferences(vec![
+            codec_parameters(111, opus),
+            codec_parameters(101, codec(MIME_TYPE_TELEPHONE_EVENT, 8_000, 1)),
+            codec_parameters(110, telephone_event_48khz),
+        ]);
+
+        let bound_local = Arc::new(Mutex::new(Vec::new()));
+        let mut interceptor = RecordingInterceptor {
+            inner: NoopInterceptor::new(),
+            bound_local: Arc::clone(&bound_local),
+        };
+        sender.interceptor_local_streams_op(&MediaEngine::default(), &mut interceptor, true);
+
+        let bound = bound_local.lock().expect("bound stream records");
+        assert_eq!(bound.len(), 2, "both SSRC encodings must bind");
+        let opus_info = bound
+            .iter()
+            .find(|info| info.ssrc == opus_ssrc)
+            .expect("Opus stream binding");
+        assert_eq!(opus_info.payload_type, 111);
+        assert_eq!(opus_info.mime_type, MIME_TYPE_OPUS);
+        let dtmf_info = bound
+            .iter()
+            .find(|info| info.ssrc == dtmf_ssrc)
+            .expect("telephone-event stream binding");
+        assert_eq!(dtmf_info.payload_type, 110);
+        assert_eq!(dtmf_info.clock_rate, 48_000);
+        assert_eq!(dtmf_info.mime_type, MIME_TYPE_TELEPHONE_EVENT);
+    }
+}

--- a/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
@@ -228,38 +228,30 @@ where
     pub(crate) peer_connection: &'a mut RTCPeerConnection<I>,
 }
 
-fn outbound_payload_type(
-    requested_payload_type: crate::rtp_transceiver::PayloadType,
-    selected_codec: &RTCRtpCodecParameters,
+fn bind_outbound_packet_to_encoding(
+    packet: &mut rtp::Packet,
     codecs: &[RTCRtpCodecParameters],
     encodings: &[RTCRtpEncodingParameters],
-) -> crate::rtp_transceiver::PayloadType {
-    let Some(requested_codec) = codecs
+) -> Result<()> {
+    let encoding = encodings
         .iter()
-        .find(|codec| codec.payload_type == requested_payload_type)
-    else {
-        return selected_codec.payload_type;
-    };
-
-    // A negotiated codec is eligible on this track only when a coding on the
-    // track represents that exact negotiated payload type. This prevents an
-    // arbitrary codec from the m-line from being injected through an SSRC
-    // owned by this sender.
-    let represented_by_track = encodings.iter().any(|encoding| {
-        let (represented_codec, match_type) =
-            codec_parameters_fuzzy_search(&encoding.codec, codecs);
-        match_type != CodecMatch::None && represented_codec.payload_type == requested_payload_type
-    });
-
-    if represented_by_track
-        && requested_codec.rtp_codec.clock_rate == selected_codec.rtp_codec.clock_rate
-    {
-        requested_payload_type
-    } else {
-        // Preserve the legacy behavior for unnegotiated, unrepresented, or
-        // clock-rate-changing payload types.
-        selected_codec.payload_type
+        .find(|encoding| {
+            encoding
+                .rtp_coding_parameters
+                .ssrc
+                .is_some_and(|ssrc| ssrc == packet.header.ssrc)
+        })
+        .ok_or(Error::ErrRTPSenderNoBaseEncoding)?;
+    let (codec, match_type) = codec_parameters_fuzzy_search(&encoding.codec, codecs);
+    if match_type == CodecMatch::None {
+        return Err(Error::ErrRTPTransceiverCodecUnsupported);
     }
+
+    // Payload type belongs to the encoding selected by this packet's SSRC.
+    // A sibling supplemental encoding must never change the primary SSRC's
+    // codec binding, even when both codecs use the same RTP clock rate.
+    packet.header.payload_type = codec.payload_type;
+    Ok(())
 }
 
 impl<I> RTCRtpSender<'_, I>
@@ -410,24 +402,7 @@ where
         let parameters = sender.get_parameters(media_engine);
         let (codecs, encodings) = (&parameters.rtp_parameters.codecs, &parameters.encodings);
 
-        //From SSRC, find the encoding
-        let encoding = encodings
-            .iter()
-            .find(|encoding| {
-                encoding
-                    .rtp_coding_parameters
-                    .ssrc
-                    .is_some_and(|s| s == packet.header.ssrc)
-            })
-            .ok_or(Error::ErrRTPSenderNoBaseEncoding)?;
-        // From the encoding, fuzzy_search the codec which contains payload_type
-        let (codec, match_type) = codec_parameters_fuzzy_search(&encoding.codec, codecs);
-        if match_type == CodecMatch::None {
-            return Err(Error::ErrRTPTransceiverCodecUnsupported);
-        }
-
-        packet.header.payload_type =
-            outbound_payload_type(packet.header.payload_type, &codec, codecs, encodings);
+        bind_outbound_packet_to_encoding(&mut packet, codecs, encodings)?;
         let track_id = sender.track().track_id().to_string();
         self.peer_connection
             .handle_write(RTCMessage::RtpPacket(track_id, packet))
@@ -495,58 +470,30 @@ mod tests {
 
     #[test]
     fn outbound_payload_type_rejects_codec_bound_to_another_ssrc() {
+        let opus_ssrc = 0x0102_0304;
+        let telephone_event_ssrc = 0x0506_0708;
         let opus = codec(111, "audio/opus", 48_000);
         let telephone_event = codec(110, "audio/telephone-event", 48_000);
         let codecs = vec![opus.clone(), telephone_event.clone()];
         let encodings = vec![
-            encoding(0x0102_0304, &opus),
-            encoding(0x0506_0708, &telephone_event),
+            encoding(opus_ssrc, &opus),
+            encoding(telephone_event_ssrc, &telephone_event),
         ];
+        let mut opus_packet = rtp::Packet::default();
+        opus_packet.header.ssrc = opus_ssrc;
+        opus_packet.header.payload_type = telephone_event.payload_type;
+        bind_outbound_packet_to_encoding(&mut opus_packet, &codecs, &encodings)
+            .expect("Opus SSRC binding");
+        assert_eq!(opus_packet.header.payload_type, opus.payload_type);
 
+        let mut telephone_event_packet = rtp::Packet::default();
+        telephone_event_packet.header.ssrc = telephone_event_ssrc;
+        telephone_event_packet.header.payload_type = telephone_event.payload_type;
+        bind_outbound_packet_to_encoding(&mut telephone_event_packet, &codecs, &encodings)
+            .expect("telephone-event SSRC binding");
         assert_eq!(
-            outbound_payload_type(telephone_event.payload_type, &opus, &codecs, &encodings),
-            opus.payload_type
-        );
-    }
-
-    #[test]
-    fn outbound_payload_type_rejects_represented_codec_with_different_clock() {
-        let opus = codec(111, "audio/opus", 48_000);
-        let telephone_event = codec(101, "audio/telephone-event", 8_000);
-        let codecs = vec![opus.clone(), telephone_event.clone()];
-        let encodings = vec![
-            encoding(0x0102_0304, &opus),
-            encoding(0x0506_0708, &telephone_event),
-        ];
-
-        assert_eq!(
-            outbound_payload_type(telephone_event.payload_type, &opus, &codecs, &encodings),
-            opus.payload_type
-        );
-    }
-
-    #[test]
-    fn outbound_payload_type_rejects_negotiated_but_unrepresented_codec() {
-        let opus = codec(111, "audio/opus", 48_000);
-        let supplemental = codec(112, "audio/example", 48_000);
-        let codecs = vec![opus.clone(), supplemental.clone()];
-        let encodings = vec![encoding(0x0102_0304, &opus)];
-
-        assert_eq!(
-            outbound_payload_type(supplemental.payload_type, &opus, &codecs, &encodings),
-            opus.payload_type
-        );
-    }
-
-    #[test]
-    fn outbound_payload_type_rejects_unnegotiated_codec() {
-        let opus = codec(111, "audio/opus", 48_000);
-        let codecs = vec![opus.clone()];
-        let encodings = vec![encoding(0x0102_0304, &opus)];
-
-        assert_eq!(
-            outbound_payload_type(127, &opus, &codecs, &encodings),
-            opus.payload_type
+            telephone_event_packet.header.payload_type,
+            telephone_event.payload_type
         );
     }
 }

--- a/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
@@ -228,6 +228,40 @@ where
     pub(crate) peer_connection: &'a mut RTCPeerConnection<I>,
 }
 
+fn outbound_payload_type(
+    requested_payload_type: crate::rtp_transceiver::PayloadType,
+    selected_codec: &RTCRtpCodecParameters,
+    codecs: &[RTCRtpCodecParameters],
+    encodings: &[RTCRtpEncodingParameters],
+) -> crate::rtp_transceiver::PayloadType {
+    let Some(requested_codec) = codecs
+        .iter()
+        .find(|codec| codec.payload_type == requested_payload_type)
+    else {
+        return selected_codec.payload_type;
+    };
+
+    // A negotiated codec is eligible on this track only when a coding on the
+    // track represents that exact negotiated payload type. This prevents an
+    // arbitrary codec from the m-line from being injected through an SSRC
+    // owned by this sender.
+    let represented_by_track = encodings.iter().any(|encoding| {
+        let (represented_codec, match_type) =
+            codec_parameters_fuzzy_search(&encoding.codec, codecs);
+        match_type != CodecMatch::None && represented_codec.payload_type == requested_payload_type
+    });
+
+    if represented_by_track
+        && requested_codec.rtp_codec.clock_rate == selected_codec.rtp_codec.clock_rate
+    {
+        requested_payload_type
+    } else {
+        // Preserve the legacy behavior for unnegotiated, unrepresented, or
+        // clock-rate-changing payload types.
+        selected_codec.payload_type
+    }
+}
+
 impl<I> RTCRtpSender<'_, I>
 where
     I: Interceptor,
@@ -392,8 +426,9 @@ where
             return Err(Error::ErrRTPTransceiverCodecUnsupported);
         }
 
+        packet.header.payload_type =
+            outbound_payload_type(packet.header.payload_type, &codec, codecs, encodings);
         let track_id = sender.track().track_id().to_string();
-        packet.header.payload_type = codec.payload_type;
         self.peer_connection
             .handle_write(RTCMessage::RtpPacket(track_id, packet))
     }
@@ -423,5 +458,95 @@ where
         let track_id = sender.track().track_id().to_string();
         self.peer_connection
             .handle_write(RTCMessage::RtcpPacket(track_id, packets))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rtp_transceiver::rtp_sender::rtp_coding_parameters::RTCRtpCodingParameters;
+
+    fn codec(
+        payload_type: crate::rtp_transceiver::PayloadType,
+        mime_type: &str,
+        clock_rate: u32,
+    ) -> RTCRtpCodecParameters {
+        RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: mime_type.to_owned(),
+                clock_rate,
+                channels: 1,
+                ..Default::default()
+            },
+            payload_type,
+        }
+    }
+
+    fn encoding(ssrc: u32, codec: &RTCRtpCodecParameters) -> RTCRtpEncodingParameters {
+        RTCRtpEncodingParameters {
+            rtp_coding_parameters: RTCRtpCodingParameters {
+                ssrc: Some(ssrc),
+                ..Default::default()
+            },
+            codec: codec.rtp_codec.clone(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn outbound_payload_type_preserves_represented_same_clock_supplemental_codec() {
+        let opus = codec(111, "audio/opus", 48_000);
+        let telephone_event = codec(110, "audio/telephone-event", 48_000);
+        let codecs = vec![opus.clone(), telephone_event.clone()];
+        let encodings = vec![
+            encoding(0x0102_0304, &opus),
+            encoding(0x0506_0708, &telephone_event),
+        ];
+
+        assert_eq!(
+            outbound_payload_type(telephone_event.payload_type, &opus, &codecs, &encodings),
+            telephone_event.payload_type
+        );
+    }
+
+    #[test]
+    fn outbound_payload_type_rejects_represented_codec_with_different_clock() {
+        let opus = codec(111, "audio/opus", 48_000);
+        let telephone_event = codec(101, "audio/telephone-event", 8_000);
+        let codecs = vec![opus.clone(), telephone_event.clone()];
+        let encodings = vec![
+            encoding(0x0102_0304, &opus),
+            encoding(0x0506_0708, &telephone_event),
+        ];
+
+        assert_eq!(
+            outbound_payload_type(telephone_event.payload_type, &opus, &codecs, &encodings),
+            opus.payload_type
+        );
+    }
+
+    #[test]
+    fn outbound_payload_type_rejects_negotiated_but_unrepresented_codec() {
+        let opus = codec(111, "audio/opus", 48_000);
+        let supplemental = codec(112, "audio/example", 48_000);
+        let codecs = vec![opus.clone(), supplemental.clone()];
+        let encodings = vec![encoding(0x0102_0304, &opus)];
+
+        assert_eq!(
+            outbound_payload_type(supplemental.payload_type, &opus, &codecs, &encodings),
+            opus.payload_type
+        );
+    }
+
+    #[test]
+    fn outbound_payload_type_rejects_unnegotiated_codec() {
+        let opus = codec(111, "audio/opus", 48_000);
+        let codecs = vec![opus.clone()];
+        let encodings = vec![encoding(0x0102_0304, &opus)];
+
+        assert_eq!(
+            outbound_payload_type(127, &opus, &codecs, &encodings),
+            opus.payload_type
+        );
     }
 }

--- a/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
@@ -494,7 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn outbound_payload_type_preserves_represented_same_clock_supplemental_codec() {
+    fn outbound_payload_type_rejects_codec_bound_to_another_ssrc() {
         let opus = codec(111, "audio/opus", 48_000);
         let telephone_event = codec(110, "audio/telephone-event", 48_000);
         let codecs = vec![opus.clone(), telephone_event.clone()];
@@ -505,7 +505,7 @@ mod tests {
 
         assert_eq!(
             outbound_payload_type(telephone_event.payload_type, &opus, &codecs, &encodings),
-            telephone_event.payload_type
+            opus.payload_type
         );
     }
 

--- a/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
+++ b/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
@@ -265,3 +265,41 @@ pub(crate) fn rtcp_feedback_intersection(
 
     out
 }
+
+#[cfg(test)]
+mod regression_tests {
+    use super::*;
+
+    fn codec(
+        payload_type: PayloadType,
+        mime_type: &str,
+        clock_rate: u32,
+        channels: u16,
+        fmtp: &str,
+    ) -> RTCRtpCodecParameters {
+        RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: mime_type.to_owned(),
+                clock_rate,
+                channels,
+                sdp_fmtp_line: fmtp.to_owned(),
+                rtcp_feedback: vec![],
+            },
+            payload_type,
+        }
+    }
+
+    #[test]
+    fn telephone_event_match_respects_clock_rate() {
+        let haystack = [
+            codec(101, MIME_TYPE_TELEPHONE_EVENT, 8_000, 1, "0-15"),
+            codec(110, MIME_TYPE_TELEPHONE_EVENT, 48_000, 1, "0-15"),
+        ];
+        let needle = codec(0, MIME_TYPE_TELEPHONE_EVENT, 48_000, 1, "0-15");
+
+        let (matched, quality) = codec_parameters_fuzzy_search(&needle.rtp_codec, &haystack);
+
+        assert_eq!(quality, CodecMatch::Exact);
+        assert_eq!(matched.payload_type, 110);
+    }
+}

--- a/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
+++ b/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
@@ -123,10 +123,25 @@ pub(crate) enum CodecMatch {
     Exact = 2,
 }
 
+fn codec_identity_matches(needle: &RTCRtpCodec, candidate: &RTCRtpCodec) -> bool {
+    needle.mime_type.eq_ignore_ascii_case(&candidate.mime_type)
+        // A zero value is retained as an unspecified/wildcard value for
+        // callers constructed from SDP forms that omit an optional field.
+        && (needle.clock_rate == 0
+            || candidate.clock_rate == 0
+            || needle.clock_rate == candidate.clock_rate)
+        && (needle.channels == 0
+            || candidate.channels == 0
+            || needle.channels == candidate.channels)
+}
+
 /// Performs fuzzy search for a codec in a list of available codecs.
 ///
-/// First attempts an exact match on both MIME type and format parameters,
-/// then falls back to matching only the MIME type.
+/// First attempts an exact match on codec identity (MIME type, clock rate,
+/// and channel count) plus format parameters, then falls back to codec
+/// identity without requiring matching format parameters. A zero clock rate
+/// or channel count is treated as unspecified for compatibility with SDP
+/// forms that omit the optional value.
 ///
 /// # Parameters
 ///
@@ -144,17 +159,22 @@ pub(crate) fn codec_parameters_fuzzy_search(
 
     //TODO: add unicode case-folding equal support
 
-    // First attempt to match on mime_type + sdpfmtp_line
+    // First attempt to match codec identity + sdpfmtp_line.
     for c in haystack {
+        if !codec_identity_matches(needle_rtp_codec, &c.rtp_codec) {
+            continue;
+        }
         let cfmpt = fmtp::parse(&c.rtp_codec.mime_type, &c.rtp_codec.sdp_fmtp_line);
         if needle_fmtp.match_fmtp(&*cfmpt) {
             return (c.clone(), CodecMatch::Exact);
         }
     }
 
-    // Fallback to just mime_type
+    // Fallback keeps the codec identity constraints but permits an fmtp
+    // mismatch. In particular, it must not collapse separate RTP clock rates
+    // for codecs such as telephone-event into the first registered payload.
     for c in haystack {
-        if c.rtp_codec.mime_type.to_uppercase() == needle_rtp_codec.mime_type.to_uppercase() {
+        if codec_identity_matches(needle_rtp_codec, &c.rtp_codec) {
             return (c.clone(), CodecMatch::Partial);
         }
     }
@@ -264,6 +284,68 @@ pub(crate) fn rtcp_feedback_intersection(
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn codec(
+        payload_type: PayloadType,
+        mime_type: &str,
+        clock_rate: u32,
+        channels: u16,
+        fmtp: &str,
+    ) -> RTCRtpCodecParameters {
+        RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: mime_type.to_owned(),
+                clock_rate,
+                channels,
+                sdp_fmtp_line: fmtp.to_owned(),
+                rtcp_feedback: vec![],
+            },
+            payload_type,
+        }
+    }
+
+    #[test]
+    fn telephone_event_match_respects_clock_rate() {
+        let haystack = [
+            codec(101, MIME_TYPE_TELEPHONE_EVENT, 8_000, 1, "0-15"),
+            codec(110, MIME_TYPE_TELEPHONE_EVENT, 48_000, 1, "0-15"),
+        ];
+        let needle = codec(0, MIME_TYPE_TELEPHONE_EVENT, 48_000, 1, "0-15");
+
+        let (matched, quality) = codec_parameters_fuzzy_search(&needle.rtp_codec, &haystack);
+
+        assert_eq!(quality, CodecMatch::Exact);
+        assert_eq!(matched.payload_type, 110);
+    }
+
+    #[test]
+    fn partial_match_still_rejects_a_different_clock_rate() {
+        let haystack = [codec(101, MIME_TYPE_TELEPHONE_EVENT, 8_000, 1, "0-16")];
+        let needle = codec(0, MIME_TYPE_TELEPHONE_EVENT, 48_000, 1, "0-15");
+
+        let (_, quality) = codec_parameters_fuzzy_search(&needle.rtp_codec, &haystack);
+
+        assert_eq!(quality, CodecMatch::None);
+    }
+
+    #[test]
+    fn codec_match_respects_audio_channel_count() {
+        let haystack = [
+            codec(109, MIME_TYPE_OPUS, 48_000, 1, "minptime=10"),
+            codec(111, MIME_TYPE_OPUS, 48_000, 2, "minptime=10"),
+        ];
+        let needle = codec(0, MIME_TYPE_OPUS, 48_000, 2, "minptime=10");
+
+        let (matched, quality) = codec_parameters_fuzzy_search(&needle.rtp_codec, &haystack);
+
+        assert_eq!(quality, CodecMatch::Exact);
+        assert_eq!(matched.payload_type, 111);
+    }
 }
 
 #[cfg(test)]

--- a/crates/webrtc/rvoip-webrtc-stack/Cargo.toml
+++ b/crates/webrtc/rvoip-webrtc-stack/Cargo.toml
@@ -203,7 +203,7 @@ version = "0.3.31"
 version = "0.4.29"
 
 [dependencies.rtc]
-version = "0.3.4"
+version = "0.3.5"
 path = "../rvoip-rtc"
 package = "rvoip-rtc"
 

--- a/crates/webrtc/rvoip-webrtc/tests/browser_interop.rs
+++ b/crates/webrtc/rvoip-webrtc/tests/browser_interop.rs
@@ -31,7 +31,6 @@ use axum::{
     Router,
 };
 use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::page::EventLoadEventFired;
 use futures::StreamExt;
 use rvoip_webrtc::{WebRtcConfig, WebRtcServerBuilder};
 use tokio::net::TcpListener;
@@ -139,17 +138,14 @@ async fn headless_chromium_whip_publish_round_trip() {
     };
     let page_url =
         format!("http://{static_addr}/whip-publish.html?whip=http://{whip}/whip/browser-test");
-    let page = browser.new_page(&page_url).await.expect("open page");
-
-    // Wait for the load event.
-    let mut load_events = page
-        .event_listener::<EventLoadEventFired>()
-        .await
-        .expect("subscribe load");
-    tokio::time::timeout(Duration::from_secs(10), load_events.next())
+    // Subscribe/navigation ordering inside `new_page(url)` can let the load
+    // event fire before a separate listener is registered. Start from a blank
+    // target and use `goto`, whose completion is tied to that navigation.
+    let page = browser.new_page("about:blank").await.expect("open page");
+    tokio::time::timeout(Duration::from_secs(10), page.goto(&page_url))
         .await
         .expect("page load timeout")
-        .expect("page load stream closed");
+        .expect("page navigation failed");
 
     // 4. Click the Start button; the page handles getUserMedia + WHIP POST.
     page.find_element("#start")


### PR DESCRIPTION
## Summary
- prepare all 44 publishable crates at 0.3.5
- update current strict-beta metadata and release notes without changing historical evidence
- integrate the reviewed six-file Chromium RTC repair and its regression coverage
- correct the headless-Chrome load-event race and the SIP exact-terminal architecture fence

## Qualification completed locally
- coordinated release prepare and all-target check
- release metadata/attestation unit tests
- rvoip-rtc 184-test library suite
- strict rvoip-rtc all-target Clippy
- recorded Chromium SDP suite
- real headless-Chrome WHIP round trip
- formatting and whitespace checks

This PR must not merge until fresh GitHub CI is green. After merge, the exact origin/main commit will undergo a new full beta qualification before verification or publication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Coordinated version and qualification-policy changes affect the whole release train; RTC SDP/RTP routing and SIP terminal-release behavior are user-visible in WebRTC and SIP call paths.
> 
> **Overview**
> Prepares the coordinated **0.3.5** release: workspace and lockfile versions move to `0.3.5`, **CHANGELOG** documents security/media/SIP/WebRTC scope, and READMEs, beta checklists, interop plans, release notes, and attestation scripts now require a **fresh strict full-beta PASS** (no `0.3.4` carry-forward).
> 
> **WebRTC (`rvoip-rtc`)** fixes the confirmed Chromium regression: codec-distinct supplemental audio (e.g. RFC 4733) is no longer treated as RID simulcast—SDP advertises only the primary audio SSRC, outbound payload types bind per SSRC, codec matching respects clock rate/channels, undeclared SSRC routing uses MID or unique payload type (with tests), and multi-SSRC remote tracks group onto one receiver. **Browser interop** avoids a headless-Chrome load-event race by navigating with `goto` instead of subscribing after `new_page(url)`.
> 
> **SIP** architecture test for `publish_and_release_session` now expects `has_exact_terminal_fact` instead of snapshot lookup on release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6dbb3c3680eb9ee85a2bdd0664f44bc09e4ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->