### PR TITLE
Fix remote release qualification regressions

### DIFF
--- a/crates/sip/rvoip-sip/examples/pbx/run.sh
+++ b/crates/sip/rvoip-sip/examples/pbx/run.sh
@@ -818,7 +818,11 @@ wait_for_pbx_tls_ready() {
       echo
       echo "## attempt $i"
       if [ "$provider" = "freeswitch" ] && command -v docker >/dev/null 2>&1; then
-        docker exec rvoip-freeswitch fs_cli -x "sofia status profile rvoip_tls_srtp" 2>&1 | sed -n '1,80p'
+        # fs_cli is useful diagnostic evidence, but the profile may still be
+        # starting. Under `set -e` that expected probe failure must not abort
+        # the readiness loop before the authoritative socket checks below.
+        docker exec rvoip-freeswitch fs_cli -x "sofia status profile rvoip_tls_srtp" 2>&1 \
+          | sed -n '1,80p' || true
       fi
       if command -v nc >/dev/null 2>&1; then
         nc -z -w 2 "$host" "$port"

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -548,6 +548,13 @@ fn validate_uac_audio_answer(
     Ok((payload_type, codec, clock_rate, channels))
 }
 
+fn exact_initial_uac_offer(session: &SessionState) -> Option<&str> {
+    session
+        .initial_invite_offer_sdp
+        .as_deref()
+        .or(session.local_sdp.as_deref())
+}
+
 /// Build the SDP answer that declines an offered audio m-line per
 /// RFC 3264 §6 / RFC 4568 §7.3. Port=0 signals refusal; the proto is
 /// echoed from the offer so the peer can distinguish a policy
@@ -1685,9 +1692,7 @@ impl MediaAdapter {
         let (remote_ip, remote_port) = self.parse_sdp_connection(remote_sdp)?;
         let parsed_answer = SdpSession::from_str(remote_sdp)
             .map_err(|_| bounded_sdp_failure("remote-answer", "syntax"))?;
-        let parsed_offer = session
-            .local_sdp
-            .as_deref()
+        let parsed_offer = exact_initial_uac_offer(session)
             .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-local-offer"))
             .and_then(|offer| {
                 SdpSession::from_str(offer)
@@ -5630,6 +5635,21 @@ a=fmtp:101 0-15\r\n";
             .build()
             .unwrap();
         assert!(validate_uac_audio_answer(&offer, &missing_dynamic_map, true).is_err());
+    }
+
+    #[test]
+    fn initial_uac_answer_uses_the_exact_retained_wire_offer() {
+        let mut session = SessionState::new(
+            SessionId("retained-initial-offer".to_string()),
+            crate::state_table::Role::UAC,
+        );
+        session.local_sdp = Some("v=0\r\na=x-later-working-description\r\n".to_string());
+        session.initial_invite_offer_sdp = Some("v=0\r\nm=audio 16000 RTP/AVP 0\r\n".to_string());
+
+        assert_eq!(
+            exact_initial_uac_offer(&session),
+            Some("v=0\r\nm=audio 16000 RTP/AVP 0\r\n")
+        );
     }
 
     #[tokio::test]

--- a/crates/sip/rvoip-sip/src/session_store/state.rs
+++ b/crates/sip/rvoip-sip/src/session_store/state.rs
@@ -234,6 +234,10 @@ pub struct SessionStateCold {
     pub pending_bye_reason: Option<(String, u16, Option<String>)>,
     pub pending_invite_options:
         Option<Arc<crate::api::send::outbound_call::OutboundCallOptionsSnapshot>>,
+    /// Exact body placed on the initial INVITE wire, retained through
+    /// authentication and timer retries until the final response consumes
+    /// the offer/answer exchange.
+    pub(crate) initial_invite_offer_sdp: Option<String>,
     pub pending_reinvite_options:
         Option<Arc<rvoip_sip_dialog::api::unified::ReInviteRequestOptions>>,
     pub pending_register_options:
@@ -590,6 +594,10 @@ impl fmt::Debug for SessionState {
             .field(
                 "pending_invite_options_present",
                 &self.pending_invite_options.is_some(),
+            )
+            .field(
+                "initial_invite_offer_sdp_present",
+                &self.initial_invite_offer_sdp.is_some(),
             )
             .field(
                 "pending_reinvite_options_present",
@@ -968,6 +976,7 @@ impl SessionState {
                 transfer_target_last_progress: None,
                 pending_bye_reason: None,
                 pending_invite_options: None,
+                initial_invite_offer_sdp: None,
                 pending_reinvite_options: None,
                 pending_register_options: None,
                 pending_refer_options: None,
@@ -1138,6 +1147,7 @@ impl SessionState {
     pub(crate) fn clear_pending_request_state_for_final_transition(&mut self) {
         let cold = self.cold.as_ref();
         let needs_clear = cold.pending_invite_options.is_some()
+            || cold.initial_invite_offer_sdp.is_some()
             || !cold.invite_authorization_credentials.is_empty()
             || cold.invite_auth_retry_count != 0
             || cold.pending_auth.is_some()
@@ -1172,6 +1182,7 @@ impl SessionState {
 
         let cold = Arc::make_mut(&mut self.cold);
         cold.pending_invite_options = None;
+        cold.initial_invite_offer_sdp = None;
         cold.invite_authorization_credentials.clear();
         cold.invite_auth_retry_count = 0;
         cold.pending_auth = None;

--- a/crates/sip/rvoip-sip/src/state_machine/actions.rs
+++ b/crates/sip/rvoip-sip/src/state_machine/actions.rs
@@ -2172,6 +2172,7 @@ pub(crate) async fn execute_action(
             // extras OR an outbound proxy is configured (E4 — that path
             // injects the pre-loaded Route header at the adapter layer).
             let use_extra_path = !extras.is_empty() || dialog_adapter.outbound_proxy_uri.is_some();
+            session.initial_invite_offer_sdp = session.local_sdp.clone();
             if !use_extra_path {
                 dialog_adapter
                     .send_invite_with_details(
@@ -2361,28 +2362,34 @@ pub(crate) async fn execute_action(
                 "Following 3xx redirect"
             );
 
-            let (invite_opts, apply_global_proxy) = if let Some(snapshot) =
+            let (invite_opts, apply_global_proxy, exact_offer_sdp) = if let Some(snapshot) =
                 session.pending_invite_options.as_ref()
             {
                 let mut redirected = (**snapshot).clone();
                 redirected.to = next_target.clone();
                 redirected.precomputed_auth = None;
                 let sdp = authoritative_invite_sdp(Some(&redirected), session.local_sdp.as_deref());
-                let (options, suppress_global_proxy) =
-                    materialize_invite_options(&redirected, session.pai_uri.as_deref(), sdp)?;
+                let (options, suppress_global_proxy) = materialize_invite_options(
+                    &redirected,
+                    session.pai_uri.as_deref(),
+                    sdp.clone(),
+                )?;
                 session.pending_invite_options = Some(Arc::new(redirected));
-                (options, !suppress_global_proxy)
+                (options, !suppress_global_proxy, sdp)
             } else {
+                let sdp = session.local_sdp.clone();
                 (
                     rvoip_sip_dialog::api::unified::InviteRequestOptions {
                         from_uri: from,
                         to_uri: next_target,
-                        sdp: session.local_sdp.clone(),
+                        sdp: sdp.clone(),
                         ..Default::default()
                     },
                     true,
+                    sdp,
                 )
             };
+            session.initial_invite_offer_sdp = exact_offer_sdp;
 
             dialog_adapter
                 .send_invite_with_options(&session.session_id, invite_opts, apply_global_proxy)
@@ -3486,10 +3493,9 @@ pub(crate) async fn execute_action(
                 // The builder-supplied body snapshot is the wire authority. SDP
                 // generation may also populate `session.local_sdp`, but an
                 // auth-int retry must hash and retransmit the exact original bytes.
-                let body_owned = authoritative_invite_sdp(
-                    invite_snapshot.as_ref(),
-                    session.local_sdp.as_deref(),
-                );
+                let body_owned = session.initial_invite_offer_sdp.clone().or_else(|| {
+                    authoritative_invite_sdp(invite_snapshot.as_ref(), session.local_sdp.as_deref())
+                });
                 let body_bytes = body_owned.as_deref().map(|s| s.as_bytes());
                 let transport_context =
                     session.pending_auth_transport.clone().unwrap_or_else(|| {
@@ -4192,7 +4198,9 @@ pub(crate) async fn execute_action(
                 .pending_invite_options
                 .as_ref()
                 .map(|snapshot| (**snapshot).clone());
-            let body = authoritative_invite_sdp(snapshot.as_ref(), session.local_sdp.as_deref());
+            let body = session.initial_invite_offer_sdp.clone().or_else(|| {
+                authoritative_invite_sdp(snapshot.as_ref(), session.local_sdp.as_deref())
+            });
             let proxy_target =
                 invite_proxy_protection_target(snapshot.as_ref(), dialog_adapter, &request_uri);
             let mut authorization_headers =
@@ -4958,6 +4966,7 @@ pub(crate) async fn execute_action(
                 // preceding `GenerateLocalSDP` action.
                 let sdp_for_wire =
                     authoritative_invite_sdp(Some(&snapshot), session.local_sdp.as_deref());
+                session.initial_invite_offer_sdp = sdp_for_wire.clone();
 
                 // `with_topology_hiding(true)` is a no-op on the fresh-INVITE
                 // build path (Via/Contact are stamped from scratch); the flag
@@ -5018,6 +5027,7 @@ pub(crate) async fn execute_action(
         // ──────────────────────────────────────────────────────────────
         Action::ClearPendingINVITEOptions => {
             session.pending_invite_options = None;
+            session.initial_invite_offer_sdp = None;
             // Keep the credentials negotiated by the successful initial
             // INVITE for method-specific requests in this exact dialog. BYE,
             // MESSAGE, and other listener-authenticated requests cannot reuse

--- a/crates/sip/rvoip-sip/tests/perf/support/sampler.rs
+++ b/crates/sip/rvoip-sip/tests/perf/support/sampler.rs
@@ -31,8 +31,74 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
+#[cfg(not(target_os = "linux"))]
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tokio::task::JoinHandle;
+
+#[cfg(target_os = "linux")]
+fn linux_proc_constants() -> Option<(u64, u64)> {
+    const AT_PAGESZ: usize = 6;
+    const AT_CLKTCK: usize = 17;
+    let bytes = std::fs::read("/proc/self/auxv").ok()?;
+    let word = std::mem::size_of::<usize>();
+    let mut page_size = None;
+    let mut clock_ticks = None;
+    for pair in bytes.chunks_exact(word * 2) {
+        let (key, value) = pair.split_at(word);
+        let key = usize::from_ne_bytes(key.try_into().ok()?);
+        let value = usize::from_ne_bytes(value.try_into().ok()?);
+        match key {
+            AT_PAGESZ => page_size = Some(value as u64),
+            AT_CLKTCK => clock_ticks = Some(value as u64),
+            0 => break,
+            _ => {}
+        }
+    }
+    Some((page_size?, clock_ticks?))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_sample(
+    started: Instant,
+    page_size: u64,
+    clock_ticks: u64,
+    previous_cpu: &mut Option<(u64, f64)>,
+) -> Option<ResourceSample> {
+    // Reading procfs avoids sysinfo's process-table refresh allocations from
+    // becoming part of the in-process RSS curve being measured.
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages = statm.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+
+    let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+    let (_, fields) = stat.rsplit_once(") ")?;
+    let mut fields = fields.split_whitespace();
+    // fields starts at proc(5) field 3 (`state`); utime/stime are 14/15.
+    let total_ticks = fields.nth(11)?.parse::<u64>().ok()? + fields.next()?.parse::<u64>().ok()?;
+    let t_secs = started.elapsed().as_secs_f64();
+    let cpu_pct = if clock_ticks > 0 {
+        previous_cpu
+            .map(|(prior_ticks, prior_secs)| {
+                let elapsed = t_secs - prior_secs;
+                if elapsed > 0.0 {
+                    ((total_ticks.saturating_sub(prior_ticks) as f64
+                        / clock_ticks as f64
+                        / elapsed)
+                        * 100.0) as f32
+                } else {
+                    0.0
+                }
+            })
+            .unwrap_or(0.0)
+    } else {
+        0.0
+    };
+    *previous_cpu = Some((total_ticks, t_secs));
+    Some(ResourceSample {
+        t_secs,
+        rss_mb: resident_pages as f64 * page_size as f64 / (1024.0 * 1024.0),
+        cpu_pct,
+    })
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ResourceSample {
@@ -205,11 +271,18 @@ impl ResourceSampler {
         let samples_task = Arc::clone(&samples);
         let stop_task = Arc::clone(&stop);
         let started = Instant::now();
+        #[cfg(not(target_os = "linux"))]
         let pid = Pid::from_u32(std::process::id());
         let task_samples_path = samples_path.clone();
 
         let task = tokio::spawn(async move {
+            #[cfg(not(target_os = "linux"))]
             let mut sys = System::new();
+            #[cfg(target_os = "linux")]
+            let mut previous_cpu = None;
+            #[cfg(target_os = "linux")]
+            let (page_size, clock_ticks) =
+                linux_proc_constants().expect("read Linux procfs sampling constants");
             let mut writer = task_samples_path.map(|path| {
                 if let Some(parent) = path.parent() {
                     std::fs::create_dir_all(parent).expect("create resource sample dir");
@@ -217,24 +290,25 @@ impl ResourceSampler {
                 BufWriter::new(File::create(path).expect("create resource sample JSONL"))
             });
             loop {
-                // Refresh CPU + memory for our PID. sysinfo's cpu_usage
-                // is "delta since last refresh of this process", so the
-                // first reading after `new()` is essentially 0; we
-                // still record it (it gets averaged out by subsequent
-                // samples).
-                sys.refresh_processes_specifics(
-                    ProcessesToUpdate::Some(&[pid]),
-                    ProcessRefreshKind::new().with_memory().with_cpu(),
-                );
-                if let Some(proc_) = sys.process(pid) {
-                    let rss_mb = proc_.memory() as f64 / (1024.0 * 1024.0);
-                    let cpu_pct = proc_.cpu_usage();
-                    let t_secs = started.elapsed().as_secs_f64();
-                    let sample = ResourceSample {
-                        t_secs,
-                        rss_mb,
-                        cpu_pct,
-                    };
+                // Refresh CPU + memory for our PID. Both backends report the
+                // first CPU reading as 0 because there is no preceding sample;
+                // it is retained and excluded from the final CPU average.
+                #[cfg(target_os = "linux")]
+                let sample =
+                    linux_process_sample(started, page_size, clock_ticks, &mut previous_cpu);
+                #[cfg(not(target_os = "linux"))]
+                let sample = {
+                    sys.refresh_processes_specifics(
+                        ProcessesToUpdate::Some(&[pid]),
+                        ProcessRefreshKind::new().with_memory().with_cpu(),
+                    );
+                    sys.process(pid).map(|proc_| ResourceSample {
+                        t_secs: started.elapsed().as_secs_f64(),
+                        rss_mb: proc_.memory() as f64 / (1024.0 * 1024.0),
+                        cpu_pct: proc_.cpu_usage(),
+                    })
+                };
+                if let Some(sample) = sample {
                     samples_task
                         .lock()
                         .expect("sampler lock")
@@ -566,6 +640,24 @@ fn linear_slope_mb_per_sec(samples: &[ResourceSample]) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn procfs_sampler_reads_current_process_without_process_table_refresh() {
+        let started = Instant::now();
+        let mut previous_cpu = None;
+        let (page_size, clock_ticks) = linux_proc_constants().expect("procfs constants");
+        let first = linux_process_sample(started, page_size, clock_ticks, &mut previous_cpu)
+            .expect("first procfs sample");
+        std::thread::sleep(Duration::from_millis(2));
+        let second = linux_process_sample(started, page_size, clock_ticks, &mut previous_cpu)
+            .expect("second procfs sample");
+
+        assert!(first.rss_mb > 0.0);
+        assert!(second.rss_mb > 0.0);
+        assert!(second.t_secs >= first.t_secs);
+        assert!(second.cpu_pct.is_finite());
+    }
 
     fn sample(t_secs: f64, rss_mb: f64) -> ResourceSample {
         ResourceSample {

--- a/crates/sip/sip-proxy/tests/interop/scripts/scenario_evidence.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/scenario_evidence.py
@@ -168,8 +168,12 @@ def read_messages(path: Path) -> list[SipMessage]:
     lines = text.splitlines()
     messages: list[SipMessage] = []
     index = 0
+    # SIPp has emitted both `received [577] bytes :` and
+    # `sent (497 bytes):` across supported releases. Accept those wire-log
+    # headings without weakening any of the SIP assertions that follow.
     header = re.compile(
-        r"^(UDP|TCP|TLS) message (sent|received) \[\d+\] bytes:$",
+        r"^(UDP|TCP|TLS) message (sent|received)\s+"
+        r"(?:\[\d+\]\s+bytes|\(\d+\s+bytes\))\s*:$",
         re.IGNORECASE,
     )
     while index < len(lines):

--- a/crates/sip/sip-proxy/tests/interop/scripts/test_scenario_evidence.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/test_scenario_evidence.py
@@ -1189,6 +1189,28 @@ class ScenarioEvidenceTests(unittest.TestCase):
         self.assertEqual(observed["declared_bytes"], len(body))
         self.assertEqual(observed["observed_bytes"], len(body))
 
+    def test_read_messages_accepts_supported_sipp_heading_shapes(self) -> None:
+        wire = (
+            "UDP message received [123] bytes :\n\n"
+            "OPTIONS sip:probe@example.test SIP/2.0\r\n"
+            "CSeq: 1 OPTIONS\r\n\r\n"
+            "--------------------\n"
+            "UDP message sent (98 bytes):\n\n"
+            "SIP/2.0 200 OK\r\n"
+            "CSeq: 1 OPTIONS\r\n\r\n"
+            "--------------------\n"
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "messages.log"
+            path.write_text(wire)
+            messages = scenario_evidence.read_messages(path)
+
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].direction, "received")
+        self.assertTrue(messages[0].start_line.startswith("OPTIONS "))
+        self.assertEqual(messages[1].direction, "sent")
+        self.assertTrue(messages[1].start_line.startswith("SIP/2.0 200 "))
+
     def test_every_udp_advanced_contract_passes_exact_wire_fixture(self) -> None:
         for scenario in sorted(scenario_evidence.UDP_ADVANCED_SCENARIOS):
             with (


### PR DESCRIPTION
## Problem

The exact-candidate non-publishing release qualification exposed four independent failures:

- authenticated initial INVITEs could validate a final answer against a later mutable SDP field instead of the exact offer sent on the wire;
- FreeSWITCH TLS readiness aborted on the first expected `fs_cli` startup miss;
- proxy evidence parsing did not recognize the SIPp heading shape emitted by the remote image, despite packet captures proving the path passed;
- Linux in-process RSS sampling refreshed a process table, making the sampler's allocations part of the curve it was measuring.

## Fix

- retain the exact initial INVITE offer through auth/session-timer retries and consume it for UAC answer validation;
- keep FreeSWITCH readiness polling after a diagnostic `fs_cli` miss;
- accept both supported SIPp message-log heading formats;
- read Linux RSS and CPU counters directly from procfs/auxv, leaving sysinfo as the non-Linux backend.

## Tests

- exact retained initial-offer unit regression: pass
- proxy scenario evidence suite (20 tests): pass
- shell syntax and diff hygiene: pass
- current failed-run proxy artifacts re-evaluated as 1 OPTIONS request, 1 OPTIONS 200, and both expected Via hops
- Linux-specific procfs sampler regression is included for the next non-publishing Linux release qualification

## Risk

The exact offer is retained only for the initial INVITE lifetime and is cleared on final-response and terminal cleanup. No public API changes.

## Related

Preserves the mandatory real-Chromium RFC 4733 regression for BridgeFu/rvoip issue #54; that gate passed in the current full run and remains required.
