### PR TITLE
ci: split SIP qualification across GCP workers

### DIFF
--- a/.github/workflows/gcp-qualification-pilot.yml
+++ b/.github/workflows/gcp-qualification-pilot.yml
@@ -33,6 +33,7 @@ jobs:
       worker_count: ${{ steps.matrix.outputs.worker_count }}
       expected_shards: ${{ steps.matrix.outputs.expected_shards }}
       expected_packages: ${{ steps.matrix.outputs.expected_packages }}
+      expected_sip_targets: ${{ steps.matrix.outputs.expected_sip_targets }}
       required_vcpus: ${{ steps.matrix.outputs.required_vcpus }}
       required_addresses: ${{ steps.matrix.outputs.required_addresses }}
       required_balanced_disk_gb: ${{ steps.matrix.outputs.required_balanced_disk_gb }}
@@ -57,6 +58,9 @@ jobs:
             --candidate HEAD \
             --changed-file Cargo.toml \
             --output target/gcp-workspace-plan.json
+          python3 scripts/ci/sip_test_partitions.py \
+            --partitions 3 \
+            --output target/gcp-sip-test-partitions.json
           python3 - "$GITHUB_OUTPUT" <<'PY'
           import base64
           import json
@@ -64,37 +68,63 @@ jobs:
           from pathlib import Path
 
           plan = json.loads(Path("target/gcp-workspace-plan.json").read_text())
+          sip_plan = json.loads(Path("target/gcp-sip-test-partitions.json").read_text())
           include = []
           for job in plan["shard_jobs"]:
               check = job["check"]
-              heavy_sip_test = check == "test" and "rvoip-sip" in job["packages"]
+              packages = [package for package in job["packages"] if not (
+                  check == "test" and package == "rvoip-sip"
+              )]
+              if not packages:
+                  continue
               include.append(
                   {
                       "id": job["id"],
                       "profile": f"workspace-shard-{check}",
                       "packages_b64": base64.b64encode(
-                          job["packages_csv"].encode()
+                          ",".join(packages).encode()
                       ).decode(),
+                      "targets_b64": "",
                       "machine_type": (
-                          "n2-standard-8" if check == "test" else "n2-standard-4"
+                          "n2-standard-8" if check == "test" else "n2-standard-2"
                       ),
-                      "disk_type": (
-                          "pd-standard"
-                          if heavy_sip_test
-                          else "pd-balanced"
-                          if check == "test"
-                          else "pd-standard"
-                      ),
-                      "disk_size_gb": 200 if heavy_sip_test else 80,
+                      "disk_type": "pd-balanced" if check == "test" else "pd-standard",
+                      "disk_size_gb": 80,
                   }
               )
+          sip_workers = [
+              {
+                  "id": "sip-core",
+                  "profile": "workspace-sip-core",
+                  "packages_b64": base64.b64encode(b"rvoip-sip").decode(),
+                  "targets_b64": "",
+                  "machine_type": "n2-standard-8",
+                  "disk_type": "pd-standard",
+                  "disk_size_gb": 200,
+              }
+          ]
+          for index, partition in enumerate(sip_plan["partitions"], start=1):
+              targets_csv = ",".join(partition["targets"])
+              sip_workers.append(
+                  {
+                      "id": f"sip-integration-{index}",
+                      "profile": "workspace-sip-integration",
+                      "packages_b64": base64.b64encode(b"rvoip-sip").decode(),
+                      "targets_b64": base64.b64encode(targets_csv.encode()).decode(),
+                      "machine_type": "n2-standard-8",
+                      "disk_type": "pd-standard",
+                      "disk_size_gb": 200,
+                  }
+              )
+          include.extend(sip_workers)
           include.extend(
               [
                   {
                       "id": "policy",
                       "profile": "workspace-policy",
                       "packages_b64": "",
-                      "machine_type": "n2-standard-4",
+                      "targets_b64": "",
+                      "machine_type": "n2-standard-2",
                       "disk_type": "pd-standard",
                       "disk_size_gb": 80,
                   },
@@ -102,7 +132,8 @@ jobs:
                       "id": "doctest",
                       "profile": "workspace-doctest",
                       "packages_b64": "",
-                      "machine_type": "n2-standard-4",
+                      "targets_b64": "",
+                      "machine_type": "n2-standard-2",
                       "disk_type": "pd-standard",
                       "disk_size_gb": 80,
                   },
@@ -110,7 +141,8 @@ jobs:
                       "id": "security-timing",
                       "profile": "workspace-security-timing",
                       "packages_b64": "",
-                      "machine_type": "n2-standard-4",
+                      "targets_b64": "",
+                      "machine_type": "n2-standard-2",
                       "disk_type": "pd-standard",
                       "disk_size_gb": 80,
                   },
@@ -123,14 +155,23 @@ jobs:
           expected_packages = json.dumps(
               sorted(plan["selected_crates"]), separators=(",", ":")
           )
+          expected_sip_targets = json.dumps(
+              sorted(
+                  target
+                  for partition in sip_plan["partitions"]
+                  for target in partition["targets"]
+              ),
+              separators=(",", ":"),
+          )
           with Path(sys.argv[1]).open("a") as output:
               output.write(f"matrix={compact}\n")
               output.write(f"candidate={plan['candidate_sha']}\n")
               output.write(f"worker_count={len(include)}\n")
               output.write(f"expected_shards={expected_shards}\n")
               output.write(f"expected_packages={expected_packages}\n")
+              output.write(f"expected_sip_targets={expected_sip_targets}\n")
               output.write(
-                  f"required_vcpus={sum(8 if item['machine_type'].endswith('-8') else 4 for item in include)}\n"
+                  f"required_vcpus={sum(int(item['machine_type'].rsplit('-', 1)[1]) for item in include)}\n"
               )
               output.write(f"required_addresses={len(include)}\n")
               output.write(
@@ -151,7 +192,8 @@ jobs:
             echo "- Candidate: \`${{ steps.matrix.outputs.candidate }}\`"
             echo "- Ephemeral workers: $(jq '.include | length' <<< '${{ steps.matrix.outputs.matrix }}')"
             echo "- Test workers: n2-standard-8"
-            echo "- Clippy, doctest, policy, and timing workers: n2-standard-4"
+            echo "- SIP test lanes: four n2-standard-8 workers"
+            echo "- Clippy, doctest, policy, and timing workers: n2-standard-2"
           } >> "$GITHUB_STEP_SUMMARY"
 
   preflight-parallel:
@@ -398,6 +440,7 @@ jobs:
           PROFILE: ${{ matrix.profile }}
           SHARD_ID: ${{ matrix.id }}
           PACKAGES_B64: ${{ matrix.packages_b64 }}
+          TARGETS_B64: ${{ matrix.targets_b64 }}
           MACHINE_TYPE: ${{ matrix.machine_type }}
           DISK_TYPE: ${{ matrix.disk_type }}
           DISK_SIZE_GB: ${{ matrix.disk_size_gb }}
@@ -430,7 +473,7 @@ jobs:
             --shielded-vtpm \
             --shielded-integrity-monitoring \
             --labels rvoip-role=workspace-shard,managed-by=github-actions \
-            --metadata "rvoip-candidate=${CANDIDATE},rvoip-profile=${PROFILE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-shard-id=${SHARD_ID},rvoip-packages-b64=${PACKAGES_B64}" \
+            --metadata "rvoip-candidate=${CANDIDATE},rvoip-profile=${PROFILE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-shard-id=${SHARD_ID},rvoip-packages-b64=${PACKAGES_B64},rvoip-targets-b64=${TARGETS_B64}" \
             --metadata-from-file startup-script=infra/release-runners/gcp-pilot-startup.sh
 
       - name: Wait for immutable shard result
@@ -583,6 +626,7 @@ jobs:
           EXPECTED_COUNT: ${{ needs.plan-parallel.outputs.worker_count }}
           EXPECTED_SHARDS: ${{ needs.plan-parallel.outputs.expected_shards }}
           EXPECTED_PACKAGES: ${{ needs.plan-parallel.outputs.expected_packages }}
+          EXPECTED_SIP_TARGETS: ${{ needs.plan-parallel.outputs.expected_sip_targets }}
         run: |
           python3 - <<'PY'
           import json
@@ -593,6 +637,7 @@ jobs:
           expected = int(os.environ["EXPECTED_COUNT"])
           expected_shards = json.loads(os.environ["EXPECTED_SHARDS"])
           expected_packages = json.loads(os.environ["EXPECTED_PACKAGES"])
+          expected_sip_targets = json.loads(os.environ["EXPECTED_SIP_TARGETS"])
           receipts = [
               json.loads(path.read_text())
               for path in sorted(
@@ -618,20 +663,63 @@ jobs:
                   errors.append(f"{shard}: status is not PASS")
               if receipt.get("publishing_attempted") is not False:
                   errors.append(f"{shard}: publishing was not proven disabled")
-          for profile in ("workspace-shard-test", "workspace-shard-clippy"):
-              package_lists = [
-                  receipt.get("packages", [])
-                  for receipt in receipts
-                  if receipt.get("profile") == profile
-              ]
-              packages = [package for values in package_lists for package in values]
-              if len(packages) != len(set(packages)):
-                  errors.append(f"{profile}: a package appears in more than one shard")
-              if sorted(packages) != expected_packages:
-                  errors.append(
-                      f"{profile}: expected all {len(expected_packages)} workspace "
-                      f"packages exactly once, got {len(packages)}"
-                  )
+          clippy_packages = [
+              package
+              for receipt in receipts
+              if receipt.get("profile") == "workspace-shard-clippy"
+              for package in receipt.get("packages", [])
+          ]
+          if len(clippy_packages) != len(set(clippy_packages)):
+              errors.append("workspace-shard-clippy: a package appears in more than one shard")
+          if sorted(clippy_packages) != expected_packages:
+              errors.append(
+                  f"workspace-shard-clippy: expected all {len(expected_packages)} workspace "
+                  f"packages exactly once, got {len(clippy_packages)}"
+              )
+
+          ordinary_test_packages = [
+              package
+              for receipt in receipts
+              if receipt.get("profile") == "workspace-shard-test"
+              for package in receipt.get("packages", [])
+          ]
+          expected_ordinary = [
+              package for package in expected_packages if package != "rvoip-sip"
+          ]
+          if len(ordinary_test_packages) != len(set(ordinary_test_packages)):
+              errors.append("workspace-shard-test: a package appears in more than one shard")
+          if sorted(ordinary_test_packages) != expected_ordinary:
+              errors.append(
+                  f"workspace-shard-test: expected {len(expected_ordinary)} non-SIP packages "
+                  f"exactly once, got {len(ordinary_test_packages)}"
+              )
+
+          sip_core = [
+              receipt for receipt in receipts
+              if receipt.get("profile") == "workspace-sip-core"
+          ]
+          sip_integration = [
+              receipt for receipt in receipts
+              if receipt.get("profile") == "workspace-sip-integration"
+          ]
+          if len(sip_core) != 1 or len(sip_integration) != 3:
+              errors.append(
+                  f"expected one SIP core and three SIP integration receipts, "
+                  f"got {len(sip_core)} and {len(sip_integration)}"
+              )
+          for receipt in [*sip_core, *sip_integration]:
+              if receipt.get("packages") != ["rvoip-sip"]:
+                  errors.append(f"{receipt.get('shard_id')}: invalid SIP package binding")
+          sip_targets = [
+              target for receipt in sip_integration for target in receipt.get("targets", [])
+          ]
+          if len(sip_targets) != len(set(sip_targets)):
+              errors.append("a SIP integration target appears in more than one shard")
+          if sorted(sip_targets) != expected_sip_targets:
+              errors.append(
+                  f"expected all {len(expected_sip_targets)} SIP integration targets "
+                  f"exactly once, got {len(sip_targets)}"
+              )
           aggregate = {
               "schema": "rvoip-gcp-workspace-aggregate-v1",
               "candidate_sha": candidate,
@@ -640,6 +728,7 @@ jobs:
               "expected_shard_count": expected,
               "expected_shard_ids": expected_shards,
               "expected_packages": expected_packages,
+              "expected_sip_targets": expected_sip_targets,
               "received_shards": len(receipts),
               "shard_ids": present_shard_ids,
               "errors": errors,

--- a/crates/sip/sip-proxy/tests/proxy_parallel_fork.rs
+++ b/crates/sip/sip-proxy/tests/proxy_parallel_fork.rs
@@ -19,7 +19,7 @@ use rvoip_sip_core::types::content_length::ContentLength;
 use rvoip_sip_core::types::param::Param;
 use rvoip_sip_core::types::status::StatusCode;
 use rvoip_sip_core::types::via::Via;
-use rvoip_sip_core::types::TypedHeader;
+use rvoip_sip_core::types::{HeaderName, Subject, TypedHeader};
 use rvoip_sip_core::{Message, Method, Request};
 use rvoip_sip_dialog::transaction::TransactionManager;
 use rvoip_sip_proxy::{RouteDecision, RouteFn, StatefulProxy};
@@ -420,8 +420,15 @@ async fn matched_upstream_cancel_gets_200_and_latches_until_provisional() {
         "CANCEL must be latched while the downstream INVITE is Calling"
     );
 
+    // A server transaction may independently generate its own upstream 100
+    // while this test is under load. Mark the downstream 100 so the assertion
+    // verifies that exact response is suppressed instead of confusing it with
+    // the transaction manager's legitimate local response.
     let trying =
         SimpleResponseBuilder::response_from_request(&invites[&uas_a], StatusCode::Trying, None)
+            .header(TypedHeader::Subject(Subject::new(
+                "downstream-trying-must-not-be-forwarded",
+            )))
             .build();
     harness.inject(Message::Response(trying), uas_a).await;
 
@@ -432,11 +439,18 @@ async fn matched_upstream_cancel_gets_200_and_latches_until_provisional() {
         })
         .await;
     assert!(
-        !harness.transport.sent().await.iter().any(|(message, destination)| {
-            matches!(message, Message::Response(response) if response.status() == StatusCode::Trying)
-                && *destination != uas_a
-        }),
-        "100 releases a latched CANCEL but remains suppressed upstream"
+        !harness
+            .transport
+            .sent()
+            .await
+            .iter()
+            .any(|(message, destination)| {
+                matches!(message, Message::Response(response)
+                if response.status() == StatusCode::Trying
+                    && response.header(&HeaderName::Subject).is_some())
+                    && *destination != uas_a
+            }),
+        "the marked downstream 100 releases a latched CANCEL but remains suppressed upstream"
     );
 
     let terminated = SimpleResponseBuilder::response_from_request(

--- a/infra/release-runners/gcp-pilot-startup.sh
+++ b/infra/release-runners/gcp-pilot-startup.sh
@@ -29,6 +29,11 @@ PACKAGES=""
 if [[ -n "$PACKAGES_B64" ]]; then
   PACKAGES="$(printf '%s' "$PACKAGES_B64" | base64 --decode)"
 fi
+TARGETS_B64="$(metadata_optional rvoip-targets-b64)"
+TARGETS=""
+if [[ -n "$TARGETS_B64" ]]; then
+  TARGETS="$(printf '%s' "$TARGETS_B64" | base64 --decode)"
+fi
 STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 START_SECONDS="$(date +%s)"
 WORKSPACE=/opt/rvoip
@@ -63,11 +68,11 @@ finish() {
   if [[ -f "$COMMAND_RECEIPT" ]]; then
     receipt_sha="$(sha256sum "$COMMAND_RECEIPT" | awk '{print $1}')"
   fi
-  python3 - "$RESULT" "$CANDIDATE" "$PROFILE" "$RUN_ID" "$STARTED_AT" "$ended_at" "$duration" "$exit_code" "$rust_version" "$SHARD_ID" "$PACKAGES" "$receipt_sha" <<'PY'
+  python3 - "$RESULT" "$CANDIDATE" "$PROFILE" "$RUN_ID" "$STARTED_AT" "$ended_at" "$duration" "$exit_code" "$rust_version" "$SHARD_ID" "$PACKAGES" "$TARGETS" "$receipt_sha" <<'PY'
 import json
 import sys
 
-path, candidate, profile, run_id, started, ended, duration, code, rust, shard_id, packages, receipt_sha = sys.argv[1:]
+path, candidate, profile, run_id, started, ended, duration, code, rust, shard_id, packages, targets, receipt_sha = sys.argv[1:]
 payload = {
     "schema": "rvoip-gcp-qualification-pilot-v1",
     "candidate_sha": candidate,
@@ -81,6 +86,7 @@ payload = {
     "rustc": rust,
     "shard_id": shard_id or None,
     "packages": [value for value in packages.split(",") if value],
+    "targets": [value for value in targets.split(",") if value],
     "command_receipt_sha256": receipt_sha or None,
     "publishing_attempted": False,
 }
@@ -171,6 +177,21 @@ elif [[ "$PROFILE" == workspace-shard-test || "$PROFILE" == workspace-shard-clip
   python3 scripts/ci/run_checks.py "$kind" \
     --name "$SHARD_ID" \
     --packages "$PACKAGES" \
+    --output "$COMMAND_RECEIPT"
+elif [[ "$PROFILE" == workspace-sip-core ]]; then
+  python3 scripts/ci/run_checks.py sip-core \
+    --name "$SHARD_ID" \
+    --packages rvoip-sip \
+    --output "$COMMAND_RECEIPT"
+elif [[ "$PROFILE" == workspace-sip-integration ]]; then
+  [[ -n "$TARGETS" ]] || {
+    echo "SIP integration shard is missing its target selection" >&2
+    exit 2
+  }
+  python3 scripts/ci/run_checks.py sip-integration \
+    --name "$SHARD_ID" \
+    --packages rvoip-sip \
+    --targets "$TARGETS" \
     --output "$COMMAND_RECEIPT"
 elif [[ "$PROFILE" == workspace-doctest ]]; then
   python3 scripts/ci/run_checks.py doctest \

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -19,6 +19,7 @@ from typing import Any
 SCHEMA = "rvoip-ci-command-receipt-v1"
 PACKAGE = re.compile(r"^[A-Za-z0-9_-]+$")
 GATE = re.compile(r"^[A-Za-z0-9_-]+$")
+TARGET = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 class CheckError(RuntimeError):
@@ -144,6 +145,37 @@ def shard_clippy_commands(
 ) -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
     selected = package_args(packages_csv)
     return [(["cargo", "clippy", "--locked", "--all-targets", *selected], None, None)]
+
+
+def sip_core_commands() -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
+    return [
+        (
+            [
+                "cargo",
+                "test",
+                "--locked",
+                "-p",
+                "rvoip-sip",
+                "--lib",
+                "--bins",
+                "--examples",
+            ],
+            None,
+            None,
+        )
+    ]
+
+
+def sip_integration_commands(
+    targets_csv: str,
+) -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
+    targets = sorted(set(filter(None, targets_csv.split(","))))
+    if not targets or any(not TARGET.fullmatch(target) for target in targets):
+        raise CheckError(f"invalid SIP integration target selection: {targets_csv!r}")
+    argv = ["cargo", "test", "--locked", "-p", "rvoip-sip"]
+    for target in targets:
+        argv.extend(("--test", target))
+    return [(argv, None, None)]
 
 
 def specialty_commands(
@@ -427,11 +459,14 @@ def main(argv: list[str] | None = None) -> int:
             "shard-clippy",
             "specialty",
             "doctest",
+            "sip-core",
+            "sip-integration",
         ),
     )
     parser.add_argument("--name", required=True)
     parser.add_argument("--packages", default="")
     parser.add_argument("--gate", default="")
+    parser.add_argument("--targets", default="")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
     root = Path(__file__).resolve().parents[2]
@@ -451,6 +486,10 @@ def main(argv: list[str] | None = None) -> int:
             commands = [
                 (["cargo", "test", "--workspace", "--doc", "--locked"], None, None)
             ]
+        elif args.kind == "sip-core":
+            commands = sip_core_commands()
+        elif args.kind == "sip-integration":
+            commands = sip_integration_commands(args.targets)
         else:
             if args.gate == "vcon-postgres":
                 postgres_name = start_postgres(root, records)
@@ -477,6 +516,7 @@ def main(argv: list[str] | None = None) -> int:
         "kind": args.kind,
         "gate": args.gate or None,
         "packages": sorted(filter(None, args.packages.split(","))),
+        "targets": sorted(filter(None, args.targets.split(","))),
         "git_commit": os.getenv("GITHUB_SHA")
         or capture_version(["git", "rev-parse", "HEAD"], root),
         "recorded_at": utc_now(),

--- a/scripts/ci/sip_test_partitions.py
+++ b/scripts/ci/sip_test_partitions.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Build deterministic, duration-balanced rvoip-sip integration-test partitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+
+
+TARGET = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Estimates are deliberately coarse. They only need to keep the known long
+# process/network fixtures from accumulating on one worker. Unknown tests get a
+# small non-zero weight so new targets are distributed instead of ignored.
+ESTIMATED_SECONDS = {
+    "audio_roundtrip_integration": 630,
+    "endpoint_unified_auth": 90,
+    "blind_transfer_integration": 55,
+    "bridge_roundtrip_integration": 35,
+    "endpoint_audio_roundtrip_integration": 20,
+}
+DEFAULT_SECONDS = 5
+
+
+class PartitionError(RuntimeError):
+    """Cargo metadata cannot be partitioned safely."""
+
+
+def eligible_targets(metadata: dict[str, Any], package_name: str) -> list[str]:
+    packages = [item for item in metadata.get("packages", []) if item.get("name") == package_name]
+    if len(packages) != 1:
+        raise PartitionError(f"expected exactly one {package_name!r} package")
+    targets = []
+    for target in packages[0].get("targets", []):
+        if "test" not in target.get("kind", []):
+            continue
+        # `cargo test --tests` skips targets whose required features are not
+        # enabled. Keep the split command exactly equivalent.
+        if target.get("required-features", []):
+            continue
+        name = target.get("name", "")
+        if not TARGET.fullmatch(name):
+            raise PartitionError(f"unsafe test target name: {name!r}")
+        targets.append(name)
+    if not targets or len(targets) != len(set(targets)):
+        raise PartitionError("integration target inventory is empty or contains duplicates")
+    return sorted(targets)
+
+
+def partition_targets(targets: list[str], count: int) -> list[dict[str, Any]]:
+    if count < 1 or count > len(targets):
+        raise PartitionError("partition count must be between one and the target count")
+    bins: list[dict[str, Any]] = [
+        {"targets": [], "estimated_seconds": 0} for _ in range(count)
+    ]
+    weighted = sorted(
+        ((ESTIMATED_SECONDS.get(name, DEFAULT_SECONDS), name) for name in targets),
+        key=lambda item: (-item[0], item[1]),
+    )
+    for weight, name in weighted:
+        destination = min(
+            range(count),
+            key=lambda index: (bins[index]["estimated_seconds"], index),
+        )
+        bins[destination]["targets"].append(name)
+        bins[destination]["estimated_seconds"] += weight
+    for item in bins:
+        item["targets"].sort()
+    return bins
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--partitions", type=int, default=3)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    completed = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode:
+        raise PartitionError(completed.stderr.strip() or "cargo metadata failed")
+    targets = eligible_targets(json.loads(completed.stdout), "rvoip-sip")
+    payload = {
+        "schema": "rvoip-sip-test-partitions-v1",
+        "package": "rvoip-sip",
+        "target_count": len(targets),
+        "partitions": partition_targets(targets, args.partitions),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -27,6 +27,30 @@ class RunChecksTests(unittest.TestCase):
         self.assertEqual(len(clippy), 1)
         self.assertEqual(clippy[0][0][0:2], ["cargo", "clippy"])
 
+    def test_sip_core_and_integration_commands_are_independent(self) -> None:
+        core = run_checks.sip_core_commands()
+        integration = run_checks.sip_integration_commands("beta,alpha")
+        self.assertIn("--lib", core[0][0])
+        self.assertNotIn("--tests", core[0][0])
+        self.assertEqual(
+            integration[0][0],
+            [
+                "cargo",
+                "test",
+                "--locked",
+                "-p",
+                "rvoip-sip",
+                "--test",
+                "alpha",
+                "--test",
+                "beta",
+            ],
+        )
+
+    def test_sip_target_arguments_reject_shell_metacharacters(self) -> None:
+        with self.assertRaises(run_checks.CheckError):
+            run_checks.sip_integration_commands("safe; touch compromised")
+
     def test_example_smoke_preserves_the_hardware_free_matrix(self) -> None:
         commands = run_checks.specialty_commands("examples-smoke", Path("/workspace"))
         self.assertEqual(len(commands), 10)

--- a/scripts/ci/test_sip_test_partitions.py
+++ b/scripts/ci/test_sip_test_partitions.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("sip_test_partitions.py")
+SPEC = importlib.util.spec_from_file_location("sip_test_partitions", SCRIPT)
+assert SPEC and SPEC.loader
+partitions = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = partitions
+SPEC.loader.exec_module(partitions)
+
+
+class SipTestPartitionTests(unittest.TestCase):
+    def test_inventory_matches_cargo_tests_and_skips_feature_gated_targets(self) -> None:
+        metadata = {
+            "packages": [
+                {
+                    "name": "rvoip-sip",
+                    "targets": [
+                        {"name": "ordinary", "kind": ["test"], "required-features": []},
+                        {
+                            "name": "feature_only",
+                            "kind": ["test"],
+                            "required-features": ["perf-tests"],
+                        },
+                        {"name": "library", "kind": ["lib"], "required-features": []},
+                    ],
+                }
+            ]
+        }
+        self.assertEqual(partitions.eligible_targets(metadata, "rvoip-sip"), ["ordinary"])
+
+    def test_every_target_is_assigned_exactly_once_and_long_test_is_isolated(self) -> None:
+        targets = ["audio_roundtrip_integration", *[f"test_{index}" for index in range(12)]]
+        result = partitions.partition_targets(targets, 3)
+        assigned = [name for item in result for name in item["targets"]]
+        self.assertEqual(sorted(assigned), sorted(targets))
+        self.assertEqual(len(assigned), len(set(assigned)))
+        audio_partition = next(
+            item for item in result if "audio_roundtrip_integration" in item["targets"]
+        )
+        self.assertEqual(audio_partition["targets"], ["audio_roundtrip_integration"])
+
+    def test_partitioning_is_deterministic(self) -> None:
+        targets = ["zeta", "alpha", "bridge_roundtrip_integration", "beta"]
+        self.assertEqual(
+            partitions.partition_targets(targets, 2),
+            partitions.partition_targets(list(reversed(targets)), 2),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -53,8 +53,12 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("if: always() && steps.worker.outputs.name != ''", workflow)
         self.assertIn("expected_shards", workflow)
         self.assertIn("expected_packages", workflow)
-        self.assertIn('heavy_sip_test = check == "test" and "rvoip-sip"', workflow)
-        self.assertIn('"disk_size_gb": 200 if heavy_sip_test else 80', workflow)
+        self.assertIn("expected_sip_targets", workflow)
+        self.assertIn("a SIP integration target appears in more than one shard", workflow)
+        self.assertIn("sip_test_partitions.py", workflow)
+        self.assertIn('"id": "sip-core"', workflow)
+        self.assertIn('f"sip-integration-{index}"', workflow)
+        self.assertIn('"disk_size_gb": 200', workflow)
         self.assertIn("publishing_attempted == false", workflow)
         self.assertIn('"publishing_attempted": False', startup)
         for profile in (
@@ -63,6 +67,8 @@ class WorkflowPolicyTests(unittest.TestCase):
             "workspace-shard-clippy",
             "workspace-doctest",
             "workspace-security-timing",
+            "workspace-sip-core",
+            "workspace-sip-integration",
         ):
             self.assertIn(profile, startup)
 


### PR DESCRIPTION
## Summary

- split `rvoip-sip` unit/examples and 99 ordinary integration targets across four ephemeral GCP workers
- isolate the known 10.5-minute audio fixture and balance the remaining targets deterministically
- bind exact target coverage into the aggregate non-publishing receipt
- fix the load-sensitive SIP proxy CANCEL test exposed by the baseline run

## Capacity

- 19 ephemeral workers
- 98 vCPUs
- 19 external addresses
- 480 GB balanced disk and 1,520 GB standard disk at peak
- all resources remain auto-deleted and final-swept

## Verification

- `cargo test -p rvoip-sip-proxy --test proxy_parallel_fork`
- `python3 -m unittest discover -s scripts/ci -p "test_*.py"`
- `python3 scripts/release.py audit`
- `cargo fmt --all -- --check`
- startup shell syntax and workflow YAML parsing

The workflow remains non-publishing. After PR checks pass, the next step is a manual `workspace-parallel` proof run against the exact merged candidate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect parallel CI orchestration and qualification coverage guarantees for a large package; runtime behavior change is limited to a test assertion fix in sip-proxy.
> 
> **Overview**
> Parallel **`workspace-parallel`** GCP qualification no longer runs **`rvoip-sip`** inside the generic test shards. **`rvoip-sip`** is removed from **`workspace-shard-test`** package lists, and four dedicated **`n2-standard-8`** workers run SIP work: one **`workspace-sip-core`** lane (lib/bins/examples) and three **`workspace-sip-integration`** lanes fed by **`sip_test_partitions.py`**, which builds duration-balanced partitions from **`cargo metadata`** (isolating long fixtures such as **`audio_roundtrip_integration`**).
> 
> Workers receive base64 **`targets_b64`** metadata; **`gcp-pilot-startup.sh`** and **`run_checks.py`** add **`sip-core`** / **`sip-integration`** command kinds and record **`targets`** on shard receipts. Aggregate reconciliation now checks one SIP core receipt, three integration receipts, and that every expected integration **`--test`** target appears exactly once via **`expected_sip_targets`**. Non-SIP clippy/test sharding rules are tightened accordingly. Policy, doctest, and security-timing workers move to **`n2-standard-2`**.
> 
> **`proxy_parallel_fork`** marks the injected downstream **100 Trying** with a **`Subject`** header so the “must not forward upstream” assertion ignores legitimate local **100** responses under parallel load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf2b8f380754bc3762f70b43bcc839cb18a3af74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->