### PR TITLE
Fix GCP release qualification failures

### DIFF
--- a/crates/sip/rvoip-sip/examples/pbx/run.sh
+++ b/crates/sip/rvoip-sip/examples/pbx/run.sh
@@ -825,16 +825,24 @@ wait_for_pbx_tls_ready() {
           | sed -n '1,80p' || true
       fi
       if command -v nc >/dev/null 2>&1; then
-        nc -z -w 2 "$host" "$port"
-        nc_rc=$?
+        if nc -z -w 2 "$host" "$port"; then
+          nc_rc=0
+        else
+          nc_rc=$?
+        fi
         echo "nc_rc=$nc_rc"
       else
         nc_rc=0
         echo "nc not found; skipping TCP socket probe"
       fi
       if command -v openssl >/dev/null 2>&1; then
-        printf '' | openssl s_client -connect "$host:$port" -servername "$host" -brief 2>&1 | sed -n '1,80p'
-        openssl_rc=$?
+        if printf '' \
+          | openssl s_client -connect "$host:$port" -servername "$host" -brief 2>&1 \
+          | sed -n '1,80p'; then
+          openssl_rc=0
+        else
+          openssl_rc=$?
+        fi
         echo "openssl_rc=$openssl_rc"
       else
         openssl_rc=0

--- a/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
+++ b/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
@@ -343,6 +343,12 @@ class BetaGateCompatibilitySourceTests(unittest.TestCase):
         self.assertIn("RUN_INITIAL_FAILURES=$(awk", pbx)
         self.assertIn('if [ "$failures" -gt "$RUN_INITIAL_FAILURES" ]; then', pbx)
 
+    def test_pbx_tls_readiness_tolerates_expected_startup_probe_failures(self) -> None:
+        pbx = (CRATE_DIR / "examples/pbx/run.sh").read_text(encoding="utf-8")
+        self.assertIn('if nc -z -w 2 "$host" "$port"; then', pbx)
+        self.assertIn("if printf '' \\\n", pbx)
+        self.assertIn('openssl s_client -connect "$host:$port"', pbx)
+
     def test_all_thirteen_standalone_manifests_are_independent_gates(self) -> None:
         examples = shell_function("run_standalone_example_gates")
         inventory_match = re.search(

--- a/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
+++ b/crates/sip/rvoip-sip/src/adapters/media_adapter.rs
@@ -501,49 +501,39 @@ fn validate_uac_audio_answer(
             return Err(bounded_sdp_failure("remote-answer", "unsupported-payload"));
         }
         if !matches!(payload_type, 13 | 101) {
+            // RFC 3264 permits an answer to retain multiple formats from the
+            // offer. Validate every dynamic primary payload before choosing
+            // the answerer's first (preferred) format for this media session.
+            if payload_type >= 96 {
+                let offer_map = audio_rtpmap(offer, payload_type)
+                    .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-offer-rtpmap"))?;
+                let answer_map = audio_rtpmap(answer, payload_type)
+                    .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-answer-rtpmap"))?;
+                if !offer_map
+                    .encoding_name
+                    .eq_ignore_ascii_case(&answer_map.encoding_name)
+                    || offer_map.clock_rate != answer_map.clock_rate
+                    || offer_map.encoding_params != answer_map.encoding_params
+                {
+                    return Err(bounded_sdp_failure(
+                        "remote-answer",
+                        "changed-dynamic-payload",
+                    ));
+                }
+            }
             primary_payloads.push(payload_type);
         }
     }
-    let payload_type = match primary_payloads.as_slice() {
-        [payload_type] => *payload_type,
-        [] => {
-            return Err(bounded_sdp_failure(
-                "remote-answer",
-                "missing-primary-payload",
-            ))
-        }
-        _ => {
-            return Err(bounded_sdp_failure(
-                "remote-answer",
-                "multiple-primary-payloads",
-            ))
-        }
-    };
+    let payload_type = primary_payloads
+        .first()
+        .copied()
+        .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-primary-payload"))?;
     if !sdp_payload_codec_available(answer, payload_type) {
         return Err(bounded_sdp_failure("remote-answer", "unsupported-payload"));
     }
     let negotiated_annex_b = payload_type == 18 && negotiated_g729_annex_b(answer, g729_annex_b);
     let (codec, clock_rate, channels) =
         negotiated_audio_shape_from_sdp(answer, payload_type, negotiated_annex_b)?;
-
-    // For dynamic payloads the answer must retain the offered codec identity.
-    if payload_type >= 96 {
-        let offer_map = audio_rtpmap(offer, payload_type)
-            .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-offer-rtpmap"))?;
-        let answer_map = audio_rtpmap(answer, payload_type)
-            .ok_or_else(|| bounded_sdp_failure("remote-answer", "missing-answer-rtpmap"))?;
-        if !offer_map
-            .encoding_name
-            .eq_ignore_ascii_case(&answer_map.encoding_name)
-            || offer_map.clock_rate != answer_map.clock_rate
-            || offer_map.encoding_params != answer_map.encoding_params
-        {
-            return Err(bounded_sdp_failure(
-                "remote-answer",
-                "changed-dynamic-payload",
-            ));
-        }
-    }
 
     Ok((payload_type, codec, clock_rate, channels))
 }
@@ -5608,7 +5598,7 @@ a=fmtp:101 0-15\r\n";
     }
 
     #[test]
-    fn uac_answer_requires_one_primary_and_valid_dynamic_mappings() {
+    fn uac_answer_accepts_multiple_offered_primaries_and_validates_dynamic_mappings() {
         let offer = SdpBuilder::new("Session")
             .origin("-", "1", "0", "IN", "IP4", "127.0.0.1")
             .connection("IN", "IP4", "127.0.0.1")
@@ -5622,7 +5612,9 @@ a=fmtp:101 0-15\r\n";
             .build()
             .unwrap();
         let multiple_primary = offer.clone();
-        assert!(validate_uac_audio_answer(&offer, &multiple_primary, true).is_err());
+        let negotiated = validate_uac_audio_answer(&offer, &multiple_primary, true)
+            .expect("an answer may retain multiple offered formats");
+        assert_eq!(negotiated.0, 0, "answer order selects the preferred codec");
 
         let missing_dynamic_map = SdpBuilder::new("Session")
             .origin("-", "2", "0", "IN", "IP4", "127.0.0.1")

--- a/crates/sip/sip-proxy/tests/interop/scripts/run.sh
+++ b/crates/sip/sip-proxy/tests/interop/scripts/run.sh
@@ -803,6 +803,7 @@ validate_scenario_trace_bounds() {
 start_uas() {
   local scenario_file=$1
   local scenario_dir=$2
+  scenario_dir=$(CDPATH= cd -- "$scenario_dir" && pwd)
   local listen_port=${3:-$UAS_PORT}
   local mode
   mode=$(sipp_mode "$current_transport")
@@ -814,7 +815,11 @@ start_uas() {
     -trace_msg -message_file "$scenario_dir/uas-messages.log"
     -trace_stat -stf "$scenario_dir/uas-stats.csv"
   )
-  "$SIPP_BIN" "${sipp_args[@]}" \
+  # SIPp can create a fallback statistics file in its current directory when
+  # it rejects an option before honoring -stf (for example, a low nofile
+  # limit). Keep even those fail-fast artifacts inside the scenario evidence
+  # directory so a failed interop row cannot dirty the source checkout.
+  (cd "$scenario_dir" && exec "$SIPP_BIN" "${sipp_args[@]}") \
     >"$scenario_dir/uas.stdout.log" 2>&1 &
   uas_pid=$!
   sleep 0.25
@@ -828,6 +833,7 @@ start_uas() {
 run_uac() {
   local scenario_file=$1
   local scenario_dir=$2
+  scenario_dir=$(CDPATH= cd -- "$scenario_dir" && pwd)
   local target_host=$3
   local target_port=$4
   local mode
@@ -841,7 +847,7 @@ run_uac() {
     -trace_msg -message_file "$scenario_dir/uac-messages.log"
     -trace_stat -stf "$scenario_dir/uac-stats.csv"
   )
-  "$SIPP_BIN" "${sipp_args[@]}" \
+  (cd "$scenario_dir" && "$SIPP_BIN" "${sipp_args[@]}") \
     >"$scenario_dir/uac.stdout.log" 2>&1
 }
 

--- a/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
@@ -101,6 +101,20 @@ class RunFailStopTests(unittest.TestCase):
             "a timed-out SIPp process must remain row-owned for cleanup",
         )
 
+    def test_sipp_fallback_outputs_are_contained_in_scenario_evidence(self) -> None:
+        self.assertGreaterEqual(
+            self.source.count('scenario_dir=$(CDPATH= cd -- "$scenario_dir" && pwd)'),
+            2,
+        )
+        self.assertIn(
+            '(cd "$scenario_dir" && exec "$SIPP_BIN" "${sipp_args[@]}")',
+            self.source,
+        )
+        self.assertIn(
+            '(cd "$scenario_dir" && "$SIPP_BIN" "${sipp_args[@]}")',
+            self.source,
+        )
+
     def test_failed_peer_shutdown_never_erases_peer_ownership(self) -> None:
         cleanup_start = self.source.index("\ncleanup_row() {")
         cleanup_end = self.source.index("\n}\n\ncleanup_all", cleanup_start)

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -130,6 +130,13 @@ git fetch --depth=1 origin "$CANDIDATE"
 git checkout --detach "$CANDIDATE"
 test "$(git rev-parse HEAD)" = "$CANDIDATE"
 
+# The stock Ubuntu startup service inherits a soft nofile limit of 1024.
+# SIPp and high-density media qualification legitimately require thousands of
+# concurrent sockets, so make the worker limit explicit and fail closed if a
+# future image cannot provide it.
+ulimit -n 262144
+test "$(ulimit -n)" -ge 262144
+
 python3 scripts/release/gates.py run-shard \
   --candidate "$CANDIDATE" \
   --environment-id "$ENVIRONMENT_ID" \

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -87,6 +87,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertGreaterEqual(startup.count("command -v sipp >/dev/null"), 2)
         self.assertIn("command -v tshark >/dev/null", startup)
         self.assertIn("docker compose version >/dev/null", startup)
+        self.assertIn("ulimit -n 262144", startup)
+        self.assertIn('test "$(ulimit -n)" -ge 262144', startup)
         self.assertIn("-name '*.jsonl'", startup)
         self.assertNotRegex(startup, r"apt-get install[^\n]*\bsipp\b")
 


### PR DESCRIPTION
## Problem

The exact-candidate non-publishing qualification on main exposed fail-closed issues in GCP high-density/soak and PBX/proxy interoperability gates.

## Fix

- raise and verify the ephemeral GCP worker open-file limit for real high-density socket workloads
- accept RFC 3264 answers that retain multiple offered primary audio formats while validating dynamic mappings
- tolerate expected early TLS readiness probe misses under fail-fast shell behavior
- contain SIPp fallback output inside per-scenario evidence directories

## Verification

- targeted Rust SDP regression
- workflow policy tests
- beta gate source tests
- proxy fail-stop tests
- shell syntax, formatting, and diff hygiene

## Risk

The GCP change affects only ephemeral release workers and does not lower test load, duration, or thresholds. The SDP change broadens valid answer handling to RFC 3264 behavior while preserving dynamic payload validation.

Follow-up exact-candidate qualification will run with publication disabled and reuse only digest-matching successful evidence from run 30724670050.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SDP answer handling is broader but still validates dynamic rtpmaps; GCP ulimit and shell probe changes affect release/interop paths only, not production runtime.
> 
> **Overview**
> Addresses fail-closed GCP release qualification by raising the ephemeral worker **open-file limit** to 262144 (with a hard check) so high-density SIPp/media gates can open enough sockets.
> 
> **SDP (`media_adapter`)**: UAC remote-answer validation now follows **RFC 3264**—answers may list multiple offered primary audio formats instead of rejecting them; dynamic payloads (≥96) are validated while building the primary list, and negotiation picks the **first** preferred primary. Regression test renamed/updated accordingly.
> 
> **PBX TLS readiness (`run.sh`)**: `nc` and `openssl s_client` probes run inside `if`/`else` so expected startup failures do not trip **`set -e`** before the retry loop finishes.
> 
> **Interop SIPp (`run.sh`)**: Normalizes `scenario_dir` to an absolute path and runs SIPp from that directory so fallback stats/logs stay in per-scenario evidence, not the checkout root.
> 
> **Tests**: New source fences for PBX TLS probes, SIPp containment, and workflow policy expectations for `ulimit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167790a81bdb51b22cc292ba7c3680c6d6992df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->