### PR TITLE
Fix remaining remote qualification false failures

### DIFF
--- a/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
@@ -31,8 +31,9 @@ use support::soak::{
     in_process_resource_sampler_enabled, media_receive_diagnostics, media_setup_raw_diagnostics,
     media_setup_timing_diagnostics, memory_diagnostic_interval, memory_diagnostic_summary,
     read_required_u16_env, resource_sampling_diagnostics, round2, round4,
-    sip_dialog_raw_diagnostics, sip_dialog_timing_diagnostics, sip_udp_diagnostics, DhatProfile,
-    EndpointRetentionSampler, MemoryDiagnosticSampler, RssGrowthGate,
+    sample_settled_rss_window, sip_dialog_raw_diagnostics, sip_dialog_timing_diagnostics,
+    sip_udp_diagnostics, DhatProfile, EndpointRetentionSampler, MemoryDiagnosticSampler,
+    RssGrowthGate,
 };
 use support::{
     CallSetupDiagnostics, LatencyHistogram, LoadProfile, ResourceSampler, ResourceSummary,
@@ -419,21 +420,28 @@ async fn perf_burst_caller() {
     retention_series.record_sample("burst_caller", final_sample);
     let final_retention_all = capture_all_caller_retention(clients.as_slice()).await;
     let retained_after_drain = final_retention_all.retained_total;
+    let (mut settled_resources, settled_observation) = if in_process_resource_sampling {
+        sample_settled_rss_window("burst_caller", scenario.acceptance.min_rss_gate_window_secs)
+            .await
+    } else {
+        (ResourceSummary::empty(), Duration::ZERO)
+    };
     let rss = support::soak::rss_result_metrics(
-        &resources,
-        active_wall.as_secs_f64(),
-        active_wall.as_secs_f64(),
-        retention_drain_wait.as_secs_f64(),
-        support::soak::RssGatePolicy::PostDrainOrTail,
+        &settled_resources,
+        0.0,
+        0.0,
+        settled_observation.as_secs_f64(),
+        support::soak::RssGatePolicy::SettledTail60,
     );
     let rss_gate_enforced =
         rss.post_drain_window_secs >= scenario.acceptance.min_rss_gate_window_secs;
     let rss_gate_reason = if rss_gate_enforced {
-        "post_drain_window_meets_minimum"
+        "settled_window_meets_minimum"
     } else {
-        "reported_only_short_post_drain_window"
+        "reported_only_short_settled_window"
     };
     resources.samples.clear();
+    settled_resources.samples.clear();
     let dhat_diagnostics = dhat_profile.finish();
 
     let offered = counters.offered.load(Ordering::Relaxed);
@@ -641,6 +649,19 @@ async fn perf_burst_caller() {
         .diagnostic_block(
             "resource_sampling",
             resource_sampling_diagnostics("burst_caller", in_process_resource_sampling),
+        )
+        .diagnostic_block(
+            "settled_resource_sampling",
+            json!({
+                "observation_secs": round2(settled_observation.as_secs_f64()),
+                "sample_count": settled_resources.sample_count,
+                "samples_path": settled_resources
+                    .samples_path
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                "baseline_rss_mb": round2(settled_resources.baseline_rss_mb),
+                "peak_rss_mb": round2(settled_resources.peak_rss_mb),
+            }),
         )
         .diagnostic_block(
             "call_failure_trace",

--- a/crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs
@@ -30,9 +30,9 @@ use support::soak::{
     diagnostic_artifact_path, diagnostic_sample_path, endpoint_metric, endpoint_retention_summary,
     in_process_resource_sampler_enabled, media_receive_diagnostics, media_setup_raw_diagnostics,
     media_setup_timing_diagnostics, memory_diagnostic_interval, memory_diagnostic_summary,
-    read_required_u16_env, resource_sampling_diagnostics, round2, sip_dialog_raw_diagnostics,
-    sip_dialog_timing_diagnostics, sip_udp_diagnostics, DhatProfile, EndpointRetentionSampler,
-    MemoryDiagnosticSampler, RssGrowthGate,
+    read_required_u16_env, resource_sampling_diagnostics, round2, sample_settled_rss_window,
+    sip_dialog_raw_diagnostics, sip_dialog_timing_diagnostics, sip_udp_diagnostics, DhatProfile,
+    EndpointRetentionSampler, MemoryDiagnosticSampler, RssGrowthGate,
 };
 use support::{
     CallSetupDiagnostics, LoadProfile, ResourceSampler, ResourceSummary, ScenarioReport,
@@ -222,21 +222,31 @@ async fn perf_burst_receiver() {
     let completed_audio_receivers = completed_audio_receivers.load(Ordering::Relaxed);
     let received_frames = received_frames.load(Ordering::Relaxed);
     let incoming_calls = incoming_calls.load(Ordering::Relaxed);
+    let (mut settled_resources, settled_observation) = if in_process_resource_sampling {
+        sample_settled_rss_window(
+            "burst_receiver",
+            scenario.acceptance.min_rss_gate_window_secs,
+        )
+        .await
+    } else {
+        (ResourceSummary::empty(), Duration::ZERO)
+    };
     let rss = support::soak::rss_result_metrics(
-        &resources,
-        active_secs,
-        active_secs,
-        retention_drain_wait.as_secs_f64(),
-        support::soak::RssGatePolicy::PostDrainOrTail,
+        &settled_resources,
+        0.0,
+        0.0,
+        settled_observation.as_secs_f64(),
+        support::soak::RssGatePolicy::SettledTail60,
     );
     let rss_gate_enforced =
         rss.post_drain_window_secs >= scenario.acceptance.min_rss_gate_window_secs;
     let rss_gate_reason = if rss_gate_enforced {
-        "post_drain_window_meets_minimum"
+        "settled_window_meets_minimum"
     } else {
-        "reported_only_short_post_drain_window"
+        "reported_only_short_settled_window"
     };
     resources.samples.clear();
+    settled_resources.samples.clear();
     let dhat_diagnostics = dhat_profile.finish();
     let retained_session_trace_path =
         if retained_after_drain > 0 || active_audio_receivers_after_drain > 0 {
@@ -345,6 +355,19 @@ async fn perf_burst_receiver() {
         .diagnostic_block(
             "resource_sampling",
             resource_sampling_diagnostics("burst_receiver", in_process_resource_sampling),
+        )
+        .diagnostic_block(
+            "settled_resource_sampling",
+            json!({
+                "observation_secs": round2(settled_observation.as_secs_f64()),
+                "sample_count": settled_resources.sample_count,
+                "samples_path": settled_resources
+                    .samples_path
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                "baseline_rss_mb": round2(settled_resources.baseline_rss_mb),
+                "peak_rss_mb": round2(settled_resources.peak_rss_mb),
+            }),
         )
         .diagnostic_block(
             "retained_session_trace",

--- a/crates/sip/rvoip-sip/tests/perf/perf_soak_30min.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_soak_30min.rs
@@ -2431,9 +2431,9 @@ mod tests {
             640.0,
             640.0,
             40.0,
-            support::soak::RssGatePolicy::PostDrainOrTail,
+            support::soak::RssGatePolicy::SettledTail60,
         );
-        assert_eq!(rss.gate_window, "post_drain_tail_60s");
+        assert_eq!(rss.gate_window, "settled_tail_60s");
         assert!(rss.gate_growth_mb_per_hr.abs() < 0.000_001);
         assert!(rss.post_drain_growth_mb_per_hr > 0.0);
         assert!(rss.active_tail_growth_mb_per_hr > 30.0);
@@ -2459,10 +2459,10 @@ mod tests {
             550.0,
             550.0,
             130.0,
-            support::soak::RssGatePolicy::PostDrainOrTail,
+            support::soak::RssGatePolicy::SettledTail60,
         );
 
-        assert_eq!(rss.gate_window, "post_drain_tail_60s");
+        assert_eq!(rss.gate_window, "settled_tail_60s");
         assert!((rss.gate_growth_mb_per_hr - 10.01).abs() < 0.000_001);
         assert!(rss.gate_growth_mb_per_hr > 10.0);
     }

--- a/crates/sip/rvoip-sip/tests/perf/support/soak.rs
+++ b/crates/sip/rvoip-sip/tests/perf/support/soak.rs
@@ -13,7 +13,7 @@ use rvoip_sip::api::unified::{AudioSource, Config, UnifiedCoordinator};
 use serde_json::{json, Value};
 use tokio::task::{JoinHandle, JoinSet};
 
-use super::{LatencyHistogram, ResourceSample, ResourceSummary};
+use super::{LatencyHistogram, ResourceSample, ResourceSampler, ResourceSummary};
 
 pub const DEFAULT_PERF_APP_EVENT_CHANNEL_CAPACITY: usize =
     Config::DEFAULT_APP_EVENT_CHANNEL_CAPACITY;
@@ -27,6 +27,7 @@ pub const MIN_RETENTION_DRAIN_WAIT_SECS: usize =
 pub const DEFAULT_RETENTION_DRAIN_WAIT_SECS: usize = MIN_RETENTION_DRAIN_WAIT_SECS;
 pub const BURST_RSS_DIAGNOSTIC_SETTLE_SECS: usize = 5;
 pub const BURST_RSS_QUIET_TAIL_SECS: usize = 60;
+pub const BURST_SETTLED_RSS_SAMPLE_INTERVAL_SECS: u64 = 5;
 pub const MIN_BURST_RETENTION_DRAIN_WAIT_SECS: usize =
     MIN_RETENTION_DRAIN_WAIT_SECS + BURST_RSS_DIAGNOSTIC_SETTLE_SECS + BURST_RSS_QUIET_TAIL_SECS;
 /// Full endpoint-retention snapshots walk and serialize every owned runtime
@@ -97,6 +98,25 @@ pub fn resource_sampling_diagnostics(role: &str, in_process_enabled: bool) -> se
         "disable_env": DISABLE_IN_PROCESS_RESOURCE_SAMPLER_ENV,
         "external_diagnostics_dir": std::env::var(EXTERNAL_RESOURCE_DIAGNOSTICS_DIR_ENV).ok(),
     })
+}
+
+/// Measure RSS after teardown and exact structural-retention capture have
+/// completed. A new baseline keeps allocator page activity from those
+/// operations out of the authoritative quiescent-runtime slope.
+pub async fn sample_settled_rss_window(
+    role: &str,
+    minimum_window_secs: f64,
+) -> (ResourceSummary, Duration) {
+    let minimum_window_secs = minimum_window_secs.ceil().max(1.0) as u64;
+    let observation = Duration::from_secs(
+        minimum_window_secs.saturating_add(BURST_SETTLED_RSS_SAMPLE_INTERVAL_SECS),
+    );
+    let sampler = ResourceSampler::start_with_output(
+        Duration::from_secs(BURST_SETTLED_RSS_SAMPLE_INTERVAL_SECS),
+        diagnostic_sample_path(role, "settled_resource"),
+    );
+    tokio::time::sleep(observation).await;
+    (sampler.stop().await, observation)
 }
 
 pub fn media_receive_diagnostics() -> serde_json::Value {
@@ -2141,10 +2161,13 @@ pub enum RssGatePolicy {
     /// Long-soak authority: qualify the final ten minutes under load and fail
     /// separately if that complete window was not captured.
     ActiveTail600,
-    /// Short/burst authority: require the full scenario-specific post-drain
-    /// coverage, then qualify its settled final 60 seconds. The full-window
-    /// slope remains diagnostic so bounded cleanup settling stays visible.
+    /// Compatibility policy for short monolithic soak invocations whose RSS
+    /// series includes both active load and the declared post-drain period.
     PostDrainOrTail,
+    /// Short/burst authority: require a complete observation captured after
+    /// teardown and structural retention checks, then qualify its final 60
+    /// seconds as quiescent runtime behavior.
+    SettledTail60,
 }
 
 pub fn rss_result_metrics(
@@ -2214,6 +2237,10 @@ pub fn rss_result_metrics(
             (sustained_growth_mb_per_hr, "post_drain_tail_60s")
         }
         RssGatePolicy::PostDrainOrTail => (sustained_growth_mb_per_hr, "tail"),
+        RssGatePolicy::SettledTail60 if post_drain_samples.len() >= 2 => {
+            (sustained_growth_mb_per_hr, "settled_tail_60s")
+        }
+        RssGatePolicy::SettledTail60 => (sustained_growth_mb_per_hr, "settled_tail_incomplete"),
     };
     let windows = rss_window_summaries(
         &resources.samples,

--- a/infra/release-runners/interop-lifecycle.sh
+++ b/infra/release-runners/interop-lifecycle.sh
@@ -14,15 +14,27 @@ else
 fi
 mkdir -p "$STATE" "$LOCAL_ENV_ROOT/asterisk" "$LOCAL_ENV_ROOT/freeswitch"
 
-wait_port() {
-  local port="$1"
+wait_udp_port() {
+  local container="$1"
+  local port="$2"
+  local port_hex
+  printf -v port_hex '%04X' "$port"
   for _ in $(seq 1 180); do
-    if nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+    if docker exec "$container" awk -v port=":$port_hex" '
+      $2 ~ port "$" && $4 == "07" { found = 1 }
+      END { exit !found }
+    ' /proc/net/udp /proc/net/udp6 >/dev/null 2>&1; then
       return 0
+    fi
+    if ! docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null | grep -qx true; then
+      echo "$container exited before UDP port $port became ready" >&2
+      docker logs "$container" >&2 || true
+      return 1
     fi
     sleep 1
   done
-  echo "port $port did not become ready" >&2
+  echo "UDP port $port did not become ready in $container" >&2
+  docker logs "$container" >&2 || true
   return 1
 }
 
@@ -60,7 +72,7 @@ PY
     -v "$build/config/modules.conf:/etc/asterisk/modules.conf:ro" \
     -v "$build/keys:/etc/asterisk/keys:ro" \
     rvoip-release-asterisk >/dev/null
-  wait_port 5060
+  wait_udp_port rvoip-release-asterisk 5060
   cat > "$LOCAL_ENV_ROOT/asterisk/rvoip-local.env" <<EOF
 SIP_SERVER=127.0.0.1
 SIP_PORT=5060
@@ -119,7 +131,7 @@ PY
     -e FS_EXTERNAL_SIP_IP=127.0.0.1 \
     -e FS_EXTERNAL_RTP_IP=127.0.0.1 \
     rvoip-release-freeswitch >/dev/null
-  wait_port 5062
+  wait_udp_port rvoip-release-freeswitch 5062
   cat > "$LOCAL_ENV_ROOT/freeswitch/freeswitch-local.env" <<'EOF'
 FREESWITCH_ADDR=127.0.0.1:5060
 FREESWITCH_IP=127.0.0.1

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -94,6 +94,9 @@ class WorkflowPolicyTests(unittest.TestCase):
         lifecycle = (ROOT / "infra/release-runners/interop-lifecycle.sh").read_text()
         self.assertIn("infra/release-runners/pbx", lifecycle)
         self.assertNotIn("beta-report/", lifecycle)
+        self.assertIn("wait_udp_port", lifecycle)
+        self.assertIn("/proc/net/udp", lifecycle)
+        self.assertNotIn("nc -z 127.0.0.1", lifecycle)
         for path in (
             "infra/release-runners/pbx/asterisk/Dockerfile",
             "infra/release-runners/pbx/asterisk/config/pjsip.conf",
@@ -102,6 +105,20 @@ class WorkflowPolicyTests(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 self.assertTrue((ROOT / path).is_file())
+
+    def test_burst_rss_gate_uses_post_retention_settled_window(self) -> None:
+        for path in (
+            "crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs",
+            "crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs",
+        ):
+            source = (ROOT / path).read_text()
+            with self.subTest(path=path):
+                final_retention = source.index("capture_endpoint_retention_sample(")
+                settled_window = source.index("sample_settled_rss_window(", final_retention)
+                rss_gate = source.index("rss_result_metrics(", settled_window)
+                self.assertLess(final_retention, settled_window)
+                self.assertLess(settled_window, rss_gate)
+                self.assertIn("&settled_resources", source[rss_gate : rss_gate + 250])
 
 
 if __name__ == "__main__":

--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -331,6 +331,11 @@ def legacy_gate(record: dict[str, Any], records: list[dict[str, Any]], packages:
         executor = "builtin"
     duration = int(record.get("duration_seconds", 0))
     timeout_minutes = max(5, math.ceil(duration / 60 * 2) + 5)
+    if record["kind"] == "cargo":
+        # Historical durations measure the command after a warm local build.
+        # Release shards can begin cold, so leave enough time to compile and
+        # then execute the required test instead of timing out mid-build.
+        timeout_minutes = max(timeout_minutes, 20)
     if resource_class(record).startswith("gcp-"):
         # GCP workers start without a warm target directory. Preserve enough
         # headroom for the first release build as well as the measured gate.
@@ -562,7 +567,12 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
             "interop.remote-proxies",
             "Kamailio and OpenSIPS proxy matrix",
             executor="argv",
-            command=["bash", "crates/sip/sip-proxy/tests/interop/scripts/beta_gate.sh"],
+            command=[
+                "env",
+                "PROXY_INTEROP_ARTIFACT_DIR={artifact_dir}/proxy-interop",
+                "bash",
+                "crates/sip/sip-proxy/tests/interop/scripts/beta_gate.sh",
+            ],
             resource="gcp-interop",
             dependencies=["source.remote-clean"],
             paths=["crates/sip/sip-proxy/**", "crates/sip/sip-transport/**", "crates/sip/sip-core/**"],

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -108,7 +108,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -166,7 +166,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -203,7 +203,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 17,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -247,7 +247,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 15,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -310,7 +310,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -358,7 +358,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 7,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -400,7 +400,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 7,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -486,7 +486,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 16,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -702,7 +702,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 13,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -788,7 +788,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 7,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -832,7 +832,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 15,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -874,7 +874,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 10,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -919,7 +919,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 11,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -961,7 +961,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1006,7 +1006,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 10,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1048,7 +1048,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1092,7 +1092,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 10,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1134,7 +1134,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 10,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1176,7 +1176,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1218,7 +1218,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1262,7 +1262,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1306,7 +1306,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 11,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1348,7 +1348,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1390,7 +1390,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1432,7 +1432,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1474,7 +1474,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1516,7 +1516,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1558,7 +1558,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1600,7 +1600,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1642,7 +1642,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1684,7 +1684,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1726,7 +1726,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1768,7 +1768,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1810,7 +1810,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1852,7 +1852,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1894,7 +1894,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1939,7 +1939,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -1985,7 +1985,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -2030,7 +2030,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -2075,7 +2075,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -2120,7 +2120,7 @@
       "retry_on_exit_codes": [
         75
       ],
-      "timeout_minutes": 6,
+      "timeout_minutes": 20,
       "working_directory": "."
     },
     {
@@ -5462,13 +5462,15 @@
       "always_fresh": false,
       "category": "Remote release framework",
       "command": [
+        "env",
+        "PROXY_INTEROP_ARTIFACT_DIR={artifact_dir}/proxy-interop",
         "bash",
         "crates/sip/sip-proxy/tests/interop/scripts/beta_gate.sh"
       ],
       "dependencies": [
         "source.remote-clean"
       ],
-      "display_command": "bash crates/sip/sip-proxy/tests/interop/scripts/beta_gate.sh",
+      "display_command": "env PROXY_INTEROP_ARTIFACT_DIR={artifact_dir}/proxy-interop bash crates/sip/sip-proxy/tests/interop/scripts/beta_gate.sh",
       "estimated_seconds": 1,
       "executor": "argv",
       "expected_outputs": [

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -211,6 +211,12 @@ class GateFrameworkTests(unittest.TestCase):
                 with self.subTest(gate=gate["id"]):
                     self.assertGreaterEqual(gate["timeout_minutes"], 20)
 
+    def test_cargo_gates_allow_for_cold_release_builds(self) -> None:
+        for gate in self.catalog["gates"]:
+            if gate["kind"] == "cargo":
+                with self.subTest(gate=gate["id"]):
+                    self.assertGreaterEqual(gate["timeout_minutes"], 20)
+
     def test_interop_gate_digests_include_tracked_pbx_lifecycle(self) -> None:
         interop = [
             gate
@@ -225,6 +231,17 @@ class GateFrameworkTests(unittest.TestCase):
                     gate["affected_paths"],
                 )
                 self.assertIn("infra/release-runners/pbx/**", gate["affected_paths"])
+
+    def test_remote_proxy_gate_persists_full_failure_evidence(self) -> None:
+        gate = next(
+            gate
+            for gate in self.catalog["gates"]
+            if gate["id"] == "interop.remote-proxies"
+        )
+        self.assertIn(
+            "PROXY_INTEROP_ARTIFACT_DIR={artifact_dir}/proxy-interop",
+            gate["command"],
+        )
 
     def test_definition_digest_is_key_order_independent(self) -> None:
         first = {"id": "a", "command": ["true"]}


### PR DESCRIPTION
## Summary
- qualify burst RSS over a fresh settled window after exact teardown/retention evidence, while preserving the 15 MB/hour threshold
- give Cargo gates enough timeout headroom for cold GitHub runners
- probe PBX UDP listeners as UDP sockets and preserve container logs on startup failure
- retain full proxy-interoperability artifacts for remote diagnosis

## Evidence
- access-edge, contact-center, and high-density burst failures all reached zero retained objects, zero active transactions, and zero active audio receivers before the old short RSS tail failed
- example 12 was terminated at exactly 360 seconds while still compiling
- Asterisk and FreeSWITCH readiness used a TCP probe for UDP-only listeners
- BridgeFu issue #54 Chromium DTMF gate passed in the same canonical run

## Verification
- release-mode burst caller/receiver binaries compiled
- 23 release-mode non-ignored burst/support tests passed
- all five affected performance binaries compile
- 34 release planner/workflow policy tests pass
- formatting, shell syntax, and diff hygiene pass

Relates to #54.

This PR changes release qualification only. It does not publish crates, create tags, or create a release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes target release/perf qualification and CI infrastructure only, not production SIP or auth paths; main risk is gate behavior or timeout tuning on runners.
> 
> **Overview**
> **Burst memory gates** now measure RSS in a **fresh settled window** after drain and final retention snapshots, using `SettledTail60` instead of qualifying the old in-process series that mixed load, diagnostics, and teardown. Caller and receiver reports add **settled_resource_sampling** diagnostics; the 15 MB/hr acceptance threshold is unchanged.
> 
> **PBX interop startup** waits for **UDP listeners** inside Docker (`/proc/net/udp`) instead of TCP `nc -z`, and dumps container logs when readiness fails.
> 
> **Release plumbing**: all **cargo** gates get at least **20 minutes** timeout for cold compiles; **proxy interop** writes artifacts under `PROXY_INTEROP_ARTIFACT_DIR`. CI policy tests lock in the settled-RSS ordering and UDP wait behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3caa979f71f539c40b1519157f6b0d5f26978676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->