### PR TITLE
Give the SIP test shard enough GCP disk

### DIFF
--- a/.github/workflows/gcp-qualification-pilot.yml
+++ b/.github/workflows/gcp-qualification-pilot.yml
@@ -67,6 +67,7 @@ jobs:
           include = []
           for job in plan["shard_jobs"]:
               check = job["check"]
+              heavy_sip_test = check == "test" and "rvoip-sip" in job["packages"]
               include.append(
                   {
                       "id": job["id"],
@@ -78,9 +79,13 @@ jobs:
                           "n2-standard-8" if check == "test" else "n2-standard-4"
                       ),
                       "disk_type": (
-                          "pd-balanced" if check == "test" else "pd-standard"
+                          "pd-standard"
+                          if heavy_sip_test
+                          else "pd-balanced"
+                          if check == "test"
+                          else "pd-standard"
                       ),
-                      "disk_size_gb": 80,
+                      "disk_size_gb": 200 if heavy_sip_test else 80,
                   }
               )
           include.extend(

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -53,7 +53,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("if: always() && steps.worker.outputs.name != ''", workflow)
         self.assertIn("expected_shards", workflow)
         self.assertIn("expected_packages", workflow)
-        self.assertIn('"pd-balanced" if check == "test" else "pd-standard"', workflow)
+        self.assertIn('heavy_sip_test = check == "test" and "rvoip-sip"', workflow)
+        self.assertIn('"disk_size_gb": 200 if heavy_sip_test else 80', workflow)
         self.assertIn("publishing_attempted == false", workflow)
         self.assertIn('"publishing_attempted": False', startup)
         for profile in (


### PR DESCRIPTION
## Root cause

The second `workspace-parallel` pilot successfully ran 14 of 15 shards, but the test shard containing `rvoip-sip` filled its 80 GB disk while linking the large SIP integration/example target set. The run was canceled once the deterministic disk failure appeared, and it left no VMs or disks.

## Fix

- identify the test shard containing `rvoip-sip` from the generated package list, without relying on a fixed shard number
- give that single worker a 200 GB standard disk
- keep the other five test workers on 80 GB balanced disks
- keep lighter Clippy, doctest, policy, and timing workers on 80 GB standard disks

Peak requirements are now 400/500 GB balanced disk and 920/4,096 GB standard disk. The pending 2 TB balanced-SSD preference was withdrawn back to the existing 500 GB limit.

## Validation

- generated matrix contains exactly one 200 GB standard-disk SIP test worker
- live GCP quota preflight passes for 84 vCPUs, 15 instances/addresses, and both disk pools
- 42 release, receipt, planner, and workflow-policy tests
- all workflow YAML parsed
- startup script syntax check

No publication path is added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only GCP worker sizing for one identified test shard; no application runtime or publishing path changes.
> 
> **Overview**
> The parallel GCP workspace matrix builder now treats the **test** shard that includes **`rvoip-sip`** as a heavy linker: that worker gets a **200 GB `pd-standard`** boot disk instead of the default **80 GB `pd-balanced`** disk used by other test shards.
> 
> Detection is **package-based** (`heavy_sip_test` when `check == "test"` and `"rvoip-sip"` is in the shard’s package list), so it does not depend on a fixed shard id. Clippy, policy, doctest, and timing workers are unchanged at **80 GB `pd-standard`**.
> 
> Workflow policy tests were updated to assert the new `heavy_sip_test` logic and **200 GB** disk sizing string in the qualification pilot workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a908a28d3dcf7c3400e4dae5ab14a2f7310b4ee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->