### PR TITLE
Send browser DTMF on the negotiated audio source

### DIFF
--- a/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/crates/webrtc/rvoip-rtc/src/rtp_transceiver/rtp_sender/mod.rs
@@ -247,10 +247,23 @@ fn bind_outbound_packet_to_encoding(
         return Err(Error::ErrRTPTransceiverCodecUnsupported);
     }
 
-    // Payload type belongs to the encoding selected by this packet's SSRC.
-    // A sibling supplemental encoding must never change the primary SSRC's
-    // codec binding, even when both codecs use the same RTP clock rate.
-    packet.header.payload_type = codec.payload_type;
+    // RFC 4733 telephone-events are an alternate audio payload on the
+    // primary audio source. Preserve an explicitly requested, negotiated
+    // telephone-event PT on that SSRC so it shares the regular audio
+    // sequence/timestamp base. Other packets remain bound to the codec of
+    // their selected encoding and cannot borrow an arbitrary sibling PT.
+    let requested = codecs
+        .iter()
+        .find(|candidate| candidate.payload_type == packet.header.payload_type);
+    let is_negotiated_telephone_event = requested.is_some_and(|candidate| {
+        candidate
+            .rtp_codec
+            .mime_type
+            .eq_ignore_ascii_case("audio/telephone-event")
+    });
+    if !is_negotiated_telephone_event {
+        packet.header.payload_type = codec.payload_type;
+    }
     Ok(())
 }
 
@@ -469,31 +482,37 @@ mod tests {
     }
 
     #[test]
-    fn outbound_payload_type_rejects_codec_bound_to_another_ssrc() {
+    fn outbound_payload_type_allows_rfc4733_on_primary_audio_ssrc_only() {
         let opus_ssrc = 0x0102_0304;
         let telephone_event_ssrc = 0x0506_0708;
         let opus = codec(111, "audio/opus", 48_000);
         let telephone_event = codec(110, "audio/telephone-event", 48_000);
         let codecs = vec![opus.clone(), telephone_event.clone()];
-        let encodings = vec![
-            encoding(opus_ssrc, &opus),
-            encoding(telephone_event_ssrc, &telephone_event),
-        ];
+        let encodings = vec![encoding(opus_ssrc, &opus)];
         let mut opus_packet = rtp::Packet::default();
         opus_packet.header.ssrc = opus_ssrc;
         opus_packet.header.payload_type = telephone_event.payload_type;
         bind_outbound_packet_to_encoding(&mut opus_packet, &codecs, &encodings)
             .expect("Opus SSRC binding");
-        assert_eq!(opus_packet.header.payload_type, opus.payload_type);
+        assert_eq!(
+            opus_packet.header.payload_type, telephone_event.payload_type,
+            "RFC 4733 must remain on the primary audio source"
+        );
+
+        let mut unknown_packet = rtp::Packet::default();
+        unknown_packet.header.ssrc = opus_ssrc;
+        unknown_packet.header.payload_type = 123;
+        bind_outbound_packet_to_encoding(&mut unknown_packet, &codecs, &encodings)
+            .expect("unknown PT falls back to the SSRC codec");
+        assert_eq!(unknown_packet.header.payload_type, opus.payload_type);
 
         let mut telephone_event_packet = rtp::Packet::default();
         telephone_event_packet.header.ssrc = telephone_event_ssrc;
         telephone_event_packet.header.payload_type = telephone_event.payload_type;
-        bind_outbound_packet_to_encoding(&mut telephone_event_packet, &codecs, &encodings)
-            .expect("telephone-event SSRC binding");
-        assert_eq!(
-            telephone_event_packet.header.payload_type,
-            telephone_event.payload_type
+        assert!(
+            bind_outbound_packet_to_encoding(&mut telephone_event_packet, &codecs, &encodings)
+                .is_err(),
+            "an unadvertised supplemental SSRC must not be accepted"
         );
     }
 }

--- a/crates/webrtc/rvoip-webrtc/src/media/dtmf.rs
+++ b/crates/webrtc/rvoip-webrtc/src/media/dtmf.rs
@@ -4,11 +4,11 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(test)]
 use rtc::rtp;
-use webrtc::media_stream::track_local::static_rtp::TrackLocalStaticRTP;
 
 use crate::errors::{Result, WebRtcError};
-use crate::media::outbound::sdes_mid_header_extension;
+use crate::media::outbound::OutboundAudioRtpWriter;
 pub use crate::peer::builder::TELEPHONE_EVENT_PAYLOAD_TYPE;
 use crate::peer::RvoipPeerConnection;
 
@@ -58,65 +58,6 @@ pub enum OutboundDtmfNegotiation {
     Pending,
     Negotiated(TelephoneEventCodec),
     Unsupported,
-}
-
-/// Per-peer outbound RFC 4733 sequence/timestamp state.
-///
-/// The state is held behind the owning peer's async mutex for the complete
-/// digit sequence. That keeps concurrent application calls from interleaving
-/// events on one SSRC and preserves one RTP sequence/timestamp timeline across
-/// successive `send_dtmf` calls.
-#[derive(Debug)]
-pub(crate) struct DtmfSenderState {
-    next_sequence_number: u16,
-    next_timestamp: u32,
-}
-
-impl DtmfSenderState {
-    #[must_use]
-    pub(crate) fn new() -> Self {
-        let seed = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
-        Self {
-            next_sequence_number: seed as u16,
-            next_timestamp: ((seed >> 16) as u32) | 1,
-        }
-    }
-
-    fn next_sequence_number(&mut self) -> u16 {
-        let sequence_number = self.next_sequence_number;
-        self.next_sequence_number = self.next_sequence_number.wrapping_add(1);
-        sequence_number
-    }
-
-    fn reserve_event_timestamp(&mut self, timing: DtmfTiming) -> u32 {
-        let timestamp = self.next_timestamp;
-        // `send_single_digit` emits its final duration one tick before the
-        // represented end of the event. `send_dtmf` waits that last tick
-        // before starting another digit, so adjacent event timestamps advance
-        // by the exact negotiated-clock duration without overlap.
-        self.next_timestamp = self
-            .next_timestamp
-            .wrapping_add(u32::from(timing.final_duration_samples));
-        timestamp
-    }
-}
-
-trait DtmfTimeline {
-    fn next_sequence_number(&mut self) -> u16;
-    fn reserve_event_timestamp(&mut self, timing: DtmfTiming) -> u32;
-}
-
-impl DtmfTimeline for DtmfSenderState {
-    fn next_sequence_number(&mut self) -> u16 {
-        DtmfSenderState::next_sequence_number(self)
-    }
-
-    fn reserve_event_timestamp(&mut self, timing: DtmfTiming) -> u32 {
-        DtmfSenderState::reserve_event_timestamp(self, timing)
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -324,6 +265,7 @@ impl DtmfDecoder {
     }
 }
 
+#[cfg(test)]
 fn telephone_event_packet(
     codec: TelephoneEventCodec,
     sequence_number: u16,
@@ -354,11 +296,9 @@ fn telephone_event_packet(
 
 #[allow(clippy::too_many_arguments)]
 async fn write_telephone_event(
-    track: &Arc<TrackLocalStaticRTP>,
+    writer: &Arc<OutboundAudioRtpWriter>,
     mid: &str,
     codec: TelephoneEventCodec,
-    sequence_number: u16,
-    ssrc: u32,
     event: u8,
     end_of_event: bool,
     volume: u8,
@@ -366,40 +306,32 @@ async fn write_telephone_event(
     timestamp: u32,
     marker: bool,
 ) -> Result<()> {
-    let pkt = telephone_event_packet(
-        codec,
-        sequence_number,
-        ssrc,
-        event,
-        end_of_event,
-        volume,
-        duration,
-        timestamp,
-        marker,
-    );
+    let payload = encode_telephone_event(event, end_of_event, volume, duration);
     tracing::trace!(
         payload_type = codec.payload_type,
         clock_rate_hz = codec.clock_rate_hz,
-        sequence_number,
-        ssrc,
+        ssrc = writer.ssrc(),
         mid,
         event,
         end_of_event,
         duration,
         "writing negotiated WebRTC telephone-event RTP"
     );
-    track
-        .write_rtp_with_extensions(pkt, &[sdes_mid_header_extension(mid)])
+    writer
+        .write_supplemental_audio(
+            codec.payload_type,
+            timestamp,
+            marker,
+            bytes::Bytes::copy_from_slice(&payload),
+        )
         .await
-        .map_err(|e| WebRtcError::Webrtc(format!("DTMF write_rtp_with_extensions: {e}")))
+        .map_err(|e| WebRtcError::Webrtc(format!("DTMF write_supplemental_audio: {e}")))
 }
 
-async fn send_single_digit<S: DtmfTimeline>(
-    track: &Arc<TrackLocalStaticRTP>,
+async fn send_single_digit(
+    writer: &Arc<OutboundAudioRtpWriter>,
     mid: &str,
     codec: TelephoneEventCodec,
-    state: &mut S,
-    ssrc: u32,
     digit: char,
     duration_ms: u32,
 ) -> Result<()> {
@@ -407,15 +339,15 @@ async fn send_single_digit<S: DtmfTimeline>(
         .ok_or_else(|| WebRtcError::Adapter(format!("invalid DTMF digit '{digit}'")))?;
 
     let timing = DtmfTiming::new(codec, duration_ms)?;
-    let start_timestamp = state.reserve_event_timestamp(timing);
+    let start_timestamp = writer
+        .reserve_telephone_event_timestamp(codec.clock_rate_hz, timing.final_duration_samples)
+        .await;
     let mut duration_samples = timing.samples_per_tick;
 
     write_telephone_event(
-        track,
+        writer,
         mid,
         codec,
-        state.next_sequence_number(),
-        ssrc,
         event_code,
         false,
         DEFAULT_VOLUME,
@@ -430,11 +362,9 @@ async fn send_single_digit<S: DtmfTimeline>(
         tokio::time::sleep(TICK).await;
         duration_samples = duration_samples.saturating_add(timing.samples_per_tick);
         write_telephone_event(
-            track,
+            writer,
             mid,
             codec,
-            state.next_sequence_number(),
-            ssrc,
             event_code,
             false,
             DEFAULT_VOLUME,
@@ -449,11 +379,9 @@ async fn send_single_digit<S: DtmfTimeline>(
     duration_samples = duration_samples.saturating_add(timing.samples_per_tick);
     for _ in 0..END_OF_EVENT_RETRANSMITS {
         write_telephone_event(
-            track,
+            writer,
             mid,
             codec,
-            state.next_sequence_number(),
-            ssrc,
             event_code,
             true,
             DEFAULT_VOLUME,
@@ -470,20 +398,16 @@ async fn send_single_digit<S: DtmfTimeline>(
 /// Send one or more DTMF digits using the remote SDP's negotiated RFC 4733
 /// payload type and clock rate.
 ///
-/// Telephone events use the negotiated telephone-event encoding's dedicated
-/// SSRC and carry the exact negotiated audio MID. This avoids changing the RTP
-/// payload mapping of the primary audio SSRC (which the alpha WebRTC engine
-/// rewrites to the primary codec) and permits a separately negotiated event
-/// clock as clarified by the verified RFC 4733 erratum. Pending or unsupported
-/// final SDP fails closed before any packet is written.
+/// Telephone events use the primary negotiated audio SSRC, sequence-number
+/// owner, timestamp base, and MID as required by RFC 4733. Pending or
+/// unsupported final SDP fails closed before any packet is written.
 pub async fn send_dtmf(
     peer: &Arc<RvoipPeerConnection>,
     digits: &str,
     duration_ms: u32,
 ) -> Result<()> {
     let codec = outbound_codec_for_sender(peer.outbound_dtmf_negotiation())?;
-    // The supplemental DTMF SSRC is intentionally not signalled in SDP.
-    // Require the exact mutually negotiated audio MID so packet demux never
+    // Require the exact mutually negotiated audio MID so BUNDLE demux never
     // falls back to payload-type or first-m-line heuristics.
     let mid = peer
         .negotiated_outbound_audio_mid()
@@ -492,16 +416,13 @@ pub async fn send_dtmf(
         .chars()
         .filter(|digit| !digit.is_whitespace())
         .collect::<Vec<_>>();
-    let track = peer
-        .local_dtmf_track()
+    peer.local_dtmf_track()
         .ok_or(WebRtcError::IncompatibleCapabilities)?;
-    let ssrc = peer
-        .local_dtmf_ssrc_for_codec(codec)
+    let writer = peer
+        .outbound_audio_writer()
         .ok_or(WebRtcError::IncompatibleCapabilities)?;
-    let mut states = peer.dtmf_sender_states().lock().await;
-    let state = states.entry(ssrc).or_insert_with(DtmfSenderState::new);
     for (index, digit) in digits.iter().copied().enumerate() {
-        send_single_digit(&track, &mid, codec, state, ssrc, digit, duration_ms).await?;
+        send_single_digit(&writer, &mid, codec, digit, duration_ms).await?;
         if index + 1 < digits.len() {
             tokio::time::sleep(TICK).await;
         }
@@ -513,6 +434,7 @@ pub async fn send_dtmf(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::media::outbound::sdes_mid_header_extension;
     use crate::peer::builder::HDREXT_SDES_MID;
     use rtc::shared::marshal::Marshal;
 
@@ -604,14 +526,10 @@ mod tests {
         assert_eq!(timing.total_ticks, 6);
         assert_eq!(timing.final_duration_samples, 5_760);
 
-        let mut state = DtmfSenderState {
-            next_sequence_number: 400,
-            next_timestamp: 48_000,
-        };
-        let timestamp = state.reserve_event_timestamp(timing);
+        let timestamp = 48_000;
         let first = telephone_event_packet(
             codec,
-            state.next_sequence_number(),
+            400,
             7,
             6,
             false,
@@ -622,7 +540,7 @@ mod tests {
         );
         let final_packet = telephone_event_packet(
             codec,
-            state.next_sequence_number(),
+            401,
             7,
             6,
             true,
@@ -640,7 +558,6 @@ mod tests {
         assert_eq!(final_packet.header.sequence_number, 401);
         assert_eq!(final_packet.header.timestamp, first.header.timestamp);
         assert_eq!(&final_packet.payload[2..], &5_760_u16.to_be_bytes());
-        assert_eq!(state.next_timestamp, 53_760);
     }
 
     #[test]

--- a/crates/webrtc/rvoip-webrtc/src/media/outbound.rs
+++ b/crates/webrtc/rvoip-webrtc/src/media/outbound.rs
@@ -94,6 +94,39 @@ impl OutboundAudioRtpState {
         self.last_wire_timestamp = Some(timestamp);
         timestamp
     }
+
+    fn reserve_telephone_event_timestamp(
+        &mut self,
+        audio_clock_rate_hz: u32,
+        event_clock_rate_hz: u32,
+        event_duration_samples: u16,
+    ) -> u32 {
+        let samples_per_audio_frame = (audio_clock_rate_hz / 50).max(1);
+        let start_audio = self
+            .last_wire_timestamp
+            .map_or_else(initial_rtp_timestamp, |last| {
+                last.wrapping_add(samples_per_audio_frame)
+            });
+        let duration_audio = ((u64::from(event_duration_samples) * u64::from(audio_clock_rate_hz)
+            + u64::from(event_clock_rate_hz).saturating_sub(1))
+            / u64::from(event_clock_rate_hz))
+        .max(1) as u32;
+        self.last_wire_timestamp = Some(start_audio.wrapping_add(duration_audio));
+        self.last_source_timestamp = None;
+
+        // RFC 4733 requires named events to use the regular audio channel's
+        // timestamp base. Only the duration field uses the telephone-event
+        // clock when its negotiated rate differs from primary audio.
+        start_audio
+    }
+}
+
+fn initial_rtp_timestamp() -> u32 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos()
+        | 1
 }
 
 /// The single enqueue boundary for primary audio RTP.
@@ -168,6 +201,65 @@ impl OutboundAudioRtpWriter {
             .mid
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = mid;
+    }
+
+    pub(crate) fn ssrc(&self) -> u32 {
+        self.ssrc
+    }
+
+    pub(crate) async fn reserve_telephone_event_timestamp(
+        &self,
+        event_clock_rate_hz: u32,
+        event_duration_samples: u16,
+    ) -> u32 {
+        self.state.lock().await.reserve_telephone_event_timestamp(
+            self.clock_rate_hz,
+            event_clock_rate_hz,
+            event_duration_samples,
+        )
+    }
+
+    pub(crate) async fn write_supplemental_audio(
+        &self,
+        payload_type: u8,
+        timestamp: u32,
+        marker: bool,
+        payload: Bytes,
+    ) -> webrtc::error::Result<()> {
+        // Keep the owner locked through the actual enqueue so audio and
+        // telephone-event packets cannot reach the track out of sequence.
+        let mut state = self.state.lock().await;
+        let sequence_number = state.next_sequence_number();
+        let packet = rtp::Packet {
+            header: rtp::Header {
+                version: 2,
+                padding: false,
+                extension: false,
+                marker,
+                payload_type,
+                sequence_number,
+                timestamp,
+                ssrc: self.ssrc,
+                ..Default::default()
+            },
+            payload,
+        };
+        let mid = self
+            .mid
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .ok_or_else(|| {
+                webrtc::error::Error::Other(
+                    "outbound audio MID is not committed by final SDP".into(),
+                )
+            })?;
+        let result = self
+            .track
+            .write_rtp_with_extensions(packet, &[sdes_mid_header_extension(&mid)])
+            .await;
+        drop(state);
+        result
     }
 
     pub(crate) async fn write_audio(
@@ -268,5 +360,26 @@ mod tests {
         assert_eq!(state.allocate_audio_timestamp(10_000, 960), 10_000);
         assert_eq!(state.allocate_audio_timestamp(10_960, 960), 10_960);
         assert_eq!(state.allocate_audio_timestamp(100, 960), 11_920);
+    }
+
+    #[test]
+    fn telephone_event_reservation_advances_the_primary_audio_timeline() {
+        let mut state = OutboundAudioRtpState {
+            next_sequence_number: 40,
+            last_wire_timestamp: Some(48_000),
+            last_source_timestamp: Some(48_000),
+        };
+        let event_timestamp = state.reserve_telephone_event_timestamp(48_000, 48_000, 5_760);
+        assert_eq!(event_timestamp, 48_960);
+        assert_eq!(state.last_wire_timestamp, Some(54_720));
+        assert_eq!(state.last_source_timestamp, None);
+        assert_eq!(state.next_sequence_number(), 40);
+
+        let event_timestamp = state.reserve_telephone_event_timestamp(48_000, 8_000, 960);
+        assert_eq!(
+            event_timestamp, 55_680,
+            "8 kHz events retain the audio timestamp base"
+        );
+        assert_eq!(state.last_wire_timestamp, Some(61_440));
     }
 }

--- a/crates/webrtc/rvoip-webrtc/src/peer/session.rs
+++ b/crates/webrtc/rvoip-webrtc/src/peer/session.rs
@@ -22,11 +22,11 @@ use webrtc::rtp_transceiver::RTCRtpTransceiverDirection;
 
 use crate::config::WebRtcConfig;
 use crate::errors::{Result, WebRtcError};
-use crate::media::dtmf::{DtmfSenderState, OutboundDtmfNegotiation, TelephoneEventCodec};
+use crate::media::dtmf::{OutboundDtmfNegotiation, TelephoneEventCodec};
 use crate::media::outbound::OutboundAudioRtpWriter;
 use crate::peer::builder::{
-    self, audio_track_rtcp_feedback, video_track_rtcp_feedback, MIME_TYPE_OPUS,
-    MIME_TYPE_TELEPHONE_EVENT, MIME_TYPE_VP8, TELEPHONE_EVENT_MAPPINGS,
+    self, audio_track_rtcp_feedback, video_track_rtcp_feedback, MIME_TYPE_OPUS, MIME_TYPE_VP8,
+    TELEPHONE_EVENT_MAPPINGS,
 };
 use crate::peer::handler::{
     ConnectionHandler, HandlerChannels, HandlerDropCounters, LocalIceEvent,
@@ -80,7 +80,6 @@ pub struct RvoipPeerConnection {
     outbound_dtmf_negotiation: SyncMutex<OutboundDtmfNegotiation>,
     outbound_audio_mid: SyncMutex<Option<NegotiatedAudioMid>>,
     outbound_dtmf_send_capable: AtomicBool,
-    dtmf_sender_states: AsyncMutex<HashMap<u32, DtmfSenderState>>,
     local_video: SyncMutex<Option<Arc<TrackLocalStaticRTP>>>,
     local_video_ssrc: SyncMutex<Option<u32>>,
     gather_timeout: Duration,
@@ -121,7 +120,6 @@ impl RvoipPeerConnection {
             outbound_dtmf_negotiation: SyncMutex::new(OutboundDtmfNegotiation::Pending),
             outbound_audio_mid: SyncMutex::new(None),
             outbound_dtmf_send_capable: AtomicBool::new(true),
-            dtmf_sender_states: AsyncMutex::new(HashMap::new()),
             local_video: SyncMutex::new(None),
             local_video_ssrc: SyncMutex::new(None),
             gather_timeout,
@@ -323,14 +321,12 @@ impl RvoipPeerConnection {
         self.trickle_ice
     }
 
-    /// Add one local audio sender with Opus plus a supplemental RFC 4733
-    /// encoding when outbound DTMF is allowed.
+    /// Add one local audio sender with Opus and RFC 4733 capability when
+    /// outbound DTMF is allowed.
     ///
-    /// Opus and telephone-event use distinct SSRC encodings on one negotiated
-    /// audio transceiver. RFC 4733 is a supplemental payload within the audio
-    /// media section, not a second `MediaStreamTrack`; creating a second track
-    /// for a one-m-line browser offer leaves that sender MID-less and its
-    /// interceptor stream unbound.
+    /// RFC 4733 is an alternate payload on the regular audio source. It must
+    /// use that source's SSRC and sequence/timestamp base, not a second track
+    /// or supplemental SSRC that browser SDP never advertises.
     pub async fn add_local_audio_track(self: &Arc<Self>) -> Result<()> {
         let dtmf_codecs = if self.outbound_dtmf_send_capable.load(Ordering::Acquire) {
             unique_telephone_event_clock_mappings()
@@ -358,7 +354,7 @@ impl RvoipPeerConnection {
             rtcp_feedback: audio_track_rtcp_feedback(),
         };
         let ssrc = rand_ssrc();
-        let mut encodings = vec![RTCRtpEncodingParameters {
+        let encodings = vec![RTCRtpEncodingParameters {
             rtp_coding_parameters: RTCRtpCodingParameters {
                 ssrc: Some(ssrc),
                 ..Default::default()
@@ -376,28 +372,7 @@ impl RvoipPeerConnection {
             if dtmf_ssrcs_by_clock.contains_key(&codec.clock_rate_hz) {
                 continue;
             }
-            let dtmf_ssrc = loop {
-                let candidate = rand_ssrc();
-                if candidate != ssrc && !dtmf_ssrcs_by_clock.values().any(|ssrc| *ssrc == candidate)
-                {
-                    break candidate;
-                }
-            };
-            encodings.push(RTCRtpEncodingParameters {
-                rtp_coding_parameters: RTCRtpCodingParameters {
-                    ssrc: Some(dtmf_ssrc),
-                    ..Default::default()
-                },
-                codec: RTCRtpCodec {
-                    mime_type: MIME_TYPE_TELEPHONE_EVENT.to_owned(),
-                    clock_rate: codec.clock_rate_hz,
-                    channels: 1,
-                    sdp_fmtp_line: "0-15".into(),
-                    rtcp_feedback: vec![],
-                },
-                ..Default::default()
-            });
-            dtmf_ssrcs_by_clock.insert(codec.clock_rate_hz, dtmf_ssrc);
+            dtmf_ssrcs_by_clock.insert(codec.clock_rate_hz, ssrc);
         }
         let track = Arc::new(TrackLocalStaticRTP::new(MediaStreamTrack::new(
             format!("rvoip-stream-{ssrc}"),
@@ -419,8 +394,7 @@ impl RvoipPeerConnection {
             48_000,
         ));
         if let Some(codec) = dtmf_codecs.first().copied() {
-            // Both handles deliberately point at the same TrackLocal: distinct
-            // SSRC encodings share one negotiated sender/transceiver.
+            // Both handles deliberately point at the same TrackLocal and SSRC.
             *self.local_dtmf.lock() = Some(track);
             *self.local_dtmf_ssrcs_by_clock.lock() = dtmf_ssrcs_by_clock;
             *self.local_dtmf_codec.lock() = Some(codec);
@@ -504,13 +478,13 @@ impl RvoipPeerConnection {
         self.outbound_audio_writer.lock().clone()
     }
 
-    /// D1 — the shared audio track containing the RFC 4733 SSRC encoding.
-    /// Returns `None` when that supplemental encoding was not attached.
+    /// The shared audio track capable of carrying RFC 4733 payloads.
+    /// Returns `None` when telephone-event was not enabled.
     pub fn local_dtmf_track(&self) -> Option<Arc<TrackLocalStaticRTP>> {
         self.local_dtmf.lock().clone()
     }
 
-    /// D1 — SSRC of the supplemental RFC 4733 encoding.
+    /// SSRC of the primary audio source used for RFC 4733 payloads.
     pub fn local_dtmf_ssrc(&self) -> Option<u32> {
         self.local_dtmf_codec()
             .and_then(|codec| self.local_dtmf_ssrc_for_codec(codec))
@@ -528,7 +502,7 @@ impl RvoipPeerConnection {
     /// This is a binding diagnostic, not proof that the current final SDP
     /// negotiated outbound DTMF. Call [`Self::negotiated_outbound_dtmf_codec`]
     /// for the active mapping; it returns `None` after a rejected remap even
-    /// though the existing physical clock encodings remain attached.
+    /// though the shared audio source remains attached.
     #[must_use]
     pub fn local_dtmf_codec(&self) -> Option<TelephoneEventCodec> {
         *self.local_dtmf_codec.lock()
@@ -573,10 +547,6 @@ impl RvoipPeerConnection {
             .lock()
             .as_ref()
             .map(|binding| binding.extension_id)
-    }
-
-    pub(crate) fn dtmf_sender_states(&self) -> &AsyncMutex<HashMap<u32, DtmfSenderState>> {
-        &self.dtmf_sender_states
     }
 
     fn disable_outbound_dtmf(&self) {
@@ -635,10 +605,9 @@ impl RvoipPeerConnection {
     }
 
     async fn prepare_send_capable_dtmf_for_offer(self: &Arc<Self>) -> Result<()> {
-        // A supplemental SSRC encoding must exist for every clock advertised
-        // by a send-capable audio offer. This covers both initial and
-        // subsequent offers, including callers that attached primary audio
-        // directly.
+        // A shared audio source must be marked DTMF-capable for every clock
+        // advertised by a send-capable offer. This also covers callers that
+        // attached primary audio directly.
         if self.outbound_dtmf_send_capable.load(Ordering::Acquire)
             && self.local_audio.lock().is_some()
             && self.local_dtmf.lock().is_none()
@@ -878,17 +847,16 @@ impl RvoipPeerConnection {
         if self.local_audio.lock().is_none() && self.local_video.lock().is_none() {
             self.add_local_audio_track().await?;
         }
-        // Any send-capable offerer with audio must own a dedicated RFC 4733
-        // SSRC before SDP generation. This also covers clients/video routes
-        // that pre-attached audio; there is no unsafe audio-track fallback.
+        // Any send-capable offerer with audio must prepare its primary source
+        // for RFC 4733 before SDP generation. This also covers clients/video
+        // routes that pre-attached audio.
         self.prepare_send_capable_dtmf_for_offer().await?;
 
         let offer = self.pc.create_offer(None).await?;
         self.pc.set_local_description(offer).await?;
-        // Setting a new local offer invalidates the final mapping used by the
-        // supplemental SSRC until an answer accepts both telephone-event and
-        // SDES MID. Do not write using the previous exchange's binding while
-        // this offer is pending.
+        // Setting a new local offer invalidates the final payload mapping until
+        // an answer accepts both telephone-event and SDES MID. Do not write
+        // using the previous exchange's binding while this offer is pending.
         self.begin_outbound_dtmf_renegotiation();
         self.wait_gather().await?;
 

--- a/crates/webrtc/rvoip-webrtc/src/sdp/inspect.rs
+++ b/crates/webrtc/rvoip-webrtc/src/sdp/inspect.rs
@@ -10,9 +10,8 @@ use crate::peer::builder::HDREXT_SDES_MID;
 
 /// Final audio MID header-extension binding for locally-originated RTP.
 ///
-/// The alpha WebRTC engine does not put supplemental SSRCs in SDP. Browsers
-/// therefore need the negotiated SDES MID extension to associate RFC 4733
-/// packets with the audio m-section. Keep both the value and ID here so the
+/// Browsers use the negotiated SDES MID extension to associate bundled RFC
+/// 4733 packets with the audio m-section. Keep both the value and ID here so the
 /// negotiation boundary can reject an ambiguous or non-one-byte binding
 /// before any RTP is written.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -35,9 +34,8 @@ fn one_audio_mid_candidate(sdp: &str) -> Option<AudioMidCandidate> {
         .iter()
         .filter(|media| media.media.eq_ignore_ascii_case("audio") && media.port != 0);
     let media = audio.next()?;
-    // One local audio sender cannot safely guess which MID owns an
-    // unsignalled supplemental SSRC when SDP contains multiple active audio
-    // sections.
+    // One local audio sender cannot safely guess which MID owns its packets
+    // when SDP contains multiple active audio sections.
     if audio.next().is_some() {
         return None;
     }

--- a/crates/webrtc/rvoip-webrtc/static/whip-publish.html
+++ b/crates/webrtc/rvoip-webrtc/static/whip-publish.html
@@ -27,6 +27,7 @@
     <button id="start">Start publish</button>
     <button id="stop" disabled>Stop</button>
   </p>
+  <audio id="remote-audio" autoplay></audio>
   <div id="log"></div>
 
   <script>
@@ -56,6 +57,7 @@
       mdnsCandidatePresent: false,
       sdpHasAudio: false,
       sdpHasVideo: false,
+      inboundAudioPackets: 0,
       error: null,
     });
     window.__rfcResults = initialResults();
@@ -113,6 +115,11 @@
         log('captured ' + stream.getTracks().map(t => t.kind).join('+'));
 
         pc = new RTCPeerConnection();
+        pc.ontrack = (event) => {
+          if (event.track.kind === 'audio') {
+            $('remote-audio').srcObject = event.streams[0] || new MediaStream([event.track]);
+          }
+        };
         pc.onconnectionstatechange = () => {
           log('pc.connectionState = ' + pc.connectionState);
           window.__rfcResults.status = pc.connectionState;
@@ -176,6 +183,25 @@
         setStatus('failed');
         $('start').disabled = false;
       }
+    };
+
+    // Browser interop tests use the receiver's real WebRTC stats instead of
+    // trusting server-side send success. RFC 4733 packets count as inbound
+    // audio RTP even though they do not produce audible PCM samples.
+    window.__inboundAudioPacketCount = async () => {
+      if (!pc) return 0;
+      let packets = 0;
+      for (const receiver of pc.getReceivers()) {
+        if (!receiver.track || receiver.track.kind !== 'audio') continue;
+        const stats = await receiver.getStats();
+        for (const report of stats.values()) {
+          if (report.type === 'inbound-rtp' && report.kind === 'audio') {
+            packets += report.packetsReceived || 0;
+          }
+        }
+      }
+      window.__rfcResults.inboundAudioPackets = packets;
+      return packets;
     };
 
     $('stop').onclick = async () => {

--- a/crates/webrtc/rvoip-webrtc/tests/browser_interop.rs
+++ b/crates/webrtc/rvoip-webrtc/tests/browser_interop.rs
@@ -32,6 +32,7 @@ use axum::{
 };
 use chromiumoxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;
+use rvoip_core::adapter::ConnectionAdapter;
 use rvoip_webrtc::{WebRtcConfig, WebRtcServerBuilder};
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
@@ -184,6 +185,50 @@ async fn headless_chromium_whip_publish_round_trip() {
     assert!(
         connected,
         "browser RTCPeerConnection never reached `connected` (last status: {last_status})"
+    );
+
+    // 7. Prove Chromium receives the outbound RFC 4733 packets. This guards
+    // against reporting send success for an unadvertised supplemental SSRC,
+    // which Chromium discards before its inbound RTP statistics advance.
+    let route_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let conn_id = loop {
+        if let Some(route) = adapter.routes().iter().next() {
+            break route.key().clone();
+        }
+        assert!(
+            tokio::time::Instant::now() < route_deadline,
+            "browser WHIP connection never appeared in the adapter route table"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    let before: u64 = page
+        .evaluate_function("async () => window.__inboundAudioPacketCount()")
+        .await
+        .expect("read Chromium inbound audio stats before DTMF")
+        .into_value()
+        .expect("decode Chromium inbound audio packet count");
+    adapter
+        .send_dtmf(conn_id, "7", 140)
+        .await
+        .expect("send negotiated RFC 4733 DTMF to Chromium");
+
+    let packet_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut after = before;
+    while tokio::time::Instant::now() < packet_deadline {
+        after = page
+            .evaluate_function("async () => window.__inboundAudioPacketCount()")
+            .await
+            .expect("read Chromium inbound audio stats after DTMF")
+            .into_value()
+            .expect("decode Chromium inbound audio packet count");
+        if after > before {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        after > before,
+        "Chromium received no outbound RFC 4733 RTP packets (before={before}, after={after})"
     );
 
     // Teardown.

--- a/crates/webrtc/rvoip-webrtc/tests/browser_sdp_interop.rs
+++ b/crates/webrtc/rvoip-webrtc/tests/browser_sdp_interop.rs
@@ -285,7 +285,7 @@ async fn same_clock_pt_remap_omitted_by_final_answer_fails_closed() {
 }
 
 #[tokio::test]
-async fn preattached_audio_offer_owns_supplemental_dtmf_encodings() {
+async fn preattached_audio_offer_uses_the_primary_ssrc_for_dtmf() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let peer = RvoipPeerConnection::new(&WebRtcConfig::loopback(), PeerRole::Offerer)
         .await
@@ -301,10 +301,10 @@ async fn preattached_audio_offer_owns_supplemental_dtmf_encodings() {
         std::sync::Arc::ptr_eq(&audio, &dtmf),
         "both clock encodings must share one negotiated sender/track"
     );
-    assert_ne!(
+    assert_eq!(
         peer.local_audio_ssrc(),
         peer.local_dtmf_ssrc(),
-        "primary audio and telephone-event require independent SSRC timelines"
+        "primary audio and telephone-event must share one RFC 4733 source timeline"
     );
 
     let offer = peer.create_offer_and_gather().await.expect("offer");
@@ -334,9 +334,9 @@ async fn offerer_accepts_a_final_pt110_48khz_answer_on_its_shared_audio_sender()
         .await
         .expect("offerer");
     let offer = offerer.create_offer_and_gather().await.expect("offer");
-    let eight_khz_ssrc = offerer
+    let primary_audio_ssrc = offerer
         .local_dtmf_ssrc()
-        .expect("pre-negotiation 8 kHz encoding");
+        .expect("pre-negotiation audio source");
 
     // A standards-compliant answer may select any mapping from the offer. Give
     // the answerer the same capabilities with 48 kHz preferred so its physical
@@ -362,10 +362,10 @@ async fn offerer_accepts_a_final_pt110_48khz_answer_on_its_shared_audio_sender()
         offerer.outbound_dtmf_negotiation(),
         OutboundDtmfNegotiation::Negotiated(TelephoneEventCodec::new(110, 48_000))
     );
-    assert_ne!(
+    assert_eq!(
         offerer.local_dtmf_ssrc(),
-        Some(eight_khz_ssrc),
-        "final PT110 must select the distinct 48 kHz SSRC encoding"
+        Some(primary_audio_ssrc),
+        "a clock-rate selection must not replace the negotiated audio source"
     );
 
     offerer.close().await.ok();

--- a/crates/webrtc/rvoip-webrtc/tests/dtmf_wire.rs
+++ b/crates/webrtc/rvoip-webrtc/tests/dtmf_wire.rs
@@ -2,10 +2,10 @@
 //! generates correct telephone-event RTP packets on the wire, end-to-end
 //! through SRTP on a real loopback.
 //!
-//! DTMF is a supplemental SSRC encoding on the same negotiated audio sender as
-//! Opus. The offer therefore carries one audio m-line, while primary audio and
-//! telephone-event retain independent RTP timelines. The tests discover every
-//! audio remote track so they remain insensitive to receiver-side demux shape.
+//! DTMF is an alternate payload on the same negotiated audio source as Opus.
+//! The offer therefore carries one audio m-line, SSRC, and sequence/timestamp
+//! owner. The tests discover every audio remote track so they remain
+//! insensitive to receiver-side demux shape.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -74,13 +74,11 @@ async fn send_dtmf_emits_rfc4733_telephone_events() {
         .await
         .expect("loopback");
 
-    // D1 — Opus and telephone-event are codec-distinct encodings on one
-    // negotiated audio sender. Receiver implementations may expose those
-    // SSRCs through one grouped track or multiple remote-track events, so the
-    // watcher drains every audio track and polls each one. A track may appear
-    // only after the first PT 101 packet arrives, so keep polling until the
-    // deadline.
-    let captured: Arc<parking_lot::Mutex<Vec<(u8, bool, u8, u16, bool)>>> =
+    // Opus and telephone-event share one negotiated audio source. Receiver
+    // implementations may expose a remote track only after the first RTP
+    // packet arrives, so keep discovering and polling until the deadline.
+    let expected_ssrc = offerer.local_audio_ssrc().expect("primary audio SSRC");
+    let captured: Arc<parking_lot::Mutex<Vec<(u8, bool, u8, u16, bool, u32)>>> =
         Arc::new(parking_lot::Mutex::new(Vec::new()));
     let cap_clone = Arc::clone(&captured);
     let answerer_watch = Arc::clone(&answerer);
@@ -103,7 +101,14 @@ async fn send_dtmf_emits_rfc4733_telephone_events() {
                         if let TrackRemoteEvent::OnRtpPacket(pkt) = event {
                             if pkt.header.payload_type == TELEPHONE_EVENT_PT {
                                 if let Some((ev, eoe, vol, dur)) = decode_event(&pkt.payload) {
-                                    cap.lock().push((ev, eoe, vol, dur, pkt.header.marker));
+                                    cap.lock().push((
+                                        ev,
+                                        eoe,
+                                        vol,
+                                        dur,
+                                        pkt.header.marker,
+                                        pkt.header.ssrc,
+                                    ));
                                 }
                             }
                         }
@@ -117,8 +122,7 @@ async fn send_dtmf_emits_rfc4733_telephone_events() {
         }
     });
 
-    // Send DTMF "5" for 100ms. The first PT 101 packet may trigger a new
-    // remote-track event for the supplemental SSRC.
+    // Send DTMF "5" for 100ms on the already-negotiated primary audio source.
     send_dtmf(&offerer, "5", 100).await.expect("send_dtmf");
 
     // Wait long enough for end-of-event retransmissions to arrive.
@@ -132,9 +136,13 @@ async fn send_dtmf_emits_rfc4733_telephone_events() {
     );
 
     // Every captured event must be digit 5 with reasonable volume (0..63).
-    for (ev, _, vol, _, _) in &events {
+    for (ev, _, vol, _, _, ssrc) in &events {
         assert_eq!(*ev, 5, "event code must be 5 for digit '5'");
         assert!(*vol <= 63, "volume must fit in 6 bits (got {vol})");
+        assert_eq!(
+            *ssrc, expected_ssrc,
+            "RFC 4733 must use the primary audio source"
+        );
     }
 
     // First packet must carry the marker bit.
@@ -154,7 +162,7 @@ async fn send_dtmf_emits_rfc4733_telephone_events() {
 
     // Duration must monotonically increase (cumulative samples across the tone).
     let mut last = 0u16;
-    for (_, _, _, dur, _) in &events {
+    for (_, _, _, dur, _, _) in &events {
         assert!(*dur >= last, "duration regressed: {dur} < {last}");
         last = *dur;
     }
@@ -202,6 +210,7 @@ async fn negotiated_pt110_48khz_reaches_the_remote_peer() {
     let expected_mid_id = sender
         .negotiated_outbound_audio_mid_extension_id()
         .expect("negotiated outbound audio MID extension ID");
+    let expected_ssrc = sender.local_audio_ssrc().expect("primary audio SSRC");
 
     let timeout = Duration::from_secs(config.connection_timeout_secs);
     tokio::try_join!(
@@ -210,7 +219,7 @@ async fn negotiated_pt110_48khz_reaches_the_remote_peer() {
     )
     .expect("connected peers");
 
-    let captured: Arc<parking_lot::Mutex<Vec<(u8, bool, u16, bool, Option<Vec<u8>>)>>> =
+    let captured: Arc<parking_lot::Mutex<Vec<(u8, bool, u16, bool, Option<Vec<u8>>, u32)>>> =
         Arc::new(parking_lot::Mutex::new(Vec::new()));
     let captured_for_watcher = Arc::clone(&captured);
     let receiver_for_watcher = Arc::clone(&receiver);
@@ -241,6 +250,7 @@ async fn negotiated_pt110_48khz_reaches_the_remote_peer() {
                                         .header
                                         .get_extension(expected_mid_id)
                                         .map(|payload| payload.to_vec()),
+                                    packet.header.ssrc,
                                 ));
                             }
                         }
@@ -266,12 +276,16 @@ async fn negotiated_pt110_48khz_reaches_the_remote_peer() {
     assert!(events.first().is_some_and(|event| event.3));
     assert!(events
         .iter()
-        .any(|(_, end, duration, _, _)| { *end && *duration == 5_760 }));
+        .any(|(_, end, duration, _, _, _)| { *end && *duration == 5_760 }));
     assert!(
         events
             .iter()
             .all(|event| event.4.as_deref() == Some(expected_mid.as_bytes())),
-        "every supplemental-SSRC packet must carry the exact negotiated MID bytes"
+        "every telephone-event packet must carry the exact negotiated MID bytes"
+    );
+    assert!(
+        events.iter().all(|event| event.5 == expected_ssrc),
+        "PT110 must use the primary audio source"
     );
 
     receiver.close().await.ok();


### PR DESCRIPTION
## What changed

- Send RFC 4733 telephone events on the negotiated primary audio SSRC, MID, sequence owner, and timestamp base.
- Preserve negotiated telephone-event payload types in the RTP sender without accepting arbitrary payload types or unadvertised SSRCs.
- Keep 8 kHz and 48 kHz duration clocks while advancing the primary audio timeline safely.
- Add a real-Chromium regression that requires browser inbound RTP statistics to advance.

## Root cause

rvoip reported successful DTMF writes but used a separate random SSRC and RTP timeline that browser SDP did not advertise. Chromium discarded those packets.

## Validation

- RFC 4733 wire tests for 8 kHz and Chromium PT 110 at 48 kHz
- SDP negotiation and fail-closed tests
- rvoip-rtc sender unit test
- Clippy for rvoip-rtc and rvoip-webrtc
- Headless Google Chrome WHIP interop test
- BridgeFu exact ignored TypeScript SDK and Chromium qualification using packaged rvoip sources

Fixes #54

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound RTP sequencing, timestamp allocation, and peer media setup on a security-sensitive real-time path; behavior change is intentional but interop-critical.
> 
> **Overview**
> **Outbound DTMF now rides the negotiated primary audio source** instead of a separate supplemental SSRC and RTP timeline that browser SDP never advertised (Chromium was discarding those packets despite “send success”).
> 
> `send_dtmf` routes through **`OutboundAudioRtpWriter`**: shared **SSRC**, **sequence numbers**, **audio timestamp base**, and **SDES MID**, with `write_supplemental_audio` and timestamp reservation that advances the primary audio timeline while keeping RFC 4733 duration clocks (8 kHz / 48 kHz). Per-peer **`DtmfSenderState`** and extra telephone-event **RTP encodings** on the local audio sender are removed; clock mappings now all point at the primary SSRC.
> 
> In **rvoip-rtc**, outbound binding **keeps negotiated `audio/telephone-event` payload types** on the primary SSRC and still **rejects unadvertised SSRCs** and arbitrary payload-type borrowing.
> 
> **Regression coverage**: wire/SDP tests assert primary SSRC; headless Chromium WHIP interop sends DTMF and checks **inbound audio RTP stats** advance via `whip-publish.html` helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdf09852e238b6590dce9720baf87748c2dfb8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->