### PR TITLE
Harden release fuzz validation and route termination

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -182,6 +182,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.91.0
+      - name: Install nightly for release fuzz validation
+        if: matrix.gate == 'release-tooling'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: nightly
+      - name: Install cargo-fuzz for release fuzz validation
+        if: matrix.gate == 'release-tooling'
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
+        with:
+          tool: cargo-fuzz@0.13.2
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: main-specialty-${{ matrix.gate }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -42,6 +42,18 @@ jobs:
         with:
           toolchain: 1.91.0
 
+      - name: Install nightly for release fuzz validation
+        if: matrix.gate == 'release-tooling'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: nightly
+
+      - name: Install cargo-fuzz for release fuzz validation
+        if: matrix.gate == 'release-tooling'
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
+        with:
+          tool: cargo-fuzz@0.13.2
+
       - name: Calculate affected crates and gates
         id: plan
         shell: bash

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -42,18 +42,6 @@ jobs:
         with:
           toolchain: 1.91.0
 
-      - name: Install nightly for release fuzz validation
-        if: matrix.gate == 'release-tooling'
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
-        with:
-          toolchain: nightly
-
-      - name: Install cargo-fuzz for release fuzz validation
-        if: matrix.gate == 'release-tooling'
-        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
-        with:
-          tool: cargo-fuzz@0.13.2
-
       - name: Calculate affected crates and gates
         id: plan
         shell: bash
@@ -184,6 +172,18 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.91.0
+
+      - name: Install nightly for release fuzz validation
+        if: matrix.gate == 'release-tooling'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: nightly
+
+      - name: Install cargo-fuzz for release fuzz validation
+        if: matrix.gate == 'release-tooling'
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
+        with:
+          tool: cargo-fuzz@0.13.2
 
       - name: Restore content-addressed Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2

--- a/crates/sip/rvoip-sip/tests/response_builders_integration.rs
+++ b/crates/sip/rvoip-sip/tests/response_builders_integration.rs
@@ -16,7 +16,7 @@ use rvoip_sip::api::incoming::IncomingCall;
 use rvoip_sip::api::respond::AuthScheme;
 use rvoip_sip::api::stream_peer::EventReceiver;
 use rvoip_sip::api::unified::{Config, UnifiedCoordinator};
-use rvoip_sip::{SipTraceConfig, SipTraceDirection};
+use rvoip_sip::{SessionError, SipTraceConfig, SipTraceDirection};
 
 fn cfg(name: &str, port: u16) -> Config {
     let mut c = Config::local(name, port);
@@ -132,11 +132,16 @@ async fn assert_call_reached_terminal(
     coordinator: &std::sync::Arc<UnifiedCoordinator>,
     id: &CallId,
 ) {
-    coordinator
+    match coordinator
         .session(id)
         .wait_for_end(Some(Duration::from_secs(8)))
         .await
-        .expect("overload-rejected caller call must reach a terminal state");
+    {
+        Ok(_) | Err(SessionError::SessionNotFound(_)) => {}
+        Err(error) => panic!(
+            "overload-rejected caller call must reach a terminal state or be fully removed: {error}"
+        ),
+    }
 }
 
 async fn wait_for_no_sessions(coordinator: &UnifiedCoordinator, timeout: Duration) -> bool {

--- a/crates/webrtc/rvoip-amazon-connect/src/adapter.rs
+++ b/crates/webrtc/rvoip-amazon-connect/src/adapter.rs
@@ -1765,10 +1765,12 @@ impl AmazonConnectAdapter {
         connection_id: ConnectionId,
         route: Route,
     ) -> JoinHandle<()> {
+        // Subscribe before spawning so a terminal signal racing with task
+        // scheduling is retained by the watch channel for this supervisor.
+        let mut terminal = route.media.subscribe_terminal();
+        let mut dtmf = route.media.take_dtmf_events();
         tokio::spawn(async move {
             let prepared = route.prepared.as_ref().cloned();
-            let mut terminal = route.media.subscribe_terminal();
-            let mut dtmf = route.media.take_dtmf_events();
             let poll = environment
                 .config
                 .keepalive_interval
@@ -1780,28 +1782,39 @@ impl AmazonConnectAdapter {
                 if prepared.as_ref().is_some_and(|route| !route.is_live()) {
                     return;
                 }
+                // `watch::Receiver::changed` only observes versions newer
+                // than the receiver. Consume a terminal cause already stored
+                // in the channel before waiting, including one published
+                // before this task received its first poll.
+                let current_terminal = *terminal.borrow_and_update();
+                if let Some(cause) = current_terminal {
+                    let event = match cause {
+                        ConnectMediaTerminalCause::RemoteEnded
+                        | ConnectMediaTerminalCause::TransportClosed => AdapterEvent::Ended {
+                            connection_id: connection_id.clone(),
+                            reason: EndReason::Normal,
+                        },
+                        ConnectMediaTerminalCause::RemoteError { .. }
+                        | ConnectMediaTerminalCause::TransportError
+                        | ConnectMediaTerminalCause::PeerFailed => AdapterEvent::Failed {
+                            connection_id: connection_id.clone(),
+                            detail: "Amazon media session failed".into(),
+                        },
+                    };
+                    let _ = environment
+                        .terminate_active(&connection_id, event, false)
+                        .await;
+                    return;
+                }
                 tokio::select! {
                     _ = route.cancel.notified() => return,
                     changed = terminal.changed() => {
-                        let cause = if changed.is_err() {
-                            ConnectMediaTerminalCause::TransportClosed
-                        } else if let Some(cause) = *terminal.borrow_and_update() {
-                            cause
-                        } else {
+                        if changed.is_ok() {
                             continue;
-                        };
-                        let event = match cause {
-                            ConnectMediaTerminalCause::RemoteEnded
-                            | ConnectMediaTerminalCause::TransportClosed => AdapterEvent::Ended {
-                                connection_id: connection_id.clone(),
-                                reason: EndReason::Normal,
-                            },
-                            ConnectMediaTerminalCause::RemoteError { .. }
-                            | ConnectMediaTerminalCause::TransportError
-                            | ConnectMediaTerminalCause::PeerFailed => AdapterEvent::Failed {
-                                connection_id: connection_id.clone(),
-                                detail: "Amazon media session failed".into(),
-                            },
+                        }
+                        let event = AdapterEvent::Ended {
+                            connection_id: connection_id.clone(),
+                            reason: EndReason::Normal,
                         };
                         let _ = environment
                             .terminate_active(&connection_id, event, false)

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -191,7 +191,35 @@ def specialty_commands(
                 ],
                 None,
                 None,
-            )
+            ),
+            (
+                [
+                    "cargo",
+                    "+nightly",
+                    "fuzz",
+                    "check",
+                    "--fuzz-dir",
+                    "crates/sip/fuzz",
+                    "--target",
+                    "x86_64-unknown-linux-gnu",
+                ],
+                None,
+                None,
+            ),
+            (
+                [
+                    "cargo",
+                    "+nightly",
+                    "fuzz",
+                    "check",
+                    "--fuzz-dir",
+                    "crates/media/fuzz",
+                    "--target",
+                    "x86_64-unknown-linux-gnu",
+                ],
+                None,
+                None,
+            ),
         ]
     if gate == "rtp-interop":
         return [(["bash", "scripts/test_libsrtp_interop.sh"], None, None)]

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -26,6 +26,15 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn("contents: write", text)
         self.assertNotIn("pull_request_target", text)
 
+    def test_main_release_tooling_installs_its_fuzz_toolchain(self) -> None:
+        text = (ROOT / ".github/workflows/main-ci.yml").read_text()
+        specialty = text.split("\n  specialty:\n", maxsplit=1)[1].split(
+            "\n  main-gate:\n", maxsplit=1
+        )[0]
+        self.assertIn("Install nightly for release fuzz validation", specialty)
+        self.assertIn("cargo-fuzz@0.13.2", specialty)
+        self.assertGreaterEqual(specialty.count("matrix.gate == 'release-tooling'"), 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -115,6 +115,11 @@ for _suffix, _target in FUZZ_TARGETS.items():
         _target,
         "--fuzz-dir",
         _fuzz_dir,
+        # GitHub's hosted environment may set a static-musl Cargo target.
+        # libFuzzer's AddressSanitizer requires the runner's dynamically
+        # linked GNU target instead.
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10",

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -2183,6 +2183,8 @@
         "sip_message",
         "--fuzz-dir",
         "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2231,6 +2233,8 @@
         "uri",
         "--fuzz-dir",
         "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2279,6 +2283,8 @@
         "header",
         "--fuzz-dir",
         "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2327,6 +2333,8 @@
         "sdp",
         "--fuzz-dir",
         "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2375,6 +2383,8 @@
         "rtp_packet",
         "--fuzz-dir",
         "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2423,6 +2433,8 @@
         "rtcp_packet",
         "--fuzz-dir",
         "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2471,6 +2483,8 @@
         "srtp_unprotect",
         "--fuzz-dir",
         "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2519,6 +2533,8 @@
         "dtls_record",
         "--fuzz-dir",
         "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2567,6 +2583,8 @@
         "stun_response",
         "--fuzz-dir",
         "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -2615,6 +2633,8 @@
         "g711_unpack",
         "--fuzz-dir",
         "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -71,6 +71,11 @@ class GateFrameworkTests(unittest.TestCase):
                         "{workspace}/crates/media/fuzz",
                     },
                 )
+                target_index = gate["command"].index("--target")
+                self.assertEqual(
+                    gate["command"][target_index + 1],
+                    "x86_64-unknown-linux-gnu",
+                )
 
     def test_multi_hour_performance_gates_are_isolated_from_perf_batch(self) -> None:
         by_id = {gate["id"]: gate for gate in self.catalog["gates"]}


### PR DESCRIPTION
## Problems

1. Hosted release fuzz gates inherited a static musl target, which is incompatible with AddressSanitizer.
2. The fail-safe workspace run exposed a production race in Amazon Connect route supervision: a remote terminal signal could arrive before the supervisor first polled its watch receiver and then be missed indefinitely.

## Fixes

- pin all hosted fuzz gates to `x86_64-unknown-linux-gnu`
- require release-tooling PRs to compile both fuzz projects with pinned nightly and cargo-fuzz
- subscribe before spawning route supervision and consume any terminal cause already stored before waiting for a newer watch version

## Verification

- hosted specialty release-tooling compiled both fuzz projects successfully
- all 53 release-tooling tests pass
- focused remote-end regression passed 50 consecutive repetitions locally
- all 63 `rvoip-amazon-connect` library tests pass locally
- the refreshed PR Gate is running full fail-safe workspace tests and Clippy

No release, tag, package publication, or cloud deployment is performed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Connect route supervision changes fix a real termination race in production media paths; fuzz/CI changes are lower risk but broaden required toolchain on release-tooling jobs.
> 
> **Overview**
> **Release fuzz on GitHub** now pins `x86_64-unknown-linux-gnu` on all security fuzz `run` gates (catalog + generator) so libFuzzer/ASan is not built against a static musl target. The **release-tooling** specialty gate installs nightly and `cargo-fuzz@0.13.2` in main/PR workflows and runs `cargo fuzz check` for SIP and media fuzz trees; policy tests assert those install steps exist.
> 
> **Amazon Connect** `spawn_route_supervisor` subscribes to the terminal watch channel before spawning and, each loop iteration, handles any cause already stored via `borrow_and_update` so an early remote terminal signal is not missed; channel close is treated as a normal end.
> 
> **SIP integration** overload tests treat `SessionError::SessionNotFound` as an acceptable terminal outcome when the rejected caller session is already gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4806a36460dba470ead72be88546ac5b63626b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->