### PR TITLE
fix(sip): publish established event after inbound ACK

### DIFF
--- a/crates/sip/rvoip-sip/src/adapters/session_event_handler.rs
+++ b/crates/sip/rvoip-sip/src/adapters/session_event_handler.rs
@@ -3538,6 +3538,11 @@ impl SessionCrossCrateEventHandler {
         }
 
         let api_event = match event {
+            crate::state_machine::executor::SessionEvent::CallEstablished { session_id } => {
+                Some(crate::api::events::Event::CallEstablished {
+                    call_id: session_id,
+                })
+            }
             crate::state_machine::executor::SessionEvent::CallCancelled { session_id } => {
                 debug!(
                     "Ignoring state-machine CallCancelled for {}; terminal cancellation is published by the dialog event handler after wire teardown",

--- a/crates/sip/rvoip-sip/src/api/callback_peer.rs
+++ b/crates/sip/rvoip-sip/src/api/callback_peer.rs
@@ -2584,6 +2584,7 @@ impl<H: CallHandler> CallbackPeer<H> {
                 // can also pattern-match on the detailed variant via
                 // `handler.on_event(...)`.
                 | Event::IncomingCallAuthenticated { .. }
+                | Event::CallEstablished { .. }
                 | Event::CallProgressDetailed(_)
                 | Event::CallEstablishedDetailed(_)
                 | Event::CallFailedDetailed(_) => {}

--- a/crates/sip/rvoip-sip/src/api/events.rs
+++ b/crates/sip/rvoip-sip/src/api/events.rs
@@ -399,6 +399,16 @@ pub enum Event {
         sdp: Option<String>,
     },
 
+    /// The INVITE dialog reached the established state.
+    ///
+    /// This role-neutral lifecycle event is emitted for both outgoing and
+    /// incoming calls. On an incoming (UAS) call it is emitted only after the
+    /// caller's ACK commits the `Answering` to `Active` transition.
+    CallEstablished {
+        /// Session identifier for the established call.
+        call_id: CallId,
+    },
+
     /// Provisional call progress response received for an outgoing call.
     ///
     /// Emitted for SIP 1xx responses such as `180 Ringing` and
@@ -877,6 +887,7 @@ impl std::fmt::Debug for Event {
                 .field("sdp_present", &sdp.is_some())
                 .field("sdp_bytes", &sdp.as_ref().map_or(0, String::len))
                 .finish(),
+            Self::CallEstablished { .. } => formatter.write_str("CallEstablished"),
             Self::CallProgress {
                 status_code,
                 reason,
@@ -1156,6 +1167,7 @@ impl Event {
             Event::IncomingCall { call_id, .. }
             | Event::IncomingCallAuthenticated { call_id, .. }
             | Event::CallAnswered { call_id, .. }
+            | Event::CallEstablished { call_id, .. }
             | Event::CallProgress { call_id, .. }
             | Event::CallEnded { call_id, .. }
             | Event::CallFailed { call_id, .. }
@@ -1220,6 +1232,7 @@ impl Event {
             Event::IncomingCall { .. }
                 | Event::IncomingCallAuthenticated { .. }
                 | Event::CallAnswered { .. }
+                | Event::CallEstablished { .. }
                 | Event::CallProgress { .. }
                 | Event::CallEnded { .. }
                 | Event::CallFailed { .. }

--- a/crates/sip/rvoip-sip/tests/event_tests.rs
+++ b/crates/sip/rvoip-sip/tests/event_tests.rs
@@ -230,6 +230,18 @@ fn test_call_on_hold_event() {
 }
 
 #[test]
+fn test_call_established_event() {
+    let id = test_id();
+    let event = Event::CallEstablished {
+        call_id: id.clone(),
+    };
+    assert_eq!(event.call_id(), Some(&id));
+    assert!(event.is_call_event());
+    assert!(!event.is_call_state_event());
+    assert_eq!(format!("{event:?}"), "CallEstablished");
+}
+
+#[test]
 fn test_call_resumed_event() {
     let id = test_id();
     let e = Event::CallResumed {

--- a/crates/sip/rvoip-sip/tests/srtp_call_integration.rs
+++ b/crates/sip/rvoip-sip/tests/srtp_call_integration.rs
@@ -129,6 +129,21 @@ async fn srtp_call_negotiates_and_establishes_end_to_end() {
         _ => unreachable!(),
     }
 
+    // The UAS becomes established only when Alice's ACK reaches Bob. This is
+    // the public lifecycle signal a B2BUA needs before it treats the received
+    // leg as connected.
+    let bob_established = wait_for(&mut bob_events, Duration::from_secs(8), |event| {
+        matches!(
+            event,
+            Event::CallEstablished { call_id } if call_id == &bob_session_id
+        )
+    })
+    .await;
+    assert!(
+        bob_established.is_some(),
+        "bob did not receive CallEstablished after the inbound ACK"
+    );
+
     // Cleanup: hang up both sides and let background tasks settle.
     bob.terminate_current_session().await.ok();
     alice.terminate_current_session().await.ok();


### PR DESCRIPTION
## Summary

- add a role-neutral public `Event::CallEstablished { call_id }`
- translate the internal state-machine `CallEstablished` event into the public event stream
- emit the event for an inbound/UAS call only after its ACK commits the dialog to `Active`
- cover the public event contract and a real end-to-end SRTP call

## Root cause

The UAS state table already published an internal `SessionEvent::CallEstablished` after ACK, but `SessionCrossCrateEventHandler` discarded that variant instead of translating it to the public API. Existing `CallAnswered` and `CallEstablishedDetailed` publication is UAC-specific.

## Impact

Consumers such as BridgeFu can await an authoritative post-ACK established signal for received calls instead of polling session state.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rvoip-sip --test event_tests --test srtp_call_integration -- --test-threads=1`

Closes #71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive public lifecycle API on SIP call setup; wrong timing could mislead B2BUA/bridge consumers, but scope is narrow and covered by integration tests.
> 
> **Overview**
> Adds a **role-neutral** public `Event::CallEstablished { call_id }` so apps can treat a call as fully connected after the INVITE dialog is established—not only via UAC-oriented `CallAnswered` / `CallEstablishedDetailed`.
> 
> `SessionCrossCrateEventHandler` now maps internal `SessionEvent::CallEstablished` to that public variant instead of dropping it. Docs on the variant state that on **incoming (UAS)** calls it fires only after the caller’s ACK commits `Answering` → `Active`. The callback peer treats it like other lifecycle events (no extra routing). `call_id()`, `is_call_event()`, and `Debug` are updated accordingly.
> 
> Unit coverage in `event_tests` and an SRTP integration test assert Bob receives `CallEstablished` after Alice’s ACK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70fc962e5fd44697a9b1ef82b22eacdc29308285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->