### PR TITLE
Fix remote release fuzz gate invocation

### DIFF
--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -108,10 +108,6 @@ for _suffix, _target in FUZZ_TARGETS.items():
         "fuzz",
         "run",
         _target,
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml"
-        if _suffix in {"sip-message", "uri", "header", "sdp"}
-        else "{workspace}/crates/media/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10",
@@ -250,6 +246,14 @@ def dependencies(record: dict[str, Any], records: list[dict[str, Any]]) -> list[
 def legacy_gate(record: dict[str, Any], records: list[dict[str, Any]], packages: list[str]) -> dict[str, Any]:
     command = normalized_command(record)
     executor = "argv" if command else "legacy-group"
+    working_directory = "."
+    if record["id"].startswith("security.fuzz-"):
+        suffix = record["id"].removeprefix("security.fuzz-")
+        working_directory = (
+            "crates/sip/fuzz"
+            if suffix in {"sip-message", "uri", "header", "sdp"}
+            else "crates/media/fuzz"
+        )
     if record["id"] == "source.clean-start":
         # The remote runner can verify this directly without invoking the
         # macOS-only beta wrapper.
@@ -263,7 +267,7 @@ def legacy_gate(record: dict[str, Any], records: list[dict[str, Any]], packages:
         "executor": executor,
         "command": command,
         "display_command": record.get("sanitized_argv"),
-        "working_directory": ".",
+        "working_directory": working_directory,
         "dependencies": dependencies(record, records),
         "resource_class": resource_class(record),
         "timeout_minutes": max(5, math.ceil(duration / 60 * 2) + 5),

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -2181,8 +2181,6 @@
         "fuzz",
         "run",
         "sip_message",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2212,7 +2210,7 @@
         75
       ],
       "timeout_minutes": 7,
-      "working_directory": "."
+      "working_directory": "crates/sip/fuzz"
     },
     {
       "affected_crates": [],
@@ -2229,8 +2227,6 @@
         "fuzz",
         "run",
         "uri",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2260,7 +2256,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/sip/fuzz"
     },
     {
       "affected_crates": [],
@@ -2277,8 +2273,6 @@
         "fuzz",
         "run",
         "header",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2308,7 +2302,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/sip/fuzz"
     },
     {
       "affected_crates": [],
@@ -2325,8 +2319,6 @@
         "fuzz",
         "run",
         "sdp",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2356,7 +2348,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/sip/fuzz"
     },
     {
       "affected_crates": [],
@@ -2373,8 +2365,6 @@
         "fuzz",
         "run",
         "rtp_packet",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2404,7 +2394,7 @@
         75
       ],
       "timeout_minutes": 7,
-      "working_directory": "."
+      "working_directory": "crates/media/fuzz"
     },
     {
       "affected_crates": [],
@@ -2421,8 +2411,6 @@
         "fuzz",
         "run",
         "rtcp_packet",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2452,7 +2440,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/media/fuzz"
     },
     {
       "affected_crates": [],
@@ -2469,8 +2457,6 @@
         "fuzz",
         "run",
         "srtp_unprotect",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2500,7 +2486,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/media/fuzz"
     },
     {
       "affected_crates": [],
@@ -2517,8 +2503,6 @@
         "fuzz",
         "run",
         "dtls_record",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2548,7 +2532,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/media/fuzz"
     },
     {
       "affected_crates": [],
@@ -2565,8 +2549,6 @@
         "fuzz",
         "run",
         "stun_response",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2596,7 +2578,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/media/fuzz"
     },
     {
       "affected_crates": [],
@@ -2613,8 +2595,6 @@
         "fuzz",
         "run",
         "g711_unpack",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2644,7 +2624,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "."
+      "working_directory": "crates/media/fuzz"
     },
     {
       "affected_crates": [],

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -53,6 +53,45 @@ class GateFrameworkTests(unittest.TestCase):
         )
         self.assertEqual(generated, self.catalog)
 
+    def test_fuzz_gates_run_from_their_fuzz_crate(self) -> None:
+        fuzz_gates = [
+            gate
+            for gate in self.catalog["gates"]
+            if gate["id"].startswith("security.fuzz-")
+        ]
+        self.assertEqual(len(fuzz_gates), 10)
+        for gate in fuzz_gates:
+            with self.subTest(gate=gate["id"]):
+                self.assertIn(
+                    gate["working_directory"],
+                    {"crates/sip/fuzz", "crates/media/fuzz"},
+                )
+                self.assertNotIn("--manifest-path", gate["command"])
+
+    def test_multi_hour_performance_gates_are_isolated_from_perf_batch(self) -> None:
+        by_id = {gate["id"]: gate for gate in self.catalog["gates"]}
+        soak_ids = {
+            "perf.monolithic-soak",
+            "perf.media-burst-matrix",
+            "perf.soak-candidate",
+        }
+        self.assertEqual(
+            {by_id[gate_id]["resource_class"] for gate_id in soak_ids},
+            {"gcp-performance-soak"},
+        )
+        matrix = gates.matrix_for(
+            [
+                {"id": gate_id, "decision": "RUN"}
+                for gate_id in sorted(soak_ids | {"perf.resiliency-all"})
+            ],
+            by_id,
+        )
+        soak_shards = [
+            shard for shard in matrix if shard["resource_class"] == "gcp-performance-soak"
+        ]
+        self.assertEqual(len(soak_shards), 3)
+        self.assertTrue(all(len(shard["gates"]) == 1 for shard in soak_shards))
+
     def test_definition_digest_is_key_order_independent(self) -> None:
         first = {"id": "a", "command": ["true"]}
         second = {"command": ["true"], "id": "a"}


### PR DESCRIPTION
## Problem

The exact-candidate remote release qualification failed all ten legacy fuzz gates before execution because current `cargo-fuzz` does not accept `--manifest-path` on `cargo fuzz run`.

## Fix

- run SIP and media fuzz targets from their respective fuzz crate directories
- regenerate the version-neutral gate catalog
- add regression coverage for fuzz command generation
- lock in the existing separation of multi-hour soak gates from normal performance shards

## Verification

- `python3 -m unittest scripts/test_release.py scripts/test_release_gates.py scripts/test_release_carry_forward_attestation.py scripts/test_release_exception_attestation.py` (53 tests pass)
- `git diff --check`

No release, tag, package publication, or cloud deployment is performed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release gate metadata and test-only changes; behavior aligns with current cargo-fuzz CLI with no product runtime impact.
> 
> **Overview**
> Fixes remote release qualification for the ten **legacy** `security.fuzz-*` gates by dropping unsupported `--manifest-path` from `cargo fuzz run` and running each target from the correct fuzz crate directory instead.
> 
> `build_gate_catalog.py` now sets `working_directory` to `crates/sip/fuzz` or `crates/media/fuzz` per gate suffix; the regenerated `gates.json` matches. **`test_release_gates.py`** adds regression checks for fuzz cwd/command shape and asserts multi-hour soak gates stay on `gcp-performance-soak` as single-gate shards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da203171d159f403b2646e699367ff06bd08335b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->