### PR TITLE
Run complete release qualification on ephemeral workers

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -51,7 +51,11 @@ jobs:
     timeout-minutes: 15
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
+      hosted_matrix: ${{ steps.plan.outputs.hosted_matrix }}
+      gcp_matrix: ${{ steps.plan.outputs.gcp_matrix }}
       shard_count: ${{ steps.plan.outputs.shard_count }}
+      hosted_shard_count: ${{ steps.plan.outputs.hosted_shard_count }}
+      gcp_shard_count: ${{ steps.plan.outputs.gcp_shard_count }}
       candidate_sha: ${{ steps.plan.outputs.candidate_sha }}
       environment_id: ${{ steps.plan.outputs.environment_id }}
       run_count: ${{ steps.plan.outputs.run_count }}
@@ -75,17 +79,6 @@ jobs:
             echo "release candidates must be commits on origin/main" >&2
             exit 1
           }
-
-      - name: Require provisioned specialty runners
-        if: inputs.profile == 'remote-release'
-        env:
-          GCP_RUNNERS_READY: ${{ vars.RVOIP_GCP_RUNNERS_READY }}
-        run: |
-          if test "$GCP_RUNNERS_READY" != true; then
-            echo "remote-release requires the approved ephemeral GCP runner fleet" >&2
-            echo "set repository variable RVOIP_GCP_RUNNERS_READY=true only after runner labels and cleanup are verified" >&2
-            exit 1
-          fi
 
       - name: Require complete structured release coverage
         if: inputs.profile == 'remote-release'
@@ -159,14 +152,15 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
-  gate:
+  gate-hosted:
     name: ${{ matrix.resource_class }} / ${{ matrix.id }}
+    if: needs.plan.outputs.hosted_shard_count != '0'
     needs: plan
-    runs-on: ${{ matrix.runs_on }}
+    runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.plan.outputs.hosted_matrix) }}
     steps:
       - name: Check out exact candidate
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -209,6 +203,10 @@ jobs:
           sudo apt-get update && sudo apt-get install -y
           libasound2-dev libopus-dev libssl-dev protobuf-compiler pkg-config cmake
 
+      - name: Install Chromium for the BridgeFu DTMF regression
+        if: matrix.needs_chromium
+        run: sudo apt-get install -y chromium
+
       - name: Run gate shard
         run: >-
           python3 scripts/release/gates.py run-shard
@@ -226,10 +224,239 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
+  preflight-gcp:
+    name: Verify ephemeral GCP capacity
+    if: needs.plan.outputs.gcp_shard_count != '0'
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.RVOIP_GCP_PILOT_PROVIDER }}
+          service_account: ${{ vars.RVOIP_GCP_PROVISIONER_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Require all compute and disk quota before creating workers
+        env:
+          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
+          REGION: ${{ vars.RVOIP_GCP_REGION }}
+          GCP_MATRIX: ${{ needs.plan.outputs.gcp_matrix }}
+        run: |
+          set -euo pipefail
+          gcloud compute project-info describe --project "$PROJECT" --format=json > global-quotas.json
+          gcloud compute regions describe "$REGION" --project "$PROJECT" --format=json > regional-quotas.json
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          workers = json.loads(os.environ["GCP_MATRIX"])["include"]
+          vcpus = sum(int(item["machine_type"].rsplit("-", 1)[1]) for item in workers)
+          instances = len(workers)
+          disk_gb = sum(int(item["disk_size_gb"]) for item in workers)
+          global_quotas = {
+              row["metric"]: row
+              for row in json.loads(Path("global-quotas.json").read_text())["quotas"]
+          }
+          regional_quotas = {
+              row["metric"]: row
+              for row in json.loads(Path("regional-quotas.json").read_text())["quotas"]
+          }
+          required = {
+              "CPUS_ALL_REGIONS": (global_quotas, vcpus),
+              "CPUS": (regional_quotas, vcpus),
+              "N2_CPUS": (regional_quotas, vcpus),
+              "INSTANCES": (regional_quotas, instances),
+              "IN_USE_ADDRESSES": (regional_quotas, instances),
+              "DISKS_TOTAL_GB": (regional_quotas, disk_gb),
+          }
+          failures = []
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a") as output:
+              output.write("## Ephemeral release capacity\n\n")
+              output.write(f"- Workers: {instances}\n- N2 vCPUs: {vcpus}\n- Standard disk: {disk_gb} GB\n\n")
+              output.write("| Quota | Required | Available |\n| --- | ---: | ---: |\n")
+              for metric, (source, needed) in required.items():
+                  quota = source.get(metric)
+                  available = -1 if quota is None else int(quota["limit"] - quota.get("usage", 0))
+                  output.write(f"| {metric} | {needed} | {available} |\n")
+                  if available < needed:
+                      failures.append(f"{metric}: requires {needed}, only {available} available")
+          if failures:
+              raise SystemExit("GCP capacity preflight failed:\n- " + "\n- ".join(failures))
+          PY
+
+  gate-gcp:
+    name: ${{ matrix.resource_class }} / ${{ matrix.id }}
+    if: needs.plan.outputs.gcp_shard_count != '0'
+    needs: [plan, preflight-gcp]
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.gcp_matrix) }}
+    steps:
+      - name: Check out controller definition
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.plan.outputs.candidate_sha }}
+
+      - name: Authenticate to Google Cloud without a key
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.RVOIP_GCP_PILOT_PROVIDER }}
+          service_account: ${{ vars.RVOIP_GCP_PROVISIONER_SERVICE_ACCOUNT }}
+
+      - name: Install Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Create an ephemeral release worker
+        id: worker
+        env:
+          CANDIDATE: ${{ needs.plan.outputs.candidate_sha }}
+          ENVIRONMENT_ID: ${{ needs.plan.outputs.environment_id }}
+          GATES: ${{ matrix.gates_csv }}
+          SHARD_ID: ${{ matrix.id }}
+          MACHINE_TYPE: ${{ matrix.machine_type }}
+          DISK_TYPE: ${{ matrix.disk_type }}
+          DISK_SIZE_GB: ${{ matrix.disk_size_gb }}
+          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
+          ZONE: ${{ vars.RVOIP_GCP_ZONE }}
+          NETWORK: ${{ vars.RVOIP_GCP_NETWORK }}
+          SUBNET: ${{ vars.RVOIP_GCP_SUBNET }}
+          BUCKET: ${{ vars.RVOIP_GCP_EVIDENCE_BUCKET }}
+          RUNNER_SERVICE_ACCOUNT: ${{ vars.RVOIP_GCP_RUNNER_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          worker="rvoip-rel-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${SHARD_ID}"
+          prefix="release/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/${SHARD_ID}"
+          gates_b64="$(printf '%s' "$GATES" | base64 -w0)"
+          environment_b64="$(printf '%s' "$ENVIRONMENT_ID" | base64 -w0)"
+          echo "name=$worker" >> "$GITHUB_OUTPUT"
+          echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+          gcloud compute instances create "$worker" \
+            --project "$PROJECT" \
+            --zone "$ZONE" \
+            --machine-type "$MACHINE_TYPE" \
+            --network "$NETWORK" \
+            --subnet "$SUBNET" \
+            --image-family ubuntu-2404-lts-amd64 \
+            --image-project ubuntu-os-cloud \
+            --boot-disk-type "$DISK_TYPE" \
+            --boot-disk-size "${DISK_SIZE_GB}GB" \
+            --boot-disk-auto-delete \
+            --service-account "$RUNNER_SERVICE_ACCOUNT" \
+            --scopes cloud-platform \
+            --shielded-secure-boot \
+            --shielded-vtpm \
+            --shielded-integrity-monitoring \
+            --labels rvoip-role=release-gate,managed-by=github-actions \
+            --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${SHARD_ID},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
+            --metadata-from-file startup-script=infra/release-runners/gcp-release-startup.sh
+
+      - name: Wait for immutable worker evidence
+        env:
+          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
+          ZONE: ${{ vars.RVOIP_GCP_ZONE }}
+          BUCKET: ${{ vars.RVOIP_GCP_EVIDENCE_BUCKET }}
+          WORKER: ${{ steps.worker.outputs.name }}
+          PREFIX: ${{ steps.worker.outputs.prefix }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 340); do
+            if gcloud storage cat "gs://${BUCKET}/${PREFIX}/result.json" > result.json 2>/dev/null; then
+              exit 0
+            fi
+            state="$(gcloud compute instances describe "$WORKER" --project "$PROJECT" --zone "$ZONE" --format='value(status)' 2>/dev/null || true)"
+            if [[ "$state" == TERMINATED ]]; then
+              echo "worker terminated without uploading a result" >&2
+              exit 1
+            fi
+            sleep 30
+          done
+          echo "release shard exceeded its 170-minute evidence deadline" >&2
+          exit 1
+
+      - name: Download and verify shard evidence
+        if: always() && steps.worker.outputs.prefix != ''
+        env:
+          BUCKET: ${{ vars.RVOIP_GCP_EVIDENCE_BUCKET }}
+          PREFIX: ${{ steps.worker.outputs.prefix }}
+          CANDIDATE: ${{ needs.plan.outputs.candidate_sha }}
+          SHARD_ID: ${{ matrix.id }}
+        run: |
+          set -euo pipefail
+          gcloud storage cp "gs://${BUCKET}/${PREFIX}/qualification.log" qualification.log || true
+          test -f result.json
+          gcloud storage cp "gs://${BUCKET}/${PREFIX}/release-shard.tar.gz" release-shard.tar.gz
+          echo "$(jq -r .evidence_archive_sha256 result.json)  release-shard.tar.gz" | sha256sum --check
+          mkdir -p target
+          tar -C target -xzf release-shard.tar.gz
+          jq -e \
+            --arg candidate "$CANDIDATE" \
+            --arg shard "$SHARD_ID" \
+            '.candidate_sha == $candidate and .shard_id == $shard and .status == "PASS" and .publishing_attempted == false' \
+            result.json
+
+      - name: Delete worker and attached disk
+        if: always() && steps.worker.outputs.name != ''
+        env:
+          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
+          ZONE: ${{ vars.RVOIP_GCP_ZONE }}
+          WORKER: ${{ steps.worker.outputs.name }}
+        run: |
+          if gcloud compute instances describe "$WORKER" --project "$PROJECT" --zone "$ZONE" >/dev/null 2>&1; then
+            gcloud compute instances delete "$WORKER" --project "$PROJECT" --zone "$ZONE" --quiet
+          fi
+
+      - name: Upload GCP shard evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-gate-shard-${{ matrix.id }}
+          path: target/release-shard/
+          retention-days: 90
+          if-no-files-found: warn
+
+  cleanup-gcp:
+    name: Delete every ephemeral release worker
+    if: always() && needs.plan.outputs.gcp_shard_count != '0'
+    needs: [plan, gate-gcp]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.RVOIP_GCP_PILOT_PROVIDER }}
+          service_account: ${{ vars.RVOIP_GCP_PROVISIONER_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Sweep workers left by interrupted controllers
+        env:
+          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
+          RUN_PREFIX: rvoip-rel-${{ github.run_id }}-${{ github.run_attempt }}-
+        run: |
+          set -euo pipefail
+          instances="$(gcloud compute instances list --project "$PROJECT" --filter="labels.managed-by=github-actions AND name~'^${RUN_PREFIX}'" --format='csv[no-heading](name,zone.basename())' || true)"
+          while IFS=, read -r worker zone; do
+            test -n "$worker" || continue
+            gcloud compute instances delete "$worker" --project "$PROJECT" --zone "$zone" --quiet
+          done <<< "$instances"
+          remaining="$(gcloud compute instances list --project "$PROJECT" --filter="labels.managed-by=github-actions AND name~'^${RUN_PREFIX}'" --format='value(name)')"
+          test -z "$remaining"
+
   collect:
     name: Release Gate
     if: always()
-    needs: [plan, gate]
+    needs: [plan, gate-hosted, gate-gcp, cleanup-gcp]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+LOG=/var/log/rvoip-release-qualification.log
+exec > >(tee -a "$LOG") 2>&1
+
+metadata() {
+  curl --fail --silent --show-error \
+    -H 'Metadata-Flavor: Google' \
+    "http://metadata.google.internal/computeMetadata/v1/instance/attributes/$1"
+}
+
+CANDIDATE="$(metadata rvoip-candidate)"
+RUN_ID="$(metadata rvoip-run-id)"
+SHARD_ID="$(metadata rvoip-shard-id)"
+BUCKET="$(metadata rvoip-evidence-bucket)"
+PREFIX="$(metadata rvoip-prefix)"
+GATES="$(metadata rvoip-gates-b64 | base64 --decode)"
+ENVIRONMENT_ID="$(metadata rvoip-environment-b64 | base64 --decode)"
+WORKSPACE=/opt/rvoip
+EVIDENCE=/tmp/release-shard
+ARCHIVE=/tmp/release-shard.tar.gz
+RESULT=/tmp/result.json
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+START_SECONDS="$(date +%s)"
+
+upload() {
+  local source="$1"
+  local object="$2"
+  local token encoded
+  token="$(curl --fail --silent --show-error \
+    -H 'Metadata-Flavor: Google' \
+    http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')"
+  encoded="$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$object")"
+  curl --fail --silent --show-error \
+    -X POST \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Content-Type: application/octet-stream' \
+    --data-binary "@${source}" \
+    "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${encoded}"
+}
+
+finish() {
+  local exit_code=$?
+  local ended_at duration archive_sha
+  trap - EXIT
+  ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  duration="$(( $(date +%s) - START_SECONDS ))"
+  archive_sha=""
+  if [[ -d "$EVIDENCE" ]]; then
+    if [[ -d "$WORKSPACE/target/perf-results" ]]; then
+      mkdir -p "$EVIDENCE/_perf-results/$SHARD_ID"
+      (
+        cd "$WORKSPACE/target/perf-results"
+        find . -type f \
+          \( -name '*.json' -o -name '*.md' -o -name '*.tsv' \
+             -o -name '*.csv' -o -name '*.log' -o -name '*.txt' \) \
+          -exec cp --parents -t "$EVIDENCE/_perf-results/$SHARD_ID" {} +
+      )
+    fi
+    tar -C /tmp -czf "$ARCHIVE" release-shard
+    archive_sha="$(sha256sum "$ARCHIVE" | awk '{print $1}')"
+    upload "$ARCHIVE" "${PREFIX}/release-shard.tar.gz" || exit_code=75
+  fi
+  python3 - "$RESULT" "$CANDIDATE" "$RUN_ID" "$SHARD_ID" "$GATES" \
+    "$STARTED_AT" "$ended_at" "$duration" "$exit_code" "$archive_sha" <<'PY'
+import json
+import sys
+
+path, candidate, run_id, shard, gates, started, ended, duration, code, archive_sha = sys.argv[1:]
+payload = {
+    "schema": "rvoip-gcp-release-shard-v1",
+    "candidate_sha": candidate,
+    "github_run_id": run_id,
+    "shard_id": shard,
+    "gates": sorted(value for value in gates.split(",") if value),
+    "started_at": started,
+    "ended_at": ended,
+    "duration_seconds": int(duration),
+    "exit_code": int(code),
+    "status": "PASS" if int(code) == 0 else "FAIL",
+    "evidence_archive_sha256": archive_sha or None,
+    "publishing_attempted": False,
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+  upload "$LOG" "${PREFIX}/qualification.log" || true
+  upload "$RESULT" "${PREFIX}/result.json" || true
+  sync
+  shutdown -h now || true
+  exit "$exit_code"
+}
+trap finish EXIT
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends \
+  baresip build-essential ca-certificates cmake curl docker.io git jq \
+  libasound2-dev libopus-dev libssl-dev pkg-config protobuf-compiler sipp
+
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+  https://sh.rustup.rs -o /tmp/rustup-init.sh
+sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain 1.91.0 \
+  --component clippy,rustfmt
+export PATH=/root/.cargo/bin:$PATH
+
+git clone --filter=blob:none https://github.com/eisenzopf/rvoip.git "$WORKSPACE"
+cd "$WORKSPACE"
+git fetch --depth=1 origin "$CANDIDATE"
+git checkout --detach "$CANDIDATE"
+test "$(git rev-parse HEAD)" = "$CANDIDATE"
+
+python3 scripts/release/gates.py run-shard \
+  --candidate "$CANDIDATE" \
+  --environment-id "$ENVIRONMENT_ID" \
+  --gates "$GATES" \
+  --output "$EVIDENCE"

--- a/infra/release-runners/interop-lifecycle.sh
+++ b/infra/release-runners/interop-lifecycle.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ACTION="${1:?usage: interop-lifecycle.sh ACTION}"
+ROOT="$(git rev-parse --show-toplevel)"
+STATE="$ROOT/target/release-interop"
+PBX_SNAPSHOT="$ROOT/crates/sip/rvoip-sip/beta-report/20260729T010954Z/environment/local-pbx"
+mkdir -p "$STATE" "$HOME/Developer/asterisk" "$HOME/Developer/freeswitch"
+
+wait_port() {
+  local port="$1"
+  for _ in $(seq 1 180); do
+    if nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "port $port did not become ready" >&2
+  return 1
+}
+
+down() {
+  docker rm -f "$1" >/dev/null 2>&1 || true
+}
+
+asterisk_up() {
+  down rvoip-release-asterisk
+  local build="$STATE/asterisk"
+  rm -rf "$build"
+  cp -R "$PBX_SNAPSHOT/asterisk" "$build"
+  python3 - "$build/config/pjsip.conf" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(
+    path.read_text()
+    .replace("<redacted>", "password123")
+    .replace("192.168.64.2", "127.0.0.1")
+)
+PY
+  mkdir -p "$build/keys"
+  openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "$build/keys/asterisk-key.pem" \
+    -out "$build/keys/asterisk.pem" -days 2 \
+    -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1' \
+    >/dev/null 2>&1
+  cp "$build/keys/asterisk.pem" "$build/keys/ca.pem"
+  docker build -t rvoip-release-asterisk "$build"
+  docker run -d --name rvoip-release-asterisk --network host \
+    -v "$build/config/pjsip.conf:/etc/asterisk/pjsip.conf:ro" \
+    -v "$build/config/extensions.conf:/etc/asterisk/extensions.conf:ro" \
+    -v "$build/config/modules.conf:/etc/asterisk/modules.conf:ro" \
+    -v "$build/keys:/etc/asterisk/keys:ro" \
+    rvoip-release-asterisk >/dev/null
+  wait_port 5060
+  cat > "$HOME/Developer/asterisk/rvoip-local.env" <<EOF
+SIP_SERVER=127.0.0.1
+SIP_PORT=5060
+SIP_TRANSPORT=TLS
+SIP_PASSWORD=password123
+SIP_USERNAME=1001
+SIP_AUTH_USERNAME=1001
+SIP_TLS_PORT=5061
+TLS_CA_PATH=$build/keys/ca.pem
+TLS_INSECURE=1
+ASTERISK_TLS_SRTP_REQUIRED=1
+ASTERISK_TLS_CONTACT_MODE=reachable-contact
+LOCAL_IP=127.0.0.1
+ADVERTISED_IP=127.0.0.1
+MEDIA_ADVERTISED_IP=127.0.0.1
+LOCAL_PORT=5070
+POST_REGISTER_SETTLE_SECS=2
+REGISTRATION_IDLE_SECS=1
+EOF
+}
+
+freeswitch_up() {
+  down rvoip-release-freeswitch
+  local build="$STATE/freeswitch"
+  rm -rf "$build"
+  cp -R "$PBX_SNAPSHOT/freeswitch" "$build"
+  python3 - "$build/Dockerfile" "$build/docker-entrypoint.sh" <<'PY'
+from pathlib import Path
+import sys
+
+dockerfile = Path(sys.argv[1])
+dockerfile.write_text(
+    dockerfile.read_text()
+    .replace("ENV FS_DEFAULT_PASSWORD=<redacted>", "ENV FS_DEFAULT_PASSWORD=1234")
+    .replace(
+        "ENV FS_EVENT_SOCKET_PASSWORD=<redacted>",
+        "ENV FS_EVENT_SOCKET_PASSWORD=ClueCon",
+    )
+)
+path = Path(sys.argv[2])
+lines = []
+for line in path.read_text().splitlines():
+    if line == "  password=<redacted>":
+        line = "  password=${FS_DEFAULT_PASSWORD:-1234}"
+    elif line.startswith("set_xml_var default_password"):
+        line = 'set_xml_var default_password "${FS_DEFAULT_PASSWORD:-1234}"'
+    elif line.startswith('  sed -i "s#<param name=\\"password\\"'):
+        line = "  sed -i 's|<param name=\"password\" value=\"[^\"]*\"/>|<param name=\"password\" value=\"'\"${FS_EVENT_SOCKET_PASSWORD:-ClueCon}\"'\"/>|g' \"$event_socket\""
+    lines.append(line)
+path.write_text("\n".join(lines) + "\n")
+PY
+  docker build --build-arg MAKE_JOBS="$(nproc)" -t rvoip-release-freeswitch "$build"
+  docker run -d --name rvoip-release-freeswitch --network host \
+    -e FS_DEFAULT_PASSWORD=1234 \
+    -e FS_EVENT_SOCKET_PASSWORD=ClueCon \
+    -e FS_EXTERNAL_SIP_IP=127.0.0.1 \
+    -e FS_EXTERNAL_RTP_IP=127.0.0.1 \
+    rvoip-release-freeswitch >/dev/null
+  wait_port 5062
+  cat > "$HOME/Developer/freeswitch/freeswitch-local.env" <<'EOF'
+FREESWITCH_ADDR=127.0.0.1:5060
+FREESWITCH_IP=127.0.0.1
+FREESWITCH_SIP_PORT=5060
+FREESWITCH_UDP_ADDR=127.0.0.1:5062
+FREESWITCH_TLS_ADDR=127.0.0.1:5063
+FREESWITCH_UDP_SIP_PORT=5062
+FREESWITCH_TLS_SIP_PORT=5063
+FREESWITCH_RTP_START=16384
+FREESWITCH_RTP_END=16484
+FREESWITCH_PASSWORD=1234
+FREESWITCH_UDP_USERS=2001,2002,2003
+FREESWITCH_TLS_USERS=1001,1002,1003
+RVOIP_LOCAL_IP=127.0.0.1
+RVOIP_ADVERTISED_IP=127.0.0.1
+RVOIP_MEDIA_ADVERTISED_IP=127.0.0.1
+EOF
+}
+
+sipp_start() {
+  local binary="$ROOT/target/release/examples/perf_listener"
+  test -x "$binary"
+  if [[ -f "$STATE/sipp.pid" ]] && kill -0 "$(cat "$STATE/sipp.pid")" 2>/dev/null; then
+    echo "managed SIPp target already running" >&2
+    exit 1
+  fi
+  nohup "$binary" 35060 127.0.0.1 --perf-profile pbx-media-server \
+    >"$STATE/sipp-listener.log" 2>&1 </dev/null &
+  echo "$!" > "$STATE/sipp.pid"
+  for _ in $(seq 1 100); do
+    grep -q 'listening on' "$STATE/sipp-listener.log" 2>/dev/null && exit 0
+    kill -0 "$(cat "$STATE/sipp.pid")" 2>/dev/null || exit 1
+    sleep 0.1
+  done
+  exit 1
+}
+
+sipp_stop() {
+  if [[ -f "$STATE/sipp.pid" ]]; then
+    pid="$(cat "$STATE/sipp.pid")"
+    kill -INT "$pid" 2>/dev/null || true
+    for _ in $(seq 1 50); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.1
+    done
+    kill -KILL "$pid" 2>/dev/null || true
+    rm -f "$STATE/sipp.pid"
+  fi
+}
+
+case "$ACTION" in
+  asterisk-up) asterisk_up ;;
+  asterisk-down|restore-asterisk-down) down rvoip-release-asterisk ;;
+  freeswitch-up) freeswitch_up ;;
+  freeswitch-down|restore-freeswitch-down) down rvoip-release-freeswitch ;;
+  sipp-start) sipp_start ;;
+  sipp-stop) sipp_stop ;;
+  *) echo "unknown interop lifecycle action: $ACTION" >&2; exit 2 ;;
+esac

--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -21,26 +21,36 @@ OUTPUT = Path("scripts/release/gates.json")
 LEGACY_UNSTRUCTURED = {
     "source.clean-start",
     "source.canonical-2k",
-    "interop.freeswitch-down-before-asterisk",
-    "interop.asterisk-up",
-    "interop.asterisk-down-after",
-    "interop.asterisk-down-before-freeswitch",
-    "interop.freeswitch-up",
-    "interop.freeswitch-down-after",
-    "interop.restore-asterisk-down",
-    "interop.restore-freeswitch-down",
-    "interop.sipp-start",
-    "interop.sipp-stop",
     "interop.proxy-descope",
     "perf.capture-boundary",
     "perf.literal-all-config",
-    "report.regression-baseline",
     "report.regression-audit",
     "report.perf-evidence-capture",
     "report.performance-metrics",
     "source.final-capture",
     "source.canonical-2k-unchanged",
 }
+COLLECT_AGGREGATES = {
+    "source.canonical-2k",
+    "perf.capture-boundary",
+    "perf.literal-all-config",
+    "report.regression-audit",
+    "report.perf-evidence-capture",
+    "report.performance-metrics",
+    "source.final-capture",
+    "source.canonical-2k-unchanged",
+    "interop.proxy-descope",
+    "perf.media-burst-matrix",
+}
+BURST_SCENARIOS = [
+    "carrier-smoke",
+    "access-edge-microburst",
+    "contact-center-flash",
+    "shift-change-long-hold",
+    "overload-recovery",
+    "high-density-media-burst",
+    "buffer-ab-legacy",
+]
 COMMAND_OVERRIDES = {
     "security.advisory-audit": [
         "cargo",
@@ -87,6 +97,24 @@ COMMAND_OVERRIDES = {
         "rvoip",
     ],
 }
+
+for _gate_id, _action in {
+    "interop.freeswitch-down-before-asterisk": "freeswitch-down",
+    "interop.asterisk-up": "asterisk-up",
+    "interop.asterisk-down-after": "asterisk-down",
+    "interop.asterisk-down-before-freeswitch": "asterisk-down",
+    "interop.freeswitch-up": "freeswitch-up",
+    "interop.freeswitch-down-after": "freeswitch-down",
+    "interop.restore-asterisk-down": "restore-asterisk-down",
+    "interop.restore-freeswitch-down": "restore-freeswitch-down",
+    "interop.sipp-start": "sipp-start",
+    "interop.sipp-stop": "sipp-stop",
+}.items():
+    COMMAND_OVERRIDES[_gate_id] = [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        _action,
+    ]
 
 FUZZ_TARGETS = {
     "sip-message": "sip_message",
@@ -198,7 +226,7 @@ def affected_paths(record: dict[str, Any], command: list[str] | None) -> list[st
         expanded = value.replace("{workspace}/", "")
         if "/Cargo.toml" in expanded:
             paths.append(expanded.rsplit("/Cargo.toml", 1)[0] + "/**")
-        elif expanded.startswith(("scripts/", "crates/", "examples/")):
+        elif expanded.startswith(("scripts/", "crates/", "examples/", "infra/")):
             path = expanded.split("=", 1)[-1]
             paths.append(path if "*" in path else path)
     return sorted(set(paths))
@@ -235,11 +263,20 @@ def dependencies(record: dict[str, Any], records: list[dict[str, Any]]) -> list[
     if gate_id == "source.clean-start":
         return []
     if gate_id == "source.canonical-2k":
-        return ["source.clean-start"]
+        return [
+            "source.clean-start",
+            "perf.concurrent-calls",
+            "perf.sipp-parity",
+            "perf.media-burst-matrix",
+        ]
     if gate_id == "source.final-capture":
         return [item["id"] for item in records if item["id"] != gate_id and not item["id"].startswith("source.canonical-2k-unchanged")]
     if gate_id == "source.canonical-2k-unchanged":
         return ["source.clean-start", "source.final-capture"]
+    if gate_id == "interop.proxy-descope":
+        return ["interop.remote-proxies"]
+    if gate_id == "perf.media-burst-matrix":
+        return [f"perf.media-burst.{scenario}" for scenario in BURST_SCENARIOS]
     if gate_id.startswith("report."):
         perf = [item["id"] for item in records if item["id"].startswith("perf.")]
         prior_reports = [
@@ -258,6 +295,10 @@ def dependencies(record: dict[str, Any], records: list[dict[str, Any]]) -> list[
 def legacy_gate(record: dict[str, Any], records: list[dict[str, Any]], packages: list[str]) -> dict[str, Any]:
     command = normalized_command(record)
     executor = "argv" if command else "legacy-group"
+    if record["id"] in COLLECT_AGGREGATES:
+        # These gates reconcile evidence produced by other shards. Running
+        # them concurrently would race the evidence they are meant to audit.
+        executor = "aggregate"
     if record["id"] == "source.clean-start":
         # The remote runner can verify this directly without invoking the
         # macOS-only beta wrapper.
@@ -412,6 +453,34 @@ def security_gates() -> list[dict[str, Any]]:
     return result
 
 
+def burst_scenario_gates() -> list[dict[str, Any]]:
+    result = []
+    for scenario in BURST_SCENARIOS:
+        gate = synthetic_gate(
+            f"perf.media-burst.{scenario}",
+            f"media burst scenario: {scenario}",
+            executor="argv",
+            command=[
+                "env",
+                "RVOIP_PERF_RESULTS={artifact_dir}",
+                f"RVOIP_PERF_BURST_SCENARIOS={scenario}",
+                "bash",
+                "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+            ],
+            resource="gcp-performance-soak",
+            dependencies=["source.remote-clean"],
+            paths=[
+                "crates/sip/rvoip-sip/**",
+                "crates/media/**",
+                "crates/foundation/**",
+            ],
+        )
+        gate["estimated_seconds"] = 900
+        gate["timeout_minutes"] = 75
+        result.append(gate)
+    return result
+
+
 def build_catalog(root: Path, source: Path) -> dict[str, Any]:
     source_payload = json.loads(source.read_text())
     records = source_payload["records"]
@@ -464,7 +533,34 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
             dependencies=["source.remote-clean"],
             paths=["crates/sip/sip-proxy/**", "crates/sip/sip-transport/**", "crates/sip/sip-core/**"],
         ),
+        synthetic_gate(
+            "interop.browser-dtmf",
+            "real Chromium outbound RFC 4733 interoperability (BridgeFu issue #54)",
+            executor="argv",
+            command=[
+                "cargo",
+                "test",
+                "--locked",
+                "-p",
+                "rvoip-webrtc",
+                "--features",
+                "interop-browser,signaling-whip,signaling-ws",
+                "--test",
+                "browser_interop",
+                "--",
+                "--include-ignored",
+                "--nocapture",
+            ],
+            resource="github-standard",
+            dependencies=["source.remote-clean"],
+            paths=[
+                "crates/webrtc/rvoip-rtc/**",
+                "crates/webrtc/rvoip-webrtc/**",
+                "crates/core/rvoip-core/**",
+            ],
+        ),
     ]
+    synthetic.extend(burst_scenario_gates())
     core = [core_gate(package, root, weights) for package in package_rows]
     security = security_gates()
     remote_without_final = [gate["id"] for gate in synthetic + core + security]
@@ -472,12 +568,14 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
         synthetic_gate(
             "report.remote-aggregate",
             "exact-candidate evidence reconciliation",
+            executor="aggregate",
             dependencies=sorted(set(remote_without_final)),
             always_fresh=True,
         ),
         synthetic_gate(
             "source.remote-final",
             "final candidate source fingerprint",
+            executor="aggregate",
             dependencies=["report.remote-aggregate"],
             always_fresh=True,
         ),
@@ -485,26 +583,40 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
     gates = legacy + synthetic + core + security + final
 
     direct_legacy = [gate["id"] for gate in legacy if gate["executor"] == "argv"]
+    structured_legacy = [
+        gate["id"] for gate in legacy if gate["executor"] != "legacy-group"
+    ]
     core_ids = [gate["id"] for gate in core]
     security_ids = [gate["id"] for gate in security]
     framework_ids = [
         "source.remote-clean",
         "source.clean-start",
         "package.inventory",
-        "report.remote-aggregate",
-        "source.remote-final",
     ]
     lightweight_legacy = [
         gate_id
         for gate_id in direct_legacy
-        if not gate_id.startswith(("perf.", "interop."))
+        if not gate_id.startswith(("perf.", "interop.", "report.", "source."))
     ]
+    lightweight_legacy.append("source.clean-start")
     heavy_direct = [
         gate_id for gate_id in direct_legacy if gate_id.startswith(("perf.", "interop."))
     ]
     remote_core = sorted(set(framework_ids + core_ids + lightweight_legacy + [security_ids[0]]))
     remote_release = sorted(
-        set(remote_core + security_ids[1:] + heavy_direct + ["interop.remote-libsrtp", "interop.remote-proxies"])
+        set(
+            remote_core
+            + security_ids[1:]
+            + structured_legacy
+            + [
+                "interop.remote-libsrtp",
+                "interop.remote-proxies",
+                "interop.browser-dtmf",
+                "report.remote-aggregate",
+                "source.remote-final",
+            ]
+            + [f"perf.media-burst.{scenario}" for scenario in BURST_SCENARIOS]
+        )
     )
     remote_release_legacy_coverage = sorted(
         set(record["id"] for record in records) - set(remote_release)
@@ -520,7 +632,13 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
         },
         "workspace_package_count": len(package_rows),
         "profiles": {
-            "legacy-full": [record["id"] for record in records],
+            "legacy-full": sorted(
+                set(
+                    [record["id"] for record in records]
+                    + ["source.remote-clean", "interop.remote-proxies"]
+                    + [f"perf.media-burst.{scenario}" for scenario in BURST_SCENARIOS]
+                )
+            ),
             "remote-core": remote_core,
             "remote-release": remote_release,
         },

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -43,11 +43,14 @@
       "category": "Source integrity",
       "command": null,
       "dependencies": [
-        "source.clean-start"
+        "source.clean-start",
+        "perf.concurrent-calls",
+        "perf.sipp-parity",
+        "perf.media-burst-matrix"
       ],
       "display_command": "python3 <workspace>/crates/sip/rvoip-sip/scripts/canonical_2k_evidence.py import --workspace-root <workspace> --beta-start <source-report> --artifact-dir <source-report> --run-dir <workspace>/target/perf-results/profiles/20260724T221956Z_clean_KRwxGm --run-dir <workspace>/target/perf-results/profiles/20260724T224300Z_clean_GbSiae --run-dir <workspace>/target/perf-results/profiles/20260724T225757Z_clean_p5XNXK",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -2674,13 +2677,17 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "freeswitch-down"
+      ],
       "dependencies": [
         "source.clean-start"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -2710,14 +2717,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "asterisk-up"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.freeswitch-down-before-asterisk"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 2,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -2796,14 +2807,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "asterisk-down"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.asterisk-matrix"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 4,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -2833,14 +2848,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "asterisk-down"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.asterisk-down-after"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -2870,14 +2889,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "freeswitch-up"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.asterisk-down-before-freeswitch"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 7,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -2956,14 +2979,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "freeswitch-down"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.freeswitch-matrix"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 11,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -2993,14 +3020,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "restore-asterisk-down"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.freeswitch-down-after"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -3030,14 +3061,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "restore-freeswitch-down"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.restore-asterisk-down"
       ],
       "display_command": "<local-path>",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -3115,14 +3150,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "sipp-start"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.sipp-build"
       ],
       "display_command": "managed perf_listener lifecycle operation (command was not structured separately by the v1 runner)",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -3198,14 +3237,18 @@
       ],
       "always_fresh": false,
       "category": "PBX and interoperability",
-      "command": null,
+      "command": [
+        "bash",
+        "infra/release-runners/interop-lifecycle.sh",
+        "sipp-stop"
+      ],
       "dependencies": [
         "source.clean-start",
         "interop.sipp-matrix"
       ],
       "display_command": "managed perf_listener lifecycle operation (command was not structured separately by the v1 runner)",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -3278,12 +3321,11 @@
       "category": "PBX and interoperability",
       "command": null,
       "dependencies": [
-        "source.clean-start",
-        "interop.strict-ua"
+        "interop.remote-proxies"
       ],
       "display_command": "bash -c set -euo pipefail",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -3320,7 +3362,7 @@
       ],
       "display_command": "prepare_perf_results_capture",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -3357,7 +3399,7 @@
       ],
       "display_command": "env BETA_RUN_BURST_MATRIX=1 BETA_BURST_MATRIX=all BETA_RUN_LONG_SOAK=1 RVOIP_PERF_SKIP_AUDIO_FRAME_DELIVERY=0 bash -c ",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -4746,11 +4788,17 @@
         "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
       ],
       "dependencies": [
-        "source.clean-start"
+        "perf.media-burst.carrier-smoke",
+        "perf.media-burst.access-edge-microburst",
+        "perf.media-burst.contact-center-flash",
+        "perf.media-burst.shift-change-long-hold",
+        "perf.media-burst.overload-recovery",
+        "perf.media-burst.high-density-media-burst",
+        "perf.media-burst.buffer-ab-legacy"
       ],
       "display_command": "env RVOIP_PERF_FEATURES=perf-tests RVOIP_PERF_BURST_SCENARIO_FILE=<workspace>/crates/sip/rvoip-sip/config/perf-burst-scenarios.yaml RVOIP_PERF_BURST_SCENARIOS=all RVOIP_PERF_MEMORY_DIAGNOSTICS=0 RVOIP_PERF_ALLOCATOR_DIAGNOSTICS=0 RVOIP_PERF_MEMORY_DIAG_INTERVAL_SECS=5 RVOIP_PERF_MIMALLOC_COLLECT_AT=off RVOIP_PERF_SKIP_AUDIO_FRAME_DELIVERY=0 RVOIP_PERF_MAX_RSS_GROWTH_MB_PER_HR=15 <workspace>/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
       "estimated_seconds": 5574,
-      "executor": "argv",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -4838,7 +4886,17 @@
       ],
       "always_fresh": true,
       "category": "Reporting and regression",
-      "command": null,
+      "command": [
+        "python3",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_regression_baseline.py",
+        "package",
+        "--manifest",
+        "{workspace}/crates/sip/rvoip-sip/perf-baselines/20260706T181609Z/manifest.json",
+        "--source-root",
+        "{workspace}/crates/sip/rvoip-sip/perf-baselines/20260706T181609Z",
+        "--artifact-dir",
+        "{artifact_dir}"
+      ],
       "dependencies": [
         "perf.ai-agent",
         "perf.b2bua",
@@ -4872,7 +4930,7 @@
       ],
       "display_command": "python3 <workspace>/crates/sip/rvoip-sip/scripts/perf_regression_baseline.py package --manifest <workspace>/crates/sip/rvoip-sip/perf-baselines/20260706T181609Z/manifest.json --source-root <workspace>/crates/sip/rvoip-sip/perf-baselines/20260706T181609Z --artifact-dir <source-report>",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "argv",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -4936,7 +4994,7 @@
       ],
       "display_command": "python3 <workspace>/crates/sip/rvoip-sip/scripts/perf_audit.py --baseline <source-report> --baseline-manifest <source-report> --current <workspace>/target/perf-results --out <source-report> --tolerance-pct 15 --latency-tolerance-pct 25 --fail-on-regression",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -5001,7 +5059,7 @@
       ],
       "display_command": "capture_current_perf_results",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -5067,7 +5125,7 @@
       ],
       "display_command": "write_performance_gate_metrics",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -5207,7 +5265,7 @@
       ],
       "display_command": "python3 <workspace>/crates/sip/rvoip-sip/scripts/canonical_2k_evidence.py fingerprint --workspace-root <workspace> --out <source-report>",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -5243,7 +5301,7 @@
       ],
       "display_command": "python3 <workspace>/crates/sip/rvoip-sip/scripts/canonical_2k_evidence.py verify-source --workspace-root <workspace> --beta-start <source-report>",
       "estimated_seconds": 1,
-      "executor": "legacy-group",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -5397,6 +5455,317 @@
         75
       ],
       "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/webrtc/rvoip-rtc/**",
+        "crates/webrtc/rvoip-webrtc/**",
+        "crates/core/rvoip-core/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "cargo",
+        "test",
+        "--locked",
+        "-p",
+        "rvoip-webrtc",
+        "--features",
+        "interop-browser,signaling-whip,signaling-ws",
+        "--test",
+        "browser_interop",
+        "--",
+        "--include-ignored",
+        "--nocapture"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "cargo test --locked -p rvoip-webrtc --features interop-browser,signaling-whip,signaling-ws --test browser_interop -- --include-ignored --nocapture",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "interop.browser-dtmf",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "real Chromium outbound RFC 4733 interoperability (BridgeFu issue #54)",
+      "resource_class": "github-standard",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/sip/rvoip-sip/**",
+        "crates/media/**",
+        "crates/foundation/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "env",
+        "RVOIP_PERF_RESULTS={artifact_dir}",
+        "RVOIP_PERF_BURST_SCENARIOS=carrier-smoke",
+        "bash",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "env RVOIP_PERF_RESULTS={artifact_dir} RVOIP_PERF_BURST_SCENARIOS=carrier-smoke bash {workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+      "estimated_seconds": 900,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "perf.media-burst.carrier-smoke",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "media burst scenario: carrier-smoke",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 75,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/sip/rvoip-sip/**",
+        "crates/media/**",
+        "crates/foundation/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "env",
+        "RVOIP_PERF_RESULTS={artifact_dir}",
+        "RVOIP_PERF_BURST_SCENARIOS=access-edge-microburst",
+        "bash",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "env RVOIP_PERF_RESULTS={artifact_dir} RVOIP_PERF_BURST_SCENARIOS=access-edge-microburst bash {workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+      "estimated_seconds": 900,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "perf.media-burst.access-edge-microburst",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "media burst scenario: access-edge-microburst",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 75,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/sip/rvoip-sip/**",
+        "crates/media/**",
+        "crates/foundation/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "env",
+        "RVOIP_PERF_RESULTS={artifact_dir}",
+        "RVOIP_PERF_BURST_SCENARIOS=contact-center-flash",
+        "bash",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "env RVOIP_PERF_RESULTS={artifact_dir} RVOIP_PERF_BURST_SCENARIOS=contact-center-flash bash {workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+      "estimated_seconds": 900,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "perf.media-burst.contact-center-flash",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "media burst scenario: contact-center-flash",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 75,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/sip/rvoip-sip/**",
+        "crates/media/**",
+        "crates/foundation/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "env",
+        "RVOIP_PERF_RESULTS={artifact_dir}",
+        "RVOIP_PERF_BURST_SCENARIOS=shift-change-long-hold",
+        "bash",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "env RVOIP_PERF_RESULTS={artifact_dir} RVOIP_PERF_BURST_SCENARIOS=shift-change-long-hold bash {workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+      "estimated_seconds": 900,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "perf.media-burst.shift-change-long-hold",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "media burst scenario: shift-change-long-hold",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 75,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/sip/rvoip-sip/**",
+        "crates/media/**",
+        "crates/foundation/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "env",
+        "RVOIP_PERF_RESULTS={artifact_dir}",
+        "RVOIP_PERF_BURST_SCENARIOS=overload-recovery",
+        "bash",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "env RVOIP_PERF_RESULTS={artifact_dir} RVOIP_PERF_BURST_SCENARIOS=overload-recovery bash {workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+      "estimated_seconds": 900,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "perf.media-burst.overload-recovery",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "media burst scenario: overload-recovery",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 75,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/sip/rvoip-sip/**",
+        "crates/media/**",
+        "crates/foundation/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "env",
+        "RVOIP_PERF_RESULTS={artifact_dir}",
+        "RVOIP_PERF_BURST_SCENARIOS=high-density-media-burst",
+        "bash",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "env RVOIP_PERF_RESULTS={artifact_dir} RVOIP_PERF_BURST_SCENARIOS=high-density-media-burst bash {workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+      "estimated_seconds": 900,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "perf.media-burst.high-density-media-burst",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "media burst scenario: high-density-media-burst",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 75,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        "crates/sip/rvoip-sip/**",
+        "crates/media/**",
+        "crates/foundation/**"
+      ],
+      "always_fresh": false,
+      "category": "Remote release framework",
+      "command": [
+        "env",
+        "RVOIP_PERF_RESULTS={artifact_dir}",
+        "RVOIP_PERF_BURST_SCENARIOS=buffer-ab-legacy",
+        "bash",
+        "{workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+      ],
+      "dependencies": [
+        "source.remote-clean"
+      ],
+      "display_command": "env RVOIP_PERF_RESULTS={artifact_dir} RVOIP_PERF_BURST_SCENARIOS=buffer-ab-legacy bash {workspace}/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh",
+      "estimated_seconds": 900,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "perf.media-burst.buffer-ab-legacy",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "media burst scenario: buffer-ab-legacy",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 75,
       "working_directory": "."
     },
     {
@@ -7804,9 +8173,17 @@
         "core.rvoip-webrtc-stack",
         "core.rvoip-websocket",
         "core.rvoip-webtransport",
+        "interop.browser-dtmf",
         "interop.remote-libsrtp",
         "interop.remote-proxies",
         "package.inventory",
+        "perf.media-burst.access-edge-microburst",
+        "perf.media-burst.buffer-ab-legacy",
+        "perf.media-burst.carrier-smoke",
+        "perf.media-burst.contact-center-flash",
+        "perf.media-burst.high-density-media-burst",
+        "perf.media-burst.overload-recovery",
+        "perf.media-burst.shift-change-long-hold",
         "security.remote-advisories",
         "security.remote-fuzz-dtls",
         "security.remote-fuzz-g711",
@@ -7820,9 +8197,9 @@
         "security.remote-fuzz-uri",
         "source.remote-clean"
       ],
-      "display_command": "builtin report.remote-aggregate",
+      "display_command": "aggregate report.remote-aggregate",
       "estimated_seconds": 1,
-      "executor": "builtin",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -7850,9 +8227,9 @@
       "dependencies": [
         "report.remote-aggregate"
       ],
-      "display_command": "builtin source.remote-final",
+      "display_command": "aggregate source.remote-final",
       "estimated_seconds": 1,
-      "executor": "builtin",
+      "executor": "aggregate",
       "expected_outputs": [
         "receipt.json",
         "command.log"
@@ -7878,34 +8255,98 @@
   },
   "profiles": {
     "legacy-full": [
-      "source.clean-start",
-      "source.canonical-2k",
-      "build.format",
-      "build.evidence-helper-tests",
-      "build.public-api",
-      "build.sip-all-targets",
       "build.claimed-lower-crates",
-      "test.supporting-sip-crates",
-      "test.rtp-core",
-      "test.workspace-unit",
-      "test.workspace-integration",
-      "test.workspace-doctest",
-      "test.sip-unit",
-      "test.sip-integration",
-      "test.sip-doctest",
-      "build.sip-examples",
-      "build.downstream-rvoip",
-      "build.downstream-rvoip-app",
+      "build.downstream-amazon-connect",
+      "build.downstream-audio-device",
       "build.downstream-client",
       "build.downstream-client-full",
       "build.downstream-core",
-      "build.downstream-amazon-connect",
-      "build.downstream-uctp",
       "build.downstream-quic",
-      "build.downstream-webtransport",
-      "build.downstream-websocket",
+      "build.downstream-rvoip",
+      "build.downstream-rvoip-app",
+      "build.downstream-uctp",
       "build.downstream-webrtc",
-      "build.downstream-audio-device",
+      "build.downstream-websocket",
+      "build.downstream-webtransport",
+      "build.evidence-helper-tests",
+      "build.format",
+      "build.public-api",
+      "build.rustdoc",
+      "build.sip-all-targets",
+      "build.sip-examples",
+      "interop.asterisk-down-after",
+      "interop.asterisk-down-before-freeswitch",
+      "interop.asterisk-matrix",
+      "interop.asterisk-up",
+      "interop.freeswitch-down-after",
+      "interop.freeswitch-down-before-asterisk",
+      "interop.freeswitch-matrix",
+      "interop.freeswitch-up",
+      "interop.proxy-descope",
+      "interop.remote-proxies",
+      "interop.restore-asterisk-down",
+      "interop.restore-freeswitch-down",
+      "interop.sipp-build",
+      "interop.sipp-matrix",
+      "interop.sipp-start",
+      "interop.sipp-stop",
+      "interop.strict-ua",
+      "perf.ai-agent",
+      "perf.b2bua",
+      "perf.backpressure",
+      "perf.call-setup-endpoint",
+      "perf.call-setup-pbx",
+      "perf.call-setup-signaling",
+      "perf.capture-boundary",
+      "perf.concurrent-calls",
+      "perf.contact-center",
+      "perf.literal-all-config",
+      "perf.long-duration",
+      "perf.mass-teardown",
+      "perf.media-burst-matrix",
+      "perf.media-burst.access-edge-microburst",
+      "perf.media-burst.buffer-ab-legacy",
+      "perf.media-burst.carrier-smoke",
+      "perf.media-burst.contact-center-flash",
+      "perf.media-burst.high-density-media-burst",
+      "perf.media-burst.overload-recovery",
+      "perf.media-burst.shift-change-long-hold",
+      "perf.media-churn",
+      "perf.mid-call-signaling",
+      "perf.mixed-workload",
+      "perf.monolithic-soak",
+      "perf.pdd-180",
+      "perf.registrar-scale",
+      "perf.registration",
+      "perf.resiliency-all",
+      "perf.rtp-steady-state",
+      "perf.session-churn",
+      "perf.sipp-parity",
+      "perf.soak-candidate",
+      "perf.soak-invariants",
+      "perf.srtp-overhead",
+      "perf.tls-overhead",
+      "perf.transport-recovery",
+      "report.perf-evidence-capture",
+      "report.performance-metrics",
+      "report.regression-audit",
+      "report.regression-baseline",
+      "security.advisory-audit",
+      "security.fuzz-dtls",
+      "security.fuzz-g711",
+      "security.fuzz-header",
+      "security.fuzz-rtcp",
+      "security.fuzz-rtp",
+      "security.fuzz-sdp",
+      "security.fuzz-sip-message",
+      "security.fuzz-srtp",
+      "security.fuzz-stun",
+      "security.fuzz-uri",
+      "source.canonical-2k",
+      "source.canonical-2k-unchanged",
+      "source.clean-start",
+      "source.final-capture",
+      "source.remote-clean",
       "test.example-01",
       "test.example-02",
       "test.example-03",
@@ -7919,73 +8360,18 @@
       "test.example-11",
       "test.example-12",
       "test.example-13",
-      "test.pbx-analyzer",
-      "build.rustdoc",
-      "test.rfc4475",
-      "test.generated-message",
       "test.generated-dialog",
-      "security.advisory-audit",
-      "security.fuzz-sip-message",
-      "security.fuzz-uri",
-      "security.fuzz-header",
-      "security.fuzz-sdp",
-      "security.fuzz-rtp",
-      "security.fuzz-rtcp",
-      "security.fuzz-srtp",
-      "security.fuzz-dtls",
-      "security.fuzz-stun",
-      "security.fuzz-g711",
-      "interop.freeswitch-down-before-asterisk",
-      "interop.asterisk-up",
-      "interop.asterisk-matrix",
-      "interop.asterisk-down-after",
-      "interop.asterisk-down-before-freeswitch",
-      "interop.freeswitch-up",
-      "interop.freeswitch-matrix",
-      "interop.freeswitch-down-after",
-      "interop.restore-asterisk-down",
-      "interop.restore-freeswitch-down",
-      "interop.sipp-build",
-      "interop.sipp-start",
-      "interop.sipp-matrix",
-      "interop.sipp-stop",
-      "interop.strict-ua",
-      "interop.proxy-descope",
-      "perf.capture-boundary",
-      "perf.literal-all-config",
-      "perf.call-setup-endpoint",
-      "perf.call-setup-pbx",
-      "perf.call-setup-signaling",
-      "perf.registration",
-      "perf.concurrent-calls",
-      "perf.rtp-steady-state",
-      "perf.backpressure",
-      "perf.transport-recovery",
-      "perf.resiliency-all",
-      "perf.mid-call-signaling",
-      "perf.tls-overhead",
-      "perf.srtp-overhead",
-      "perf.pdd-180",
-      "perf.long-duration",
-      "perf.registrar-scale",
-      "perf.mixed-workload",
-      "perf.b2bua",
-      "perf.ai-agent",
-      "perf.contact-center",
-      "perf.sipp-parity",
-      "perf.soak-invariants",
-      "perf.media-churn",
-      "perf.monolithic-soak",
-      "perf.mass-teardown",
-      "perf.session-churn",
-      "perf.media-burst-matrix",
-      "perf.soak-candidate",
-      "report.regression-baseline",
-      "report.regression-audit",
-      "report.perf-evidence-capture",
-      "report.performance-metrics",
-      "source.final-capture",
-      "source.canonical-2k-unchanged"
+      "test.generated-message",
+      "test.pbx-analyzer",
+      "test.rfc4475",
+      "test.rtp-core",
+      "test.sip-doctest",
+      "test.sip-integration",
+      "test.sip-unit",
+      "test.supporting-sip-crates",
+      "test.workspace-doctest",
+      "test.workspace-integration",
+      "test.workspace-unit"
     ],
     "remote-core": [
       "build.claimed-lower-crates",
@@ -8052,7 +8438,6 @@
       "core.rvoip-websocket",
       "core.rvoip-webtransport",
       "package.inventory",
-      "report.remote-aggregate",
       "security.advisory-audit",
       "security.fuzz-dtls",
       "security.fuzz-g711",
@@ -8067,7 +8452,6 @@
       "security.remote-advisories",
       "source.clean-start",
       "source.remote-clean",
-      "source.remote-final",
       "test.example-01",
       "test.example-02",
       "test.example-03",
@@ -8158,12 +8542,24 @@
       "core.rvoip-webrtc-stack",
       "core.rvoip-websocket",
       "core.rvoip-webtransport",
+      "interop.asterisk-down-after",
+      "interop.asterisk-down-before-freeswitch",
       "interop.asterisk-matrix",
+      "interop.asterisk-up",
+      "interop.browser-dtmf",
+      "interop.freeswitch-down-after",
+      "interop.freeswitch-down-before-asterisk",
       "interop.freeswitch-matrix",
+      "interop.freeswitch-up",
+      "interop.proxy-descope",
       "interop.remote-libsrtp",
       "interop.remote-proxies",
+      "interop.restore-asterisk-down",
+      "interop.restore-freeswitch-down",
       "interop.sipp-build",
       "interop.sipp-matrix",
+      "interop.sipp-start",
+      "interop.sipp-stop",
       "interop.strict-ua",
       "package.inventory",
       "perf.ai-agent",
@@ -8172,11 +8568,20 @@
       "perf.call-setup-endpoint",
       "perf.call-setup-pbx",
       "perf.call-setup-signaling",
+      "perf.capture-boundary",
       "perf.concurrent-calls",
       "perf.contact-center",
+      "perf.literal-all-config",
       "perf.long-duration",
       "perf.mass-teardown",
       "perf.media-burst-matrix",
+      "perf.media-burst.access-edge-microburst",
+      "perf.media-burst.buffer-ab-legacy",
+      "perf.media-burst.carrier-smoke",
+      "perf.media-burst.contact-center-flash",
+      "perf.media-burst.high-density-media-burst",
+      "perf.media-burst.overload-recovery",
+      "perf.media-burst.shift-change-long-hold",
       "perf.media-churn",
       "perf.mid-call-signaling",
       "perf.mixed-workload",
@@ -8193,6 +8598,10 @@
       "perf.srtp-overhead",
       "perf.tls-overhead",
       "perf.transport-recovery",
+      "report.perf-evidence-capture",
+      "report.performance-metrics",
+      "report.regression-audit",
+      "report.regression-baseline",
       "report.remote-aggregate",
       "security.advisory-audit",
       "security.fuzz-dtls",
@@ -8216,7 +8625,10 @@
       "security.remote-fuzz-srtp",
       "security.remote-fuzz-stun",
       "security.remote-fuzz-uri",
+      "source.canonical-2k",
+      "source.canonical-2k-unchanged",
       "source.clean-start",
+      "source.final-capture",
       "source.remote-clean",
       "source.remote-final",
       "test.example-01",
@@ -8247,30 +8659,9 @@
     ]
   },
   "remote_release_legacy_coverage": {
-    "profile_legacy_count": 88,
+    "profile_legacy_count": 108,
     "required_legacy_count": 108,
-    "unautomated_legacy_ids": [
-      "interop.asterisk-down-after",
-      "interop.asterisk-down-before-freeswitch",
-      "interop.asterisk-up",
-      "interop.freeswitch-down-after",
-      "interop.freeswitch-down-before-asterisk",
-      "interop.freeswitch-up",
-      "interop.proxy-descope",
-      "interop.restore-asterisk-down",
-      "interop.restore-freeswitch-down",
-      "interop.sipp-start",
-      "interop.sipp-stop",
-      "perf.capture-boundary",
-      "perf.literal-all-config",
-      "report.perf-evidence-capture",
-      "report.performance-metrics",
-      "report.regression-audit",
-      "report.regression-baseline",
-      "source.canonical-2k",
-      "source.canonical-2k-unchanged",
-      "source.final-capture"
-    ]
+    "unautomated_legacy_ids": []
   },
   "schema": "rvoip-release-gate-catalog-v1",
   "workspace_package_count": 44

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -110,7 +111,7 @@ def validate_catalog(root: Path, catalog: dict[str, Any]) -> None:
         raise GateError(f"duplicate gate ids: {duplicates}")
     by_id = gate_map(catalog)
     for gate in gates:
-        if gate.get("executor") not in {"argv", "builtin", "legacy-group"}:
+        if gate.get("executor") not in {"argv", "builtin", "legacy-group", "aggregate"}:
             raise GateError(f"gate {gate['id']} has unsupported executor")
         if gate["executor"] == "argv" and not isinstance(gate.get("command"), list):
             raise GateError(f"gate {gate['id']} lacks argv command")
@@ -125,6 +126,16 @@ def validate_catalog(root: Path, catalog: dict[str, Any]) -> None:
         missing = sorted(set(selected) - set(by_id))
         if missing:
             raise GateError(f"profile {profile} references unknown gates: {missing}")
+        selected_ids = set(selected)
+        dependency_gaps = {
+            gate_id: sorted(set(by_id[gate_id].get("dependencies", [])) - selected_ids)
+            for gate_id in selected
+            if set(by_id[gate_id].get("dependencies", [])) - selected_ids
+        }
+        if dependency_gaps:
+            raise GateError(
+                f"profile {profile} omits gate dependencies: {dependency_gaps}"
+            )
     coverage = catalog.get("remote_release_legacy_coverage")
     if not isinstance(coverage, dict):
         raise GateError("catalog must declare remote-release legacy coverage")
@@ -404,7 +415,11 @@ def balance_gates(gates: list[dict[str, Any]], count: int) -> list[list[dict[str
 
 
 def matrix_for(plan_gates: list[dict[str, Any]], by_id: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
-    runnable = [by_id[item["id"]] for item in plan_gates if item["decision"] == "RUN"]
+    runnable = [
+        by_id[item["id"]]
+        for item in plan_gates
+        if item["decision"] == "RUN" and by_id[item["id"]]["executor"] != "aggregate"
+    ]
     groups: dict[str, list[dict[str, Any]]] = collections.defaultdict(list)
     for gate in runnable:
         groups[gate["resource_class"]].append(gate)
@@ -413,8 +428,8 @@ def matrix_for(plan_gates: list[dict[str, Any]], by_id: dict[str, dict[str, Any]
         "github-standard": 6,
         "github-nightly": 5,
         "github-evidence": 1,
-        "gcp-performance": 8,
-        "gcp-performance-soak": 4,
+        "gcp-performance": 7,
+        "gcp-performance-soak": 9,
         # Interoperability gates share one stateful peer lab. Keep their
         # lifecycle dependency chain in one shard so start/matrix/stop/restore
         # operations cannot race across ephemeral jobs.
@@ -435,6 +450,13 @@ def matrix_for(plan_gates: list[dict[str, Any]], by_id: dict[str, dict[str, Any]
                     "resource_class": resource,
                     "runs_on": runs_on,
                     "hosted": not resource.startswith("gcp-"),
+                    "machine_type": (
+                        "n2-standard-4"
+                        if resource in {"gcp-interop", "gcp-performance-soak"}
+                        else "n2-standard-8"
+                    ),
+                    "disk_type": "pd-standard",
+                    "disk_size_gb": 200,
                     "gates": gate_ids,
                     "gates_csv": ",".join(gate_ids),
                     "needs_nightly": any(
@@ -444,6 +466,9 @@ def matrix_for(plan_gates: list[dict[str, Any]], by_id: dict[str, dict[str, Any]
                     "needs_cargo_deny": any(
                         gate["id"] in {"security.remote-advisories", "security.advisory-audit"}
                         for gate in shard
+                    ),
+                    "needs_chromium": any(
+                        gate["id"] == "interop.browser-dtmf" for gate in shard
                     ),
                     "estimated_seconds": sum(int(gate.get("estimated_seconds", 1)) for gate in shard),
                 }
@@ -516,6 +541,8 @@ def create_plan(
                 "id": gate_id,
                 "decision": "RUN",
                 "reason": reason,
+                "executor": gate["executor"],
+                "dependencies": gate.get("dependencies", []),
                 **{key: inputs[gate_id][key] for key in ("gate_definition_sha256", "environment_sha256", "input_sha256")},
             }
         else:
@@ -523,6 +550,8 @@ def create_plan(
                 "id": gate_id,
                 "decision": "REUSE",
                 "reason": "exact definition, input, and environment digest match",
+                "executor": gate["executor"],
+                "dependencies": gate.get("dependencies", []),
                 **{key: inputs[gate_id][key] for key in ("gate_definition_sha256", "environment_sha256", "input_sha256")},
                 "reuse_receipt": {key: value for key, value in reuse.items() if not key.startswith("_")},
                 "reuse_receipt_sha256": reuse["_sha256"],
@@ -549,9 +578,15 @@ def create_plan(
 
 
 def write_github_output(path: Path, plan: dict[str, Any]) -> None:
+    hosted = [item for item in plan["matrix"] if item["hosted"]]
+    gcp = [item for item in plan["matrix"] if not item["hosted"]]
     values = {
         "matrix": json.dumps({"include": plan["matrix"]}, separators=(",", ":")),
+        "hosted_matrix": json.dumps({"include": hosted}, separators=(",", ":")),
+        "gcp_matrix": json.dumps({"include": gcp}, separators=(",", ":")),
         "shard_count": str(len(plan["matrix"])),
+        "hosted_shard_count": str(len(hosted)),
+        "gcp_shard_count": str(len(gcp)),
         "run_count": str(sum(item["decision"] == "RUN" for item in plan["gates"])),
         "reuse_count": str(sum(item["decision"] == "REUSE" for item in plan["gates"])),
         "candidate_sha": plan["candidate_sha"],
@@ -667,6 +702,10 @@ def execute_gate(
     final_code = 1
     for attempt in range(1, max_attempts + 1):
         attempt_start = time.monotonic()
+        if gate["executor"] == "aggregate":
+            raise GateError(
+                f"aggregate gate {gate['id']} must run during evidence collection"
+            )
         if gate["executor"] == "builtin":
             final_code, output = clean_source(root)
             with log_path.open("a") as handle:
@@ -790,19 +829,88 @@ def validate_log(evidence_root: Path, receipt: dict[str, Any]) -> bool:
     return False
 
 
+def reconcile_performance_regression(root: Path, evidence_root: Path, artifact: Path) -> dict[str, Any]:
+    manifests = sorted(evidence_root.rglob("perf-regression-baseline/manifest.json"))
+    if len(manifests) != 1:
+        raise GateError(
+            "performance regression reconciliation requires exactly one packaged baseline manifest"
+        )
+    manifest = manifests[0]
+    baseline = manifest.parent / "perf-results"
+    payload = load_json(manifest, "packaged performance baseline")
+    comparison_paths = payload.get("comparison_paths")
+    if not isinstance(comparison_paths, list) or not comparison_paths:
+        raise GateError("packaged performance baseline has no comparison paths")
+    current = artifact / "current-performance"
+    current.mkdir(parents=True, exist_ok=True)
+    selected = {}
+    for value in comparison_paths:
+        if not isinstance(value, str) or Path(value).is_absolute() or ".." in Path(value).parts:
+            raise GateError(f"unsafe performance comparison path: {value!r}")
+        matches = sorted(
+            path
+            for path in (evidence_root / "_perf-results").rglob(Path(value).name)
+            if path.as_posix().endswith("/" + value)
+        )
+        if len(matches) != 1:
+            raise GateError(
+                f"performance comparison path {value} has {len(matches)} exact-candidate results"
+            )
+        destination = current / value
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(matches[0], destination)
+        selected[value] = file_sha256(destination)
+    report = artifact / "perf-audit.md"
+    completed = run(
+        [
+            "python3",
+            "crates/sip/rvoip-sip/scripts/perf_audit.py",
+            "--baseline",
+            str(baseline),
+            "--baseline-manifest",
+            str(manifest),
+            "--current",
+            str(current),
+            "--out",
+            str(report),
+            "--tolerance-pct",
+            "15",
+            "--latency-tolerance-pct",
+            "25",
+            "--fail-on-regression",
+        ],
+        root=root,
+        check=False,
+    )
+    if completed.returncode:
+        raise GateError(
+            "performance regression audit failed:\n"
+            + ((completed.stdout or "") + (completed.stderr or "")).strip()
+        )
+    return {
+        "baseline_manifest_sha256": file_sha256(manifest),
+        "selected_results": selected,
+        "report_sha256": file_sha256(report),
+    }
+
+
 def collect(
     *,
     plan: dict[str, Any],
     evidence_root: Path,
     output: Path,
+    root: Path | None = None,
 ) -> int:
     if plan.get("schema") != PLAN_SCHEMA:
         raise GateError("unsupported or missing release gate plan")
     receipts = receipt_index(evidence_root)
     failures = []
     accepted = []
+    accepted_ids: set[str] = set()
     for item in plan["gates"]:
         gate_id = item["id"]
+        if item.get("executor") == "aggregate" and item["decision"] == "RUN":
+            continue
         if item["decision"] == "REUSE":
             receipt = item.get("reuse_receipt", {})
             if sha256_bytes(canonical_bytes(receipt)) != item.get("reuse_receipt_sha256"):
@@ -847,6 +955,90 @@ def collect(
                 "input_sha256": item["input_sha256"],
             }
         )
+        accepted_ids.add(gate_id)
+
+    plan_by_id = {item["id"]: item for item in plan["gates"]}
+    aggregate_ids = [
+        item["id"]
+        for item in plan["gates"]
+        if item.get("executor") == "aggregate" and item["decision"] == "RUN"
+    ]
+    aggregate_definitions = {
+        gate_id: {"dependencies": plan_by_id[gate_id].get("dependencies", [])}
+        for gate_id in aggregate_ids
+    }
+    for gate_id in dependency_order(aggregate_ids, aggregate_definitions):
+        item = plan_by_id[gate_id]
+        missing = sorted(
+            dependency
+            for dependency in item.get("dependencies", [])
+            if dependency not in accepted_ids
+        )
+        if missing:
+            failures.append(
+                f"{gate_id}: cannot aggregate until dependencies pass: {', '.join(missing)}"
+            )
+            continue
+        if root is not None and git(root, "rev-parse", "HEAD") != plan["candidate_sha"]:
+            failures.append(f"{gate_id}: collector checkout does not match candidate")
+            continue
+        artifact = evidence_root / f"collect-{re.sub(r'[^A-Za-z0-9_.-]', '-', gate_id)}"
+        artifact.mkdir(parents=True, exist_ok=True)
+        log = artifact / "command.log"
+        specialized = None
+        if gate_id == "report.regression-audit":
+            if root is None:
+                failures.append(f"{gate_id}: collector workspace is unavailable")
+                continue
+            try:
+                specialized = reconcile_performance_regression(root, evidence_root, artifact)
+            except GateError as error:
+                failures.append(f"{gate_id}: {error}")
+                continue
+        reconciliation = {
+            "gate_id": gate_id,
+            "candidate_sha": plan["candidate_sha"],
+            "dependencies": item.get("dependencies", []),
+            "accepted_dependency_receipts": sorted(
+                row["receipt_sha256"]
+                for row in accepted
+                if row["gate_id"] in set(item.get("dependencies", []))
+            ),
+            "source_tree": git(root, "rev-parse", "HEAD^{tree}") if root is not None else None,
+            "specialized_evidence": specialized,
+        }
+        log.write_bytes(canonical_bytes(reconciliation))
+        receipt = {
+            "schema": RECEIPT_SCHEMA,
+            "gate_id": gate_id,
+            "candidate_sha": plan["candidate_sha"],
+            "status": "PASS",
+            "gate_definition_sha256": item["gate_definition_sha256"],
+            "input_sha256": item["input_sha256"],
+            "environment_id": plan["environment_id"],
+            "environment_sha256": item["environment_sha256"],
+            "started_at": utc_now(),
+            "ended_at": utc_now(),
+            "duration_seconds": 0,
+            "attempts": [{"attempt": 1, "argv": ["aggregate", gate_id], "exit_code": 0, "duration_seconds": 0}],
+            "log": {
+                "path": log.relative_to(evidence_root).as_posix(),
+                "sha256": file_sha256(log),
+                "bytes": log.stat().st_size,
+            },
+        }
+        receipt_path = artifact / "receipt.json"
+        receipt_path.write_bytes(canonical_bytes(receipt))
+        accepted.append(
+            {
+                "gate_id": gate_id,
+                "source": "fresh",
+                "receipt_candidate_sha": plan["candidate_sha"],
+                "receipt_sha256": file_sha256(receipt_path),
+                "input_sha256": item["input_sha256"],
+            }
+        )
+        accepted_ids.add(gate_id)
     aggregate = {
         "schema": AGGREGATE_SCHEMA,
         "generated_at": utc_now(),
@@ -952,7 +1144,7 @@ def main(argv: list[str] | None = None) -> int:
         plan = load_json(args.plan if args.plan.is_absolute() else root / args.plan, "gate plan")
         evidence = args.evidence if args.evidence.is_absolute() else root / args.evidence
         output = args.output if args.output.is_absolute() else root / args.output
-        return collect(plan=plan, evidence_root=evidence, output=output)
+        return collect(plan=plan, evidence_root=evidence, output=output, root=root)
     except (GateError, OSError, ValueError, subprocess.SubprocessError) as error:
         print(f"release gates: FAIL: {error}", file=sys.stderr)
         return 2

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+import shutil
 import sys
 import tempfile
 import unittest
@@ -53,6 +54,19 @@ class GateFrameworkTests(unittest.TestCase):
         )
         self.assertEqual(generated, self.catalog)
 
+    def test_every_profile_is_dependency_closed(self) -> None:
+        by_id = {gate["id"]: gate for gate in self.catalog["gates"]}
+        for profile, selected in self.catalog["profiles"].items():
+            selected_ids = set(selected)
+            with self.subTest(profile=profile):
+                self.assertFalse(
+                    {
+                        gate_id: set(by_id[gate_id]["dependencies"]) - selected_ids
+                        for gate_id in selected
+                        if set(by_id[gate_id]["dependencies"]) - selected_ids
+                    }
+                )
+
     def test_fuzz_gates_select_their_fuzz_crate_explicitly(self) -> None:
         fuzz_gates = [
             gate
@@ -98,8 +112,45 @@ class GateFrameworkTests(unittest.TestCase):
         soak_shards = [
             shard for shard in matrix if shard["resource_class"] == "gcp-performance-soak"
         ]
-        self.assertEqual(len(soak_shards), 3)
+        self.assertEqual(len(soak_shards), 2)
         self.assertTrue(all(len(shard["gates"]) == 1 for shard in soak_shards))
+        self.assertNotIn(
+            "perf.media-burst-matrix",
+            {gate for shard in soak_shards for gate in shard["gates"]},
+        )
+
+    def test_media_burst_scenarios_run_on_independent_workers(self) -> None:
+        scenario_ids = {
+            gate["id"]
+            for gate in self.catalog["gates"]
+            if gate["id"].startswith("perf.media-burst.")
+        }
+        self.assertEqual(len(scenario_ids), 7)
+        by_id = {gate["id"]: gate for gate in self.catalog["gates"]}
+        matrix = gates.matrix_for(
+            [{"id": gate_id, "decision": "RUN"} for gate_id in scenario_ids],
+            by_id,
+        )
+        self.assertEqual(len(matrix), 7)
+        self.assertTrue(all(len(shard["gates"]) == 1 for shard in matrix))
+        self.assertTrue(all(shard["machine_type"] == "n2-standard-4" for shard in matrix))
+        aggregate = by_id["perf.media-burst-matrix"]
+        self.assertEqual(aggregate["executor"], "aggregate")
+        self.assertEqual(set(aggregate["dependencies"]), scenario_ids)
+
+    def test_remote_release_requires_bridgefu_chromium_dtmf_regression(self) -> None:
+        gate_id = "interop.browser-dtmf"
+        self.assertIn(gate_id, self.catalog["profiles"]["remote-release"])
+        gate = next(gate for gate in self.catalog["gates"] if gate["id"] == gate_id)
+        self.assertIn("browser_interop", gate["command"])
+        self.assertIn("--include-ignored", gate["command"])
+        matrix = gates.matrix_for(
+            [{"id": gate_id, "decision": "RUN"}],
+            {item["id"]: item for item in self.catalog["gates"]},
+        )
+        self.assertEqual(len(matrix), 1)
+        self.assertTrue(matrix[0]["hosted"])
+        self.assertTrue(matrix[0]["needs_chromium"])
 
     def test_definition_digest_is_key_order_independent(self) -> None:
         first = {"id": "a", "command": ["true"]}
@@ -231,6 +282,118 @@ class GateFrameworkTests(unittest.TestCase):
             )
             self.assertEqual(status, 124)
             self.assertIn("exceeded catalogued timeout", log.read_text())
+
+    def test_github_outputs_split_hosted_and_ephemeral_gcp_matrices(self) -> None:
+        plan = {
+            "matrix": [
+                {"id": "hosted", "hosted": True},
+                {"id": "gcp", "hosted": False},
+            ],
+            "gates": [{"decision": "RUN"}, {"decision": "REUSE"}],
+            "candidate_sha": "c" * 40,
+            "environment_id": "test",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "github-output"
+            gates.write_github_output(output, plan)
+            values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+        self.assertEqual(json.loads(values["hosted_matrix"])["include"], [plan["matrix"][0]])
+        self.assertEqual(json.loads(values["gcp_matrix"])["include"], [plan["matrix"][1]])
+        self.assertEqual(values["hosted_shard_count"], "1")
+        self.assertEqual(values["gcp_shard_count"], "1")
+
+    def test_collector_materializes_aggregate_only_after_dependencies_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dependency_dir = root / "dependency"
+            dependency_dir.mkdir()
+            log = dependency_dir / "command.log"
+            log.write_text("pass\n")
+            dependency = {
+                "schema": gates.RECEIPT_SCHEMA,
+                "gate_id": "gate.dependency",
+                "candidate_sha": "c" * 40,
+                "status": "PASS",
+                "gate_definition_sha256": "d" * 64,
+                "input_sha256": "i" * 64,
+                "environment_sha256": "e" * 64,
+                "log": {
+                    "path": "dependency/command.log",
+                    "sha256": gates.file_sha256(log),
+                    "bytes": log.stat().st_size,
+                },
+            }
+            (dependency_dir / "receipt.json").write_bytes(
+                gates.canonical_bytes(dependency)
+            )
+            plan = {
+                "schema": gates.PLAN_SCHEMA,
+                "candidate_sha": "c" * 40,
+                "profile": "test",
+                "catalog_sha256": "x" * 64,
+                "environment_id": "test",
+                "gates": [
+                    {
+                        "id": "gate.dependency",
+                        "decision": "RUN",
+                        "executor": "argv",
+                        "dependencies": [],
+                        "gate_definition_sha256": "d" * 64,
+                        "input_sha256": "i" * 64,
+                        "environment_sha256": "e" * 64,
+                    },
+                    {
+                        "id": "gate.aggregate",
+                        "decision": "RUN",
+                        "executor": "aggregate",
+                        "dependencies": ["gate.dependency"],
+                        "gate_definition_sha256": "a" * 64,
+                        "input_sha256": "b" * 64,
+                        "environment_sha256": "e" * 64,
+                    },
+                ],
+            }
+            output = root / "aggregate.json"
+            self.assertEqual(
+                gates.collect(plan=plan, evidence_root=root, output=output), 0
+            )
+            result = json.loads(output.read_text())
+            self.assertEqual(result["status"], "PASS")
+            self.assertEqual(result["gate_count"], 2)
+            self.assertTrue((root / "collect-gate.aggregate/receipt.json").is_file())
+
+            (dependency_dir / "receipt.json").unlink()
+            self.assertEqual(
+                gates.collect(plan=plan, evidence_root=root, output=output), 1
+            )
+
+    def test_performance_reconciliation_runs_real_baseline_audit(self) -> None:
+        baseline_root = (
+            ROOT / "crates/sip/rvoip-sip/perf-baselines/20260706T181609Z"
+        )
+        manifest = json.loads((baseline_root / "manifest.json").read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory) / "evidence"
+            packaged = evidence / "baseline-gate/perf-regression-baseline"
+            packaged.mkdir(parents=True)
+            shutil.copy2(baseline_root / "manifest.json", packaged / "manifest.json")
+            for relative in manifest["comparison_paths"]:
+                source = baseline_root / relative
+                baseline_target = packaged / "perf-results" / relative
+                current_target = evidence / "_perf-results/shard" / relative
+                baseline_target.parent.mkdir(parents=True, exist_ok=True)
+                current_target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, baseline_target)
+                shutil.copy2(source, current_target)
+            artifact = evidence / "collect-report.regression-audit"
+            artifact.mkdir()
+            result = gates.reconcile_performance_regression(
+                ROOT, evidence, artifact
+            )
+            self.assertTrue((artifact / "perf-audit.md").is_file())
+            self.assertEqual(
+                set(result["selected_results"]), set(manifest["comparison_paths"])
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- run GitHub-hosted and specialty GCP release shards in parallel without persistent self-hosted runners
- cover all 108 historical release gates with dependency-closed, fail-closed planning
- split the seven media-burst scenarios onto independent ephemeral workers
- preserve the two intentional one-hour soak tests as isolated workers
- carry raw performance JSON into the final exact-candidate regression audit
- provision real PBX and SIPp lifecycle dependencies on the isolated interop worker
- require the real-Chromium RFC 4733 regression that protects BridgeFu from rvoip issue #54
- verify quota before provisioning, verify non-publishing evidence, delete each worker, and sweep interrupted workers

## Why

The prior workflow required permanently registered self-hosted labels and could not run the complete remote-release profile because 20 historical gates had no structured replacement. The monolithic media-burst job also created a roughly 93-minute serial bottleneck.

This change makes the full non-publishing release qualification runnable from GitHub. A fresh run plans 17 short-lived GCP workers (96 N2 vCPUs) plus hosted GitHub shards. The fixed one-hour soak duration remains the expected critical path.

## Validation

- all 108 legacy mappings and all 44 workspace crate gates validate
- every profile is dependency-closed
- remote-release coverage ledger has zero missing gates
- 83 Python policy/release tests pass
- release catalog regenerates byte-for-byte
- shell scripts pass syntax checks
- workflow YAML parses successfully
- planned remote-release matrix stays within configured GCP quota (17 workers, 96 N2 vCPUs, 3.4 TB transient standard disk)

No crates are published by this workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CI/infra change touching release gating, GCP provisioning, and evidence reconciliation; mistakes could block releases or leak workers, but the workflow stays non-publishing with quota preflight and explicit cleanup.
> 
> **Overview**
> **Release qualification** no longer depends on pre-provisioned self-hosted GCP runners or a single mixed `gate` job. Planning now emits separate **hosted** and **GCP** matrices; GitHub shards run on `ubuntu-latest` (including optional Chromium for `interop.browser-dtmf`), while specialty work is driven by controller jobs that **preflight quota**, **create ephemeral VMs** via `gcp-release-startup.sh`, wait for **GCS evidence** with hash verification, delete workers, and **sweep** stragglers on failure.
> 
> The gate catalog and `gates.py` close **remote-release** to all **108** legacy gates: PBX/SIPp lifecycle steps call `interop-lifecycle.sh`; seven **perf.media-burst.*** scenarios run on independent soak workers with `perf.media-burst-matrix` as an **aggregate**; reporting/source gates that reconcile shard evidence use **aggregate** execution in **collect** (including a real `report.regression-audit` perf baseline audit). Profiles are validated as **dependency-closed**; `unautomated_legacy_ids` is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b0e8b81ed2984192f9f076cefacd92a966ba3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->