### PR TITLE
fix(release): align remote interop networking and evidence

### DIFF
--- a/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh
+++ b/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 CRATE_DIR="${WORKSPACE_ROOT}/crates/sip/rvoip-sip"
-PERF_DIR="${WORKSPACE_ROOT}/target/perf-results"
+PERF_DIR="${RVOIP_PERF_RESULTS:-${WORKSPACE_ROOT}/target/perf-results}"
 CARGO_ARTIFACT_HELPER="${SCRIPT_DIR}/perf_cargo_artifact.py"
 
 export CARGO_MANIFEST_DIR="${CRATE_DIR}"

--- a/crates/sip/sip-dialog/src/diagnostics.rs
+++ b/crates/sip/sip-dialog/src/diagnostics.rs
@@ -42,6 +42,9 @@ const MAX_TRANSACTION_DISPATCH_DIAG_WORKERS: usize = 64;
 const MAX_CALL_TIMING_TRACE_ENTRIES: usize = 20_000;
 
 static ENABLED_OVERRIDE: AtomicU8 = AtomicU8::new(0);
+#[cfg(test)]
+static ENABLED_TEST_THREAD: LazyLock<Mutex<Option<std::thread::ThreadId>>> =
+    LazyLock::new(|| Mutex::new(None));
 static TRANSACTION_TIMING_ENABLED: AtomicU8 = AtomicU8::new(0);
 static DIALOG_TIMING_ENABLED: AtomicU8 = AtomicU8::new(0);
 static CALL_TIMING_TRACE_STORE: LazyLock<CallTimingTraceStore> =
@@ -843,10 +846,21 @@ impl CallTimingTraceStore {
 }
 
 pub fn enabled() -> bool {
-    match ENABLED_OVERRIDE.load(Ordering::Relaxed) {
-        2 => true,
-        _ => false,
+    if ENABLED_OVERRIDE.load(Ordering::Relaxed) != 2 {
+        return false;
     }
+
+    #[cfg(test)]
+    {
+        return ENABLED_TEST_THREAD
+            .lock()
+            .expect("diagnostic test thread lock")
+            .as_ref()
+            .is_none_or(|owner| *owner == std::thread::current().id());
+    }
+
+    #[cfg(not(test))]
+    true
 }
 
 pub fn set_enabled(enabled: bool) {
@@ -879,6 +893,9 @@ pub fn set_dialog_timing_enabled(enabled: bool) {
 
 #[cfg(test)]
 fn set_enabled_for_tests(enabled: bool) {
+    *ENABLED_TEST_THREAD
+        .lock()
+        .expect("diagnostic test thread lock") = enabled.then(|| std::thread::current().id());
     set_enabled(enabled);
 }
 
@@ -2588,6 +2605,15 @@ mod tests {
         set_transaction_timing_enabled_for_tests(true);
         set_dialog_timing_enabled_for_tests(true);
         reset();
+
+        std::thread::spawn(record_duplicate_invite_existing_transaction)
+            .join()
+            .expect("parallel diagnostic probe");
+        assert_eq!(
+            snapshot().duplicate_invite_existing_transaction,
+            0,
+            "another test thread must not contaminate exact diagnostic counts"
+        );
 
         record_duplicate_invite_existing_transaction();
         record_duplicate_invite_cache_hit();

--- a/crates/sip/sip-proxy/tests/interop/scripts/common.sh
+++ b/crates/sip/sip-proxy/tests/interop/scripts/common.sh
@@ -18,6 +18,14 @@ if command -v colima >/dev/null 2>&1 \
   && [[ "$(docker context show 2>/dev/null)" == "colima" ]]; then
   COMPOSE_FILE_ARGS+=(--file "$COLIMA_HOST_COMPOSE_FILE")
   export PROXY_INTEROP_NETWORK_TOPOLOGY=colima-vm-host
+elif [[ "$(uname -s)" == "Linux" ]] \
+  && [[ "$(docker info --format '{{.OperatingSystem}}' 2>/dev/null)" != *"Docker Desktop"* ]]; then
+  # Every helper that sources this file (including up.sh) must use the same
+  # native host network selected by run.sh. Keeping this only in run.sh made
+  # `compose config` report host networking while the subprocess that actually
+  # started the peer silently fell back to an isolated bridge network.
+  COMPOSE_FILE_ARGS+=(--file "$COLIMA_HOST_COMPOSE_FILE")
+  export PROXY_INTEROP_NETWORK_TOPOLOGY=linux-native-host-network
 else
   export PROXY_INTEROP_NETWORK_TOPOLOGY=${PROXY_INTEROP_NETWORK_TOPOLOGY:-portable-published-port}
 fi

--- a/infra/release-runners/interop-lifecycle.sh
+++ b/infra/release-runners/interop-lifecycle.sh
@@ -95,7 +95,7 @@ EOF
 }
 
 freeswitch_up() {
-  down rvoip-release-freeswitch
+  down rvoip-freeswitch
   local build="$STATE/freeswitch"
   rm -rf "$build"
   cp -R "$PBX_SNAPSHOT/freeswitch" "$build"
@@ -125,13 +125,13 @@ for line in path.read_text().splitlines():
 path.write_text("\n".join(lines) + "\n")
 PY
   docker build --build-arg MAKE_JOBS="$(nproc)" -t rvoip-release-freeswitch "$build"
-  docker run -d --name rvoip-release-freeswitch --network host \
+  docker run -d --name rvoip-freeswitch --network host \
     -e FS_DEFAULT_PASSWORD=1234 \
     -e FS_EVENT_SOCKET_PASSWORD=ClueCon \
     -e FS_EXTERNAL_SIP_IP=127.0.0.1 \
     -e FS_EXTERNAL_RTP_IP=127.0.0.1 \
     rvoip-release-freeswitch >/dev/null
-  wait_udp_port rvoip-release-freeswitch 5062
+  wait_udp_port rvoip-freeswitch 5062
   cat > "$LOCAL_ENV_ROOT/freeswitch/freeswitch-local.env" <<'EOF'
 FREESWITCH_ADDR=127.0.0.1:5060
 FREESWITCH_IP=127.0.0.1
@@ -186,7 +186,7 @@ case "$ACTION" in
   asterisk-up) asterisk_up ;;
   asterisk-down|restore-asterisk-down) down rvoip-release-asterisk ;;
   freeswitch-up) freeswitch_up ;;
-  freeswitch-down|restore-freeswitch-down) down rvoip-release-freeswitch ;;
+  freeswitch-down|restore-freeswitch-down) down rvoip-freeswitch ;;
   sipp-start) sipp_start ;;
   sipp-stop) sipp_stop ;;
   *) echo "unknown interop lifecycle action: $ACTION" >&2; exit 2 ;;

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -97,6 +97,10 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("wait_udp_port", lifecycle)
         self.assertIn("/proc/net/udp", lifecycle)
         self.assertNotIn("nc -z 127.0.0.1", lifecycle)
+        self.assertIn("--name rvoip-freeswitch", lifecycle)
+        self.assertIn("wait_udp_port rvoip-freeswitch 5062", lifecycle)
+        self.assertNotIn("--name rvoip-release-freeswitch", lifecycle)
+        self.assertNotIn("down rvoip-release-freeswitch", lifecycle)
         for path in (
             "infra/release-runners/pbx/asterisk/Dockerfile",
             "infra/release-runners/pbx/asterisk/config/pjsip.conf",
@@ -105,6 +109,25 @@ class WorkflowPolicyTests(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 self.assertTrue((ROOT / path).is_file())
+
+    def test_linux_proxy_helpers_share_the_reviewed_host_network(self) -> None:
+        common = (
+            ROOT / "crates/sip/sip-proxy/tests/interop/scripts/common.sh"
+        ).read_text()
+        self.assertIn('elif [[ "$(uname -s)" == "Linux" ]]', common)
+        self.assertIn('COMPOSE_FILE_ARGS+=(--file "$COLIMA_HOST_COMPOSE_FILE")', common)
+        self.assertIn(
+            "PROXY_INTEROP_NETWORK_TOPOLOGY=linux-native-host-network", common
+        )
+
+    def test_burst_runner_honors_remote_artifact_directory(self) -> None:
+        runner = (
+            ROOT / "crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+        ).read_text()
+        self.assertIn(
+            'PERF_DIR="${RVOIP_PERF_RESULTS:-${WORKSPACE_ROOT}/target/perf-results}"',
+            runner,
+        )
 
     def test_burst_rss_gate_uses_post_retention_settled_window(self) -> None:
         for path in (


### PR DESCRIPTION
## Summary
- keep Linux proxy peer startup on the reviewed host network across helper subprocesses
- use the FreeSWITCH container name expected by the PBX matrix
- honor the remote artifact directory for burst diagnostics
- add policy regressions for all three contracts

## Verification
- `python3 -m unittest scripts.ci.test_workflow_policy scripts.test_release_gates`
- shell syntax validation for all changed scripts
- `git diff --check`

This fixes failures exposed by non-publishing release qualification run 30715527913. It does not publish packages, create a tag, or create a release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI scripts, interop helpers, perf runner env wiring, and test-only diagnostic gating; no production SIP routing or auth behavior is altered.
> 
> **Overview**
> Aligns **release qualification** interop and perf harness behavior with what CI and the PBX matrix expect, after failures on non-publishing run 30715527913.
> 
> **Linux proxy interop:** `common.sh` now picks the same **native host-network** compose overlay as `run.sh` on Linux without Docker Desktop, so helpers like `up.sh` do not start peers on a bridge while `compose config` still shows host networking.
> 
> **PBX lifecycle:** FreeSWITCH is started and torn down as **`rvoip-freeswitch`** (replacing `rvoip-release-freeswitch`) so lifecycle scripts match the matrix.
> 
> **Burst perf:** `perf_burst_matrix.sh` writes results under **`RVOIP_PERF_RESULTS`** when set, for remote artifact collection.
> 
> **Diagnostics tests:** Under `cfg(test)`, SIP dialog diagnostics **`enabled()`** is scoped to the test thread that turned them on, with a regression that parallel threads cannot bump shared counters.
> 
> **Policy:** `test_workflow_policy.py` locks in these three contracts plus the FreeSWITCH container name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52aceec030caac2dd845c5a7214f1870c798865c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->