### PR TITLE
Fix remote fuzz gate arguments

### DIFF
--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -428,6 +428,7 @@ def security_gates() -> list[dict[str, Any]]:
         "g711": ("crates/media/fuzz/Cargo.toml", "g711_unpack"),
     }
     for suffix, (manifest, target) in targets.items():
+        fuzz_dir = manifest.rsplit("/", 1)[0]
         result.append(
             synthetic_gate(
                 f"security.remote-fuzz-{suffix}",
@@ -439,15 +440,17 @@ def security_gates() -> list[dict[str, Any]]:
                     "fuzz",
                     "run",
                     target,
-                    "--manifest-path",
-                    f"{{workspace}}/{manifest}",
+                    "--fuzz-dir",
+                    f"{{workspace}}/{fuzz_dir}",
+                    "--target",
+                    "x86_64-unknown-linux-gnu",
                     "--",
                     "-runs=1000",
                     "-max_total_time=10",
                 ],
                 resource="github-nightly",
                 dependencies=["source.remote-clean"],
-                paths=[manifest, manifest.rsplit("/", 1)[0] + "/**"],
+                paths=[manifest, fuzz_dir + "/**"],
             )
         )
     return result

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -7714,8 +7714,10 @@
         "fuzz",
         "run",
         "sip_message",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -7723,7 +7725,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run sip_message --manifest-path {workspace}/crates/sip/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run sip_message --fuzz-dir {workspace}/crates/sip/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -7756,8 +7758,10 @@
         "fuzz",
         "run",
         "uri",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -7765,7 +7769,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run uri --manifest-path {workspace}/crates/sip/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run uri --fuzz-dir {workspace}/crates/sip/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -7798,8 +7802,10 @@
         "fuzz",
         "run",
         "header",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -7807,7 +7813,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run header --manifest-path {workspace}/crates/sip/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run header --fuzz-dir {workspace}/crates/sip/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -7840,8 +7846,10 @@
         "fuzz",
         "run",
         "sdp",
-        "--manifest-path",
-        "{workspace}/crates/sip/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/sip/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -7849,7 +7857,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run sdp --manifest-path {workspace}/crates/sip/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run sdp --fuzz-dir {workspace}/crates/sip/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -7882,8 +7890,10 @@
         "fuzz",
         "run",
         "rtp_packet",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -7891,7 +7901,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run rtp_packet --manifest-path {workspace}/crates/media/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run rtp_packet --fuzz-dir {workspace}/crates/media/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -7924,8 +7934,10 @@
         "fuzz",
         "run",
         "rtcp_packet",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -7933,7 +7945,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run rtcp_packet --manifest-path {workspace}/crates/media/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run rtcp_packet --fuzz-dir {workspace}/crates/media/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -7966,8 +7978,10 @@
         "fuzz",
         "run",
         "srtp_unprotect",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -7975,7 +7989,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run srtp_unprotect --manifest-path {workspace}/crates/media/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run srtp_unprotect --fuzz-dir {workspace}/crates/media/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -8008,8 +8022,10 @@
         "fuzz",
         "run",
         "dtls_record",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -8017,7 +8033,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run dtls_record --manifest-path {workspace}/crates/media/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run dtls_record --fuzz-dir {workspace}/crates/media/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -8050,8 +8066,10 @@
         "fuzz",
         "run",
         "stun_response",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -8059,7 +8077,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run stun_response --manifest-path {workspace}/crates/media/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run stun_response --fuzz-dir {workspace}/crates/media/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [
@@ -8092,8 +8110,10 @@
         "fuzz",
         "run",
         "g711_unpack",
-        "--manifest-path",
-        "{workspace}/crates/media/fuzz/Cargo.toml",
+        "--fuzz-dir",
+        "{workspace}/crates/media/fuzz",
+        "--target",
+        "x86_64-unknown-linux-gnu",
         "--",
         "-runs=1000",
         "-max_total_time=10"
@@ -8101,7 +8121,7 @@
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "cargo +nightly fuzz run g711_unpack --manifest-path {workspace}/crates/media/fuzz/Cargo.toml -- -runs=1000 -max_total_time=10",
+      "display_command": "cargo +nightly fuzz run g711_unpack --fuzz-dir {workspace}/crates/media/fuzz --target x86_64-unknown-linux-gnu -- -runs=1000 -max_total_time=10",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -91,6 +91,22 @@ class GateFrameworkTests(unittest.TestCase):
                     "x86_64-unknown-linux-gnu",
                 )
 
+        remote_fuzz_gates = [
+            gate
+            for gate in self.catalog["gates"]
+            if gate["id"].startswith("security.remote-fuzz-")
+        ]
+        self.assertEqual(len(remote_fuzz_gates), 10)
+        for gate in remote_fuzz_gates:
+            with self.subTest(gate=gate["id"]):
+                self.assertNotIn("--manifest-path", gate["command"])
+                self.assertIn("--fuzz-dir", gate["command"])
+                target_index = gate["command"].index("--target")
+                self.assertEqual(
+                    gate["command"][target_index + 1],
+                    "x86_64-unknown-linux-gnu",
+                )
+
     def test_multi_hour_performance_gates_are_isolated_from_perf_batch(self) -> None:
         by_id = {gate["id"]: gate for gate in self.catalog["gates"]}
         soak_ids = {


### PR DESCRIPTION
## What changed

- use the supported cargo-fuzz `--fuzz-dir` option for all ten synthetic remote fuzz gates
- pin the GNU target consistently with the canonical legacy fuzz gates
- add catalog tests that reject the unsupported `--manifest-path` form

## Root cause

The first complete remote qualification reached the hosted fuzz lane and showed that cargo-fuzz 0.13.2 does not accept `--manifest-path` for `cargo fuzz run`. Four gates in the affected shard failed immediately with usage exit code 2.

## Validation

- release catalog regenerates and validates
- release-gate and workflow-policy unit tests pass
- remote and canonical fuzz gates both assert `--fuzz-dir` plus the pinned GNU target

This changes test orchestration only. It does not publish crates or change Rust APIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/CI gate definitions and generated catalog only; no runtime product or API changes.
> 
> **Overview**
> Remote release fuzz smoke gates were failing on hosted runners because **cargo-fuzz 0.13.2 rejects `--manifest-path` on `cargo fuzz run`**. This PR switches all ten `security.remote-fuzz-*` gates to the supported **`--fuzz-dir`** layout (derived from each fuzz crate path) and pins **`--target x86_64-unknown-linux-gnu`**, matching the canonical `security.fuzz-*` overrides.
> 
> `build_gate_catalog.py` generates the updated argv and path globs; **`gates.json`** is regenerated accordingly. **`test_release_gates.py`** now asserts every remote fuzz gate omits `--manifest-path`, includes `--fuzz-dir`, and uses the GNU target—parallel to the existing canonical fuzz gate checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0559c53f5aac53c34eb55640f0a5361adef13d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->