### PR TITLE
Select fuzz projects explicitly in release gates

### DIFF
--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -102,12 +102,19 @@ FUZZ_TARGETS = {
 }
 
 for _suffix, _target in FUZZ_TARGETS.items():
+    _fuzz_dir = (
+        "{workspace}/crates/sip/fuzz"
+        if _suffix in {"sip-message", "uri", "header", "sdp"}
+        else "{workspace}/crates/media/fuzz"
+    )
     COMMAND_OVERRIDES[f"security.fuzz-{_suffix}"] = [
         "cargo",
         "+nightly",
         "fuzz",
         "run",
         _target,
+        "--fuzz-dir",
+        _fuzz_dir,
         "--",
         "-runs=1000",
         "-max_total_time=10",
@@ -246,14 +253,6 @@ def dependencies(record: dict[str, Any], records: list[dict[str, Any]]) -> list[
 def legacy_gate(record: dict[str, Any], records: list[dict[str, Any]], packages: list[str]) -> dict[str, Any]:
     command = normalized_command(record)
     executor = "argv" if command else "legacy-group"
-    working_directory = "."
-    if record["id"].startswith("security.fuzz-"):
-        suffix = record["id"].removeprefix("security.fuzz-")
-        working_directory = (
-            "crates/sip/fuzz"
-            if suffix in {"sip-message", "uri", "header", "sdp"}
-            else "crates/media/fuzz"
-        )
     if record["id"] == "source.clean-start":
         # The remote runner can verify this directly without invoking the
         # macOS-only beta wrapper.
@@ -267,7 +266,7 @@ def legacy_gate(record: dict[str, Any], records: list[dict[str, Any]], packages:
         "executor": executor,
         "command": command,
         "display_command": record.get("sanitized_argv"),
-        "working_directory": working_directory,
+        "working_directory": ".",
         "dependencies": dependencies(record, records),
         "resource_class": resource_class(record),
         "timeout_minutes": max(5, math.ceil(duration / 60 * 2) + 5),

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -2181,6 +2181,8 @@
         "fuzz",
         "run",
         "sip_message",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2210,7 +2212,7 @@
         75
       ],
       "timeout_minutes": 7,
-      "working_directory": "crates/sip/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2227,6 +2229,8 @@
         "fuzz",
         "run",
         "uri",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2256,7 +2260,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/sip/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2273,6 +2277,8 @@
         "fuzz",
         "run",
         "header",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2302,7 +2308,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/sip/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2319,6 +2325,8 @@
         "fuzz",
         "run",
         "sdp",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2348,7 +2356,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/sip/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2365,6 +2373,8 @@
         "fuzz",
         "run",
         "rtp_packet",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2394,7 +2404,7 @@
         75
       ],
       "timeout_minutes": 7,
-      "working_directory": "crates/media/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2411,6 +2421,8 @@
         "fuzz",
         "run",
         "rtcp_packet",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2440,7 +2452,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/media/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2457,6 +2469,8 @@
         "fuzz",
         "run",
         "srtp_unprotect",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2486,7 +2500,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/media/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2503,6 +2517,8 @@
         "fuzz",
         "run",
         "dtls_record",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2532,7 +2548,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/media/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2549,6 +2565,8 @@
         "fuzz",
         "run",
         "stun_response",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2578,7 +2596,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/media/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],
@@ -2595,6 +2613,8 @@
         "fuzz",
         "run",
         "g711_unpack",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2624,7 +2644,7 @@
         75
       ],
       "timeout_minutes": 6,
-      "working_directory": "crates/media/fuzz"
+      "working_directory": "."
     },
     {
       "affected_crates": [],

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -53,7 +53,7 @@ class GateFrameworkTests(unittest.TestCase):
         )
         self.assertEqual(generated, self.catalog)
 
-    def test_fuzz_gates_run_from_their_fuzz_crate(self) -> None:
+    def test_fuzz_gates_select_their_fuzz_crate_explicitly(self) -> None:
         fuzz_gates = [
             gate
             for gate in self.catalog["gates"]
@@ -62,11 +62,15 @@ class GateFrameworkTests(unittest.TestCase):
         self.assertEqual(len(fuzz_gates), 10)
         for gate in fuzz_gates:
             with self.subTest(gate=gate["id"]):
-                self.assertIn(
-                    gate["working_directory"],
-                    {"crates/sip/fuzz", "crates/media/fuzz"},
-                )
                 self.assertNotIn("--manifest-path", gate["command"])
+                index = gate["command"].index("--fuzz-dir")
+                self.assertIn(
+                    gate["command"][index + 1],
+                    {
+                        "{workspace}/crates/sip/fuzz",
+                        "{workspace}/crates/media/fuzz",
+                    },
+                )
 
     def test_multi_hour_performance_gates_are_isolated_from_perf_batch(self) -> None:
         by_id = {gate["id"]: gate for gate in self.catalog["gates"]}


### PR DESCRIPTION
## Problem

Changing a fuzz gate's working directory is insufficient inside the rvoip Cargo workspace: cargo-fuzz still searches for `<workspace>/fuzz/Cargo.toml`. The remote qualification receipts exposed this after the prior CLI-option fix.

## Fix

- select the SIP or media fuzz project with cargo-fuzz's supported `--fuzz-dir` option
- regenerate all ten fuzz gate definitions
- update regression coverage to require an explicit valid fuzz directory

## Verification

- all 53 release-tooling tests pass
- both fuzz projects enumerate all ten targets using `cargo +nightly fuzz list --fuzz-dir ...`
- `git diff --check`

This PR performs no release, tag, package publication, or cloud deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release gate definition and catalog generation only; no runtime product or security logic changes.
> 
> **Overview**
> **Release fuzz gates** no longer rely on `working_directory` under the workspace root. Each of the ten `security.fuzz-*` gates now passes **`cargo fuzz run … --fuzz-dir {workspace}/crates/sip/fuzz`** or **`…/crates/media/fuzz`** so cargo-fuzz targets the correct project instead of defaulting to `<workspace>/fuzz/Cargo.toml`.
> 
> `build_gate_catalog.py` injects `--fuzz-dir` in `COMMAND_OVERRIDES` and drops the special-case `working_directory` for fuzz IDs (all fuzz gates use `"."`). **`gates.json`** is regenerated to match. **`test_release_gates.py`** asserts an explicit `--fuzz-dir` path instead of crate-relative cwd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b73eaa60d231edd523fb62b4e0570a1bf93b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->