### PR TITLE
test(sip): make soak evidence authoritative

### DIFF
--- a/crates/sip/rvoip-sip/tests/builder_auth_retry_preserves_headers.rs
+++ b/crates/sip/rvoip-sip/tests/builder_auth_retry_preserves_headers.rs
@@ -278,7 +278,14 @@ async fn run_invite_extras_auth_retry(uas_port: u16, uac_port: u16, fail_bye_bef
                             _ => None,
                         };
                         if let Some(label) = label {
-                            trace_sequence.push(label);
+                            // The fixture deliberately retransmits the final
+                            // 200 and separately requires the UAC to ACK both
+                            // copies. A legal duplicate 2xx must not turn the
+                            // semantic auth sequence into a timing-dependent
+                            // fifth step.
+                            if label != "200" || trace_sequence.last() != Some(&"200") {
+                                trace_sequence.push(label);
+                            }
                         }
                     }
                     Some(_) => {}

--- a/crates/sip/rvoip-sip/tests/perf/perf_soak_30min.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_soak_30min.rs
@@ -1552,6 +1552,9 @@ fn read_positive_usize_env(name: &str) -> Option<usize> {
 struct RetentionSampler {
     stop_tx: tokio::sync::watch::Sender<bool>,
     task: JoinHandle<RetentionSeries>,
+    alice: Arc<UnifiedCoordinator>,
+    bob: Arc<UnifiedCoordinator>,
+    started: std::time::Instant,
 }
 
 struct RetentionSeries {
@@ -1571,12 +1574,16 @@ impl RetentionSampler {
         periodic_limit: Option<Duration>,
     ) -> Self {
         let (stop_tx, mut stop_rx) = tokio::sync::watch::channel(false);
+        let started = std::time::Instant::now();
+        let sampled_alice = Arc::clone(&alice);
+        let sampled_bob = Arc::clone(&bob);
         let task = tokio::spawn(async move {
-            let started = std::time::Instant::now();
             let mut series = RetentionSeries::new(retention_samples_path());
             let mut writer = series.open_writer();
             loop {
-                let sample = capture_retention_sample("periodic", started, &alice, &bob).await;
+                let sample =
+                    capture_retention_sample("periodic", started, &sampled_alice, &sampled_bob)
+                        .await;
                 series.record(sample, &mut writer);
                 if let Some(limit) = periodic_limit {
                     let remaining = limit.saturating_sub(started.elapsed());
@@ -1594,21 +1601,37 @@ impl RetentionSampler {
                     }
                 }
             }
-            let sample = capture_retention_sample("after_drain", started, &alice, &bob).await;
-            series.record(sample, &mut writer);
             writer
                 .flush()
                 .expect("flush monolithic retention diagnostics JSONL");
             series
         });
-        Self { stop_tx, task }
+        Self {
+            stop_tx,
+            task,
+            alice,
+            bob,
+            started,
+        }
     }
 
     async fn stop(self) -> RetentionSeries {
         let _ = self.stop_tx.send(true);
-        self.task
+        let mut series = self
+            .task
             .await
-            .unwrap_or_else(|_| RetentionSeries::new(retention_samples_path()))
+            .unwrap_or_else(|_| RetentionSeries::new(retention_samples_path()));
+        let sample =
+            capture_retention_sample("after_drain", self.started, &self.alice, &self.bob).await;
+        let mut writer = std::io::BufWriter::new(
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&series.samples_path)
+                .expect("open monolithic retention diagnostics JSONL for final sample"),
+        );
+        series.record(sample, &mut writer);
+        series
     }
 }
 
@@ -2123,20 +2146,22 @@ fn rss_active_tail_metrics(
         _ => 0.0,
     };
     let endpoint = support::soak::rss_endpoint_median_growth_mb_per_hr(&selected);
+    let theil_sen = support::soak::rss_theil_sen_growth_mb_per_hr(&selected);
     let complete = active_secs >= LONG_SOAK_ACTIVE_RSS_WINDOW_SECS
         && actual_secs >= LONG_SOAK_MIN_ACTIVE_RSS_COVERAGE_SECS
         && selected.len() >= LONG_SOAK_MIN_ACTIVE_RSS_SAMPLES
+        && theil_sen.is_some()
         && endpoint.is_some();
     ActiveTailRssMetrics {
-        growth_mb_per_hr: endpoint.as_ref().map_or_else(
+        growth_mb_per_hr: theil_sen.map_or_else(
             || rss_growth_mb_per_min(&selected) * 60.0,
-            |estimate| estimate.growth_mb_per_hr,
+            |estimate| estimate,
         ),
         sample_count: selected.len(),
         window_secs: actual_secs,
         complete,
-        estimator: if endpoint.is_some() {
-            "median_first_last_sixth_capped_60s"
+        estimator: if theil_sen.is_some() && endpoint.is_some() {
+            "theil_sen_pairwise_slopes"
         } else {
             "unavailable_ols_diagnostic_only"
         },
@@ -2357,7 +2382,7 @@ mod tests {
         assert!(metrics.complete);
         assert_eq!(metrics.sample_count, 121);
         assert_eq!(metrics.window_secs, 600.0);
-        assert_eq!(metrics.estimator, "median_first_last_sixth_capped_60s");
+        assert_eq!(metrics.estimator, "theil_sen_pairwise_slopes");
         assert!((metrics.growth_mb_per_hr - 36.0).abs() < 0.000_001);
 
         assert!(!rss_active_tail_metrics(&samples, 599.0, 5.0).complete);
@@ -2394,6 +2419,35 @@ mod tests {
             endpoint_gap_metrics.estimator,
             "unavailable_ols_diagnostic_only"
         );
+    }
+
+    #[test]
+    fn active_tail_estimator_rejects_allocator_noise_but_detects_growth() {
+        let noise = [0.0, 4.5, -3.0, 2.0, -1.5, 3.5, -4.0, 1.0];
+        let noisy_flat = (0..=120)
+            .map(|index| ResourceSample {
+                t_secs: index as f64 * 5.0,
+                rss_mb: 220.0 + noise[index % noise.len()],
+                cpu_pct: 0.0,
+            })
+            .collect::<Vec<_>>();
+        let flat = rss_active_tail_metrics(&noisy_flat, 600.0, 5.0);
+        assert!(flat.complete);
+        assert!(flat.growth_mb_per_hr.abs() < 1.0);
+
+        let continuous_growth = (0..=120)
+            .map(|index| {
+                let t_secs = index as f64 * 5.0;
+                ResourceSample {
+                    t_secs,
+                    rss_mb: 220.0 + t_secs * 20.0 / 3600.0,
+                    cpu_pct: 0.0,
+                }
+            })
+            .collect::<Vec<_>>();
+        let growth = rss_active_tail_metrics(&continuous_growth, 600.0, 5.0);
+        assert!(growth.complete);
+        assert!((growth.growth_mb_per_hr - 20.0).abs() < 0.000_001);
     }
 
     #[test]
@@ -2522,7 +2576,7 @@ mod tests {
         );
 
         assert!(rss.active_tail_window_complete);
-        assert_eq!(rss.active_tail_estimator, "median_60s_ols_windows");
+        assert_eq!(rss.active_tail_estimator, "theil_sen_pairwise_slopes");
         assert!(rss.active_tail_growth_mb_per_hr.abs() < 0.000_001);
         assert!(endpoint.growth_mb_per_hr > 15.0);
         assert!(rss.active_tail_endpoint_separation_secs > 500.0);

--- a/crates/sip/rvoip-sip/tests/perf/support/soak.rs
+++ b/crates/sip/rvoip-sip/tests/perf/support/soak.rs
@@ -2193,9 +2193,9 @@ pub fn rss_result_metrics(
         .cloned()
         .collect();
     let active_tail_endpoint = rss_endpoint_median_growth_mb_per_hr(&active_tail_samples);
-    let active_tail_window_median = rss_median_window_growth_mb_per_hr(&active_tail_samples, 60.0);
-    let active_tail_growth_mb_per_hr = active_tail_window_median
-        .unwrap_or_else(|| rss_growth_mb_per_min(&active_tail_samples) * 60.0);
+    let active_tail_theil_sen = rss_theil_sen_growth_mb_per_hr(&active_tail_samples);
+    let active_tail_growth_mb_per_hr =
+        active_tail_theil_sen.unwrap_or_else(|| rss_growth_mb_per_min(&active_tail_samples) * 60.0);
     let active_tail_window_secs = match (active_tail_samples.first(), active_tail_samples.last()) {
         (Some(first), Some(last)) => (last.t_secs - first.t_secs).max(0.0),
         _ => 0.0,
@@ -2203,7 +2203,8 @@ pub fn rss_result_metrics(
     let active_tail_window_complete = active_load_end_secs >= LONG_SOAK_ACTIVE_WINDOW_SECS
         && active_tail_window_secs >= LONG_SOAK_MIN_ACTIVE_COVERAGE_SECS
         && active_tail_samples.len() >= LONG_SOAK_MIN_ACTIVE_SAMPLES
-        && active_tail_window_median.is_some();
+        && active_tail_theil_sen.is_some()
+        && active_tail_endpoint.is_some();
     let post_drain_samples: Vec<ResourceSample> = resources
         .samples
         .iter()
@@ -2255,8 +2256,9 @@ pub fn rss_result_metrics(
         active_tail_sample_count: active_tail_samples.len(),
         active_tail_window_secs,
         active_tail_window_complete,
-        active_tail_estimator: if active_tail_window_median.is_some() {
-            "median_60s_ols_windows"
+        active_tail_estimator: if active_tail_theil_sen.is_some() && active_tail_endpoint.is_some()
+        {
+            "theil_sen_pairwise_slopes"
         } else {
             "unavailable_ols_diagnostic_only"
         },
@@ -2281,38 +2283,29 @@ pub fn rss_result_metrics(
     }
 }
 
-/// Robust sustained RSS rate for a powered active-load window.
+/// Robust slope across the complete selected RSS window.
 ///
-/// A bounded allocator/high-water step can permanently move the RSS level and
-/// therefore fool an endpoint delta into projecting that one step across an
-/// hour. The median of minute-scale slopes rejects isolated level changes but
-/// still measures continuous growth in every powered interval.
-pub fn rss_median_window_growth_mb_per_hr(
-    samples: &[ResourceSample],
-    window_secs: f64,
-) -> Option<f64> {
-    const MIN_POWERED_WINDOWS: usize = 8;
+/// The median of every pairwise slope (the Theil-Sen estimator) uses the
+/// entire ten-minute evidence window, resists allocator/sample spikes, and
+/// still returns the exact rate for continuous linear growth. At the release
+/// sampler's 5-second cadence this is only 7,140
+/// slopes, so the quadratic calculation remains negligible.
+pub fn rss_theil_sen_growth_mb_per_hr(samples: &[ResourceSample]) -> Option<f64> {
+    const MIN_SAMPLES: usize = 3;
 
-    if samples.len() < 2 || window_secs <= 0.0 {
+    if samples.len() < MIN_SAMPLES {
         return None;
     }
-    let first_t = samples.first()?.t_secs;
-    let last_t = samples.last()?.t_secs;
-    let mut rates = Vec::new();
-    let mut start = first_t;
-    while start < last_t {
-        let end = (start + window_secs).min(last_t);
-        let window = samples
-            .iter()
-            .filter(|sample| sample.t_secs >= start && sample.t_secs <= end)
-            .cloned()
-            .collect::<Vec<_>>();
-        if window.len() >= 2 {
-            rates.push(rss_growth_mb_per_min(&window) * 60.0);
+    let mut slopes = Vec::with_capacity(samples.len() * (samples.len() - 1) / 2);
+    for (index, first) in samples.iter().enumerate() {
+        for last in &samples[index + 1..] {
+            let elapsed_secs = last.t_secs - first.t_secs;
+            if elapsed_secs > 0.0 {
+                slopes.push((last.rss_mb - first.rss_mb) * 3600.0 / elapsed_secs);
+            }
         }
-        start += window_secs;
     }
-    (rates.len() >= MIN_POWERED_WINDOWS).then(|| median_f64(rates))
+    (!slopes.is_empty()).then(|| median_f64(slopes))
 }
 
 /// Robust retained-RSS rate across the first and last minute of a selected

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -1061,6 +1061,7 @@ def collect(
         "profile": plan["profile"],
         "catalog_sha256": plan["catalog_sha256"],
         "environment_id": plan["environment_id"],
+        "publishing_attempted": False,
         "gate_count": len(plan["gates"]),
         "fresh_count": sum(item["source"] == "fresh" for item in accepted),
         "reused_count": sum(item["source"] == "reused" for item in accepted),

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -537,6 +537,7 @@ class GateFrameworkTests(unittest.TestCase):
             result = json.loads(output.read_text())
             self.assertEqual(result["status"], "PASS")
             self.assertEqual(result["gate_count"], 2)
+            self.assertFalse(result["publishing_attempted"])
             self.assertTrue((root / "collect-gate.aggregate/receipt.json").is_file())
 
             (dependency_dir / "receipt.json").unlink()


### PR DESCRIPTION
## Problem

The first complete remote qualification exposed two evidence bugs in the long-running SIP soak gates:

- the monolithic periodic sampler captured its `after_drain` snapshot when its periodic limit expired, ten minutes before teardown;
- the split soak projected normal minute-scale allocator oscillation into an 84 MB/hour false positive even though the complete ten-minute trend was negative.

## Fix

- Capture the monolithic authoritative structural snapshot only when the sampler is stopped after teardown and the configured drain wait.
- Qualify long-soak RSS with a Theil-Sen median of all pairwise slopes across the complete ten-minute active window.
- Retain endpoint coverage checks and endpoint metrics as fail-closed evidence.
- Add synthetic coverage for allocator noise, bounded level changes, missing coverage, and continuous growth.

## Tests

- `cargo test -p rvoip-sip --features perf-tests --test perf_soak_30min active_tail_ -- --nocapture`
- `python3 -m unittest scripts.test_release_gates scripts.ci.test_workflow_policy`
- `cargo fmt --all -- --check`
- `git diff --check`

No production API or runtime behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to perf/soak tests, release gate metadata, and one SIP trace assertion; no production API or runtime behavior.
> 
> **Overview**
> Fixes long-soak **qualification evidence** so gates reflect teardown timing and RSS trends more reliably—no production runtime changes.
> 
> **Retention sampling:** The monolithic `after_drain` retention snapshot is no longer taken when the periodic sampler hits its time limit (~10 minutes before teardown). `RetentionSampler::stop()` now records that sample after the drain wait, using coordinators held on the sampler.
> 
> **RSS active-tail gate:** Long-soak memory growth uses a **Theil–Sen** median of pairwise slopes across the full 10-minute active window instead of minute-window OLS medians. Endpoint median checks stay required for a “complete” window. Shared soak helpers and monolithic metrics report `theil_sen_pairwise_slopes`; tests cover flat noisy RSS vs continuous growth.
> 
> **Auth retry test:** Duplicate retransmitted `200` SIP trace events no longer add a fifth step to the semantic `INVITE → 401 → INVITE → 200` sequence.
> 
> **Release gates:** Gate aggregate JSON includes `publishing_attempted: false` with a unit test assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4dd801aaf6558fadccf185686faddb3279aaa65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->