### PR TITLE
Fix GCP release worker dependencies

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -323,6 +323,7 @@ jobs:
           ENVIRONMENT_ID: ${{ needs.plan.outputs.environment_id }}
           GATES: ${{ matrix.gates_csv }}
           SHARD_ID: ${{ matrix.id }}
+          RESOURCE_CLASS: ${{ matrix.resource_class }}
           MACHINE_TYPE: ${{ matrix.machine_type }}
           DISK_TYPE: ${{ matrix.disk_type }}
           DISK_SIZE_GB: ${{ matrix.disk_size_gb }}
@@ -357,7 +358,7 @@ jobs:
             --shielded-vtpm \
             --shielded-integrity-monitoring \
             --labels rvoip-role=release-gate,managed-by=github-actions \
-            --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${SHARD_ID},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
+            --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${SHARD_ID},rvoip-resource-class=${RESOURCE_CLASS},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
             --metadata-from-file startup-script=infra/release-runners/gcp-release-startup.sh
 
       - name: Wait for immutable worker evidence

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -107,6 +107,12 @@ if [[ "$RESOURCE_CLASS" == "gcp-interop" ]]; then
   # Keep these heavyweight, network-facing tools off performance-only workers.
   apt-get install -y --no-install-recommends \
     baresip docker.io netcat-openbsd openssl sip-tester
+  command -v sipp >/dev/null
+elif [[ ",$GATES," == *",perf.sipp-parity,"* ]]; then
+  # This performance test otherwise treats a missing external SIPp binary as a
+  # local-development skip. Release qualification must execute it, not skip it.
+  apt-get install -y --no-install-recommends sip-tester
+  command -v sipp >/dev/null
 fi
 
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -13,6 +13,7 @@ metadata() {
 CANDIDATE="$(metadata rvoip-candidate)"
 RUN_ID="$(metadata rvoip-run-id)"
 SHARD_ID="$(metadata rvoip-shard-id)"
+RESOURCE_CLASS="$(metadata rvoip-resource-class)"
 BUCKET="$(metadata rvoip-evidence-bucket)"
 PREFIX="$(metadata rvoip-prefix)"
 GATES="$(metadata rvoip-gates-b64 | base64 --decode)"
@@ -98,8 +99,15 @@ trap finish EXIT
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y --no-install-recommends \
-  baresip build-essential ca-certificates cmake curl docker.io git jq \
-  libasound2-dev libopus-dev libssl-dev pkg-config protobuf-compiler sipp
+  build-essential ca-certificates cmake curl git jq libasound2-dev libopus-dev \
+  libssl-dev pkg-config protobuf-compiler
+
+if [[ "$RESOURCE_CLASS" == "gcp-interop" ]]; then
+  # Ubuntu packages the SIPp binary as `sip-tester`; `sipp` is not a package.
+  # Keep these heavyweight, network-facing tools off performance-only workers.
+  apt-get install -y --no-install-recommends \
+    baresip docker.io netcat-openbsd openssl sip-tester
+fi
 
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
   https://sh.rustup.rs -o /tmp/rustup-init.sh

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -72,6 +72,17 @@ class WorkflowPolicyTests(unittest.TestCase):
         ):
             self.assertIn(profile, startup)
 
+    def test_release_workers_install_interop_tools_only_for_interop(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        startup = (ROOT / "infra/release-runners/gcp-release-startup.sh").read_text()
+
+        self.assertIn("RESOURCE_CLASS: ${{ matrix.resource_class }}", workflow)
+        self.assertIn("rvoip-resource-class=${RESOURCE_CLASS}", workflow)
+        self.assertIn('RESOURCE_CLASS="$(metadata rvoip-resource-class)"', startup)
+        self.assertIn('if [[ "$RESOURCE_CLASS" == "gcp-interop" ]]', startup)
+        self.assertIn("sip-tester", startup)
+        self.assertNotRegex(startup, r"apt-get install[^\n]*\bsipp\b")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -81,6 +81,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('RESOURCE_CLASS="$(metadata rvoip-resource-class)"', startup)
         self.assertIn('if [[ "$RESOURCE_CLASS" == "gcp-interop" ]]', startup)
         self.assertIn("sip-tester", startup)
+        self.assertIn('elif [[ ",$GATES," == *",perf.sipp-parity,"* ]]', startup)
+        self.assertGreaterEqual(startup.count("command -v sipp >/dev/null"), 2)
         self.assertNotRegex(startup, r"apt-get install[^\n]*\bsipp\b")
 
 


### PR DESCRIPTION
## Summary
- install the Ubuntu `sip-tester` package that provides SIPp
- pass the planned resource class into ephemeral release workers
- install SIPp, baresip, Docker, and network tools only on the interoperability worker
- add workflow-policy regression coverage

## Why
The first full remote qualification exposed an Ubuntu package-name mismatch (`sipp` versus `sip-tester`). Because setup installed interoperability tools on every worker, this prevented all GCP shards from reaching their tests.

## Testing
- `bash -n infra/release-runners/gcp-release-startup.sh`
- `python3 -m unittest scripts.ci.test_workflow_policy`
- `python3 -m unittest scripts.test_release_gates`
- `git diff --check`

## Release safety
This changes test infrastructure only. It does not publish packages or create a release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes release qualification VM startup and workflow metadata only; no product runtime, auth, or publish paths.
> 
> **Overview**
> Fixes GCP release qualification workers failing during bootstrap because Ubuntu has no `sipp` package (SIPp comes from **`sip-tester`**) and because **baresip**, **Docker**, and related tools were installed on every shard.
> 
> **`release-qualify.yml`** now passes **`matrix.resource_class`** into the ephemeral VM as **`rvoip-resource-class`** metadata. **`gcp-release-startup.sh`** always installs the Rust/build baseline, then installs interoperability stack (**`baresip`**, **`docker.io`**, **`sip-tester`**, etc.) only when **`RESOURCE_CLASS`** is **`gcp-interop`**, or installs **`sip-tester`** alone when the shard runs **`perf.sipp-parity`** so that gate cannot skip for a missing binary.
> 
> Adds **`test_release_workers_install_interop_tools_only_for_interop`** in **`test_workflow_policy.py`** to lock in the metadata wiring and forbid apt lines that reference a nonexistent **`sipp`** package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de342f8a8ae14e77aaf55dd6726670f0dab14fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->