### PR TITLE
ci: bound pull request verification fanout

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -241,6 +241,7 @@ jobs:
             --job 'specialty=${{ needs.specialty.result }}' \
             --job 'doctest=${{ needs.doctest.result }}' \
             --required-job doctest \
+            --shard-layout shards \
             --required-receipt doctest
       - name: Upload full main receipt
         if: always()

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -176,6 +176,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix: ${{ fromJSON(needs.plan.outputs.specialty) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -31,6 +31,8 @@ jobs:
       shard_count: ${{ steps.plan.outputs.shard_count }}
       specialty: ${{ steps.plan.outputs.specialty }}
       specialty_count: ${{ steps.plan.outputs.specialty_count }}
+      sip_jobs: ${{ steps.plan.outputs.sip_jobs }}
+      sip_job_count: ${{ steps.plan.outputs.sip_job_count }}
     steps:
       - name: Check out candidate merge
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -55,6 +57,7 @@ jobs:
             --base "$base" \
             --head "$head" \
             --candidate HEAD \
+            --job-mode combined \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Summarize selection
@@ -67,6 +70,7 @@ jobs:
             echo "- Candidate: \`${{ steps.plan.outputs.candidate_sha }}\`"
             echo "- Reason: ${{ steps.plan.outputs.reason }}"
             echo "- Crate shards: ${{ steps.plan.outputs.shard_count }}"
+            echo "- SIP lanes: ${{ steps.plan.outputs.sip_job_count }}"
             echo "- Specialty gates: ${{ steps.plan.outputs.specialty_count }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -228,10 +232,62 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  sip-tests:
+    name: SIP ${{ matrix.id }}
+    needs: plan
+    if: needs.plan.outputs.sip_job_count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.sip_jobs) }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.91.0
+          components: clippy
+
+      - name: Restore SIP lane cache
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          shared-key: pr-sip-${{ matrix.id }}
+
+      - name: Install system dependencies
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          libasound2-dev libopus-dev protobuf-compiler pkg-config cmake lsof
+
+      - name: Test and lint SIP core
+        if: matrix.kind == 'core'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-pr-core
+          --name sip-${{ matrix.id }}
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Run bounded SIP integration partition
+        if: matrix.kind == 'integration'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-integration
+          --name sip-${{ matrix.id }}
+          --targets '${{ matrix.targets_csv }}'
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Upload SIP lane receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pr-evidence-sip-${{ matrix.id }}
+          path: target/ci-receipts/sip-${{ matrix.id }}.json
+          retention-days: 14
+          if-no-files-found: warn
+
   pr-gate:
     name: PR Gate
     if: always()
-    needs: [plan, policy, crate-tests, specialty]
+    needs: [plan, policy, crate-tests, specialty, sip-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -254,7 +310,8 @@ jobs:
             --job 'plan=${{ needs.plan.result }}' \
             --job 'policy=${{ needs.policy.result }}' \
             --job 'crate-tests=${{ needs.crate-tests.result }}' \
-            --job 'specialty=${{ needs.specialty.result }}'
+            --job 'specialty=${{ needs.specialty.result }}' \
+            --job 'sip-tests=${{ needs.sip-tests.result }}'
 
       - name: Publish receipt summary
         if: always()
@@ -267,6 +324,7 @@ jobs:
               echo "- Status: \`$(jq -r .status target/pr-receipt/pr-receipt.json)\`"
               echo "- Mode: \`$(jq -r .plan.mode target/pr-receipt/pr-receipt.json)\`"
               echo "- Selected crates: $(jq '.plan.selected_crates | length' target/pr-receipt/pr-receipt.json)"
+              echo "- SIP lanes: $(jq '.plan.sip_jobs | length' target/pr-receipt/pr-receipt.json)"
               echo "- Specialty gates: $(jq '.plan.specialty_gates | length' target/pr-receipt/pr-receipt.json)"
             } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -113,7 +113,7 @@ jobs:
           if-no-files-found: warn
 
   crate-tests:
-    name: Crate shard ${{ matrix.shard_id }} (${{ matrix.check }})
+    name: Crate shard ${{ matrix.shard_id }} (test + lint)
     needs: plan
     if: needs.plan.outputs.shard_job_count != '0'
     runs-on: ubuntu-latest
@@ -133,26 +133,26 @@ jobs:
       - name: Restore content-addressed Rust cache
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
-          shared-key: pr-shard-${{ matrix.shard_id }}-${{ matrix.check }}
+          shared-key: pr-shard-${{ matrix.shard_id }}
 
       - name: Install system dependencies
         run: >-
           sudo apt-get update && sudo apt-get install -y
           libasound2-dev libopus-dev protobuf-compiler pkg-config cmake lsof
 
-      - name: Run selected crate check
+      - name: Test and lint selected crates on one warm build graph
         run: >-
-          python3 scripts/ci/run_checks.py shard-${{ matrix.check }}
-          --name shard-${{ matrix.shard_id }}-${{ matrix.check }}
+          python3 scripts/ci/run_checks.py shard
+          --name shard-${{ matrix.shard_id }}-all
           --packages '${{ matrix.packages_csv }}'
-          --output target/ci-receipts/shard-${{ matrix.shard_id }}-${{ matrix.check }}.json
+          --output target/ci-receipts/shard-${{ matrix.shard_id }}-all.json
 
       - name: Upload shard receipt
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: pr-evidence-shard-${{ matrix.shard_id }}-${{ matrix.check }}
-          path: target/ci-receipts/shard-${{ matrix.shard_id }}-${{ matrix.check }}.json
+          name: pr-evidence-shard-${{ matrix.shard_id }}-all
+          path: target/ci-receipts/shard-${{ matrix.shard_id }}-all.json
           retention-days: 14
           if-no-files-found: warn
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,11 @@ specialty gates declared for the changed paths. It balances that work into no
 more than four shards and runs tests and Clippy on the same warm build graph.
 Public API changes compile a representative example contract set on the PR;
 the Main Gate still tests all 44 crates, doctests, and every standalone
-example. Changes to shared or unmapped build inputs deliberately select the
-full workspace, while CI-policy-only changes run the planner and policy tests.
+example. The large SIP integration inventory is duration-balanced across
+three PR lanes; its ten-minute audio round-trip target runs on Main Gate and
+release qualification instead of holding every SIP PR open. Changes to shared
+or unmapped build inputs deliberately select the full workspace, while
+CI-policy-only changes run the planner and policy tests.
 
 ## Pull request expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,12 @@ documentation, and focused features are welcome.
 
 You do not need to run the complete release suite on your computer. CI chooses
 the directly affected workspace crates, their reverse dependencies, and any
-specialty gates declared for the changed paths. Changes to shared or unmapped
-build inputs deliberately select the full workspace.
+specialty gates declared for the changed paths. It balances that work into no
+more than four shards and runs tests and Clippy on the same warm build graph.
+Public API changes compile a representative example contract set on the PR;
+the Main Gate still tests all 44 crates, doctests, and every standalone
+example. Changes to shared or unmapped build inputs deliberately select the
+full workspace, while CI-policy-only changes run the planner and policy tests.
 
 ## Pull request expectations
 

--- a/scripts/ci/aggregate_receipts.py
+++ b/scripts/ci/aggregate_receipts.py
@@ -41,6 +41,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--job", action="append", default=[])
     parser.add_argument("--required-job", action="append", default=[])
     parser.add_argument("--required-receipt", action="append", default=[])
+    parser.add_argument(
+        "--shard-layout",
+        choices=("jobs", "shards"),
+        default="jobs",
+        help="validate receipts from shard_jobs or one receipt per shard",
+    )
     args = parser.parse_args(argv)
 
     failures: list[str] = []
@@ -66,11 +72,16 @@ def main(argv: list[str] | None = None) -> int:
             failures.append(f"required job {required} was {jobs.get(required, 'missing')}")
 
     shard_count = len(plan.get("shards", []))
+    sip_count = len(plan.get("sip_jobs", []))
     specialty_count = len(plan.get("specialty_gates", []))
     if shard_count and jobs.get("crate-tests") != "success":
         failures.append(f"crate-tests was {jobs.get('crate-tests', 'missing')}")
     if not shard_count and jobs.get("crate-tests") not in {"skipped", "success"}:
         failures.append(f"unexpected crate-tests result {jobs.get('crate-tests', 'missing')}")
+    if sip_count and jobs.get("sip-tests") != "success":
+        failures.append(f"sip-tests was {jobs.get('sip-tests', 'missing')}")
+    if not sip_count and jobs.get("sip-tests") not in {None, "skipped", "success"}:
+        failures.append(f"unexpected sip-tests result {jobs.get('sip-tests', 'missing')}")
     if specialty_count and jobs.get("specialty") != "success":
         failures.append(f"specialty was {jobs.get('specialty', 'missing')}")
     if not specialty_count and jobs.get("specialty") not in {"skipped", "success"}:
@@ -85,10 +96,11 @@ def main(argv: list[str] | None = None) -> int:
         failures.append("impact plan is missing a 40-character candidate SHA")
     expected = {"policy"}
     shard_jobs = plan.get("shard_jobs")
-    if shard_jobs is None:
+    if args.shard_layout == "shards" or shard_jobs is None:
         expected.update(f"shard-{shard['id']}" for shard in plan.get("shards", []))
     else:
         expected.update(f"shard-{job['shard_id']}-{job['check']}" for job in shard_jobs)
+    expected.update(f"sip-{job['id']}" for job in plan.get("sip_jobs", []))
     expected.update(f"specialty-{gate}" for gate in plan.get("specialty_gates", []))
     expected.update(args.required_receipt)
     missing = sorted(expected - set(by_name))
@@ -125,7 +137,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"- {failure}", file=sys.stderr)
         return 1
     print(
-        f"PR Gate passed: {shard_count} crate shard(s), "
+        f"PR Gate passed: {shard_count} crate shard(s), {sip_count} SIP lane(s), "
         f"{specialty_count} specialty gate(s)."
     )
     return 0

--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -45,6 +45,16 @@
     "06-attended-transfer",
     "11-ai-harness-demo"
   ],
+  "pr_sip_partitions": 3,
+  "pr_deferred_sip_targets": [
+    "audio_roundtrip_integration"
+  ],
+  "pr_sip_target_weights": {
+    "endpoint_unified_auth": 90,
+    "blind_transfer_integration": 55,
+    "bridge_roundtrip_integration": 35,
+    "endpoint_audio_roundtrip_integration": 20
+  },
   "specialty_rules": [
     {
       "gate": "browser-smoke",

--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -40,6 +40,11 @@
     "13-sip-to-amazon-connect",
     "14-vapi-agent"
   ],
+  "pr_example_projects": [
+    "01-quickstart-p2p",
+    "06-attended-transfer",
+    "11-ai-harness-demo"
+  ],
   "specialty_rules": [
     {
       "gate": "browser-smoke",

--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -1,6 +1,6 @@
 {
   "schema": "rvoip-ci-impact-policy-v1",
-  "max_shards": 6,
+  "max_shards": 4,
   "target_shard_weight": 12,
   "full_paths": [
     "Cargo.toml",
@@ -8,9 +8,6 @@
     "rust-toolchain",
     "rust-toolchain.toml",
     ".cargo/**",
-    ".github/workflows/**",
-    "scripts/ci/**",
-    "scripts/test_all.sh",
     "deny.toml"
   ],
   "known_policy_paths": [
@@ -18,6 +15,9 @@
     ".github/dependabot.yml",
     ".github/pull_request_template.md",
     ".github/release.yml",
+    ".github/workflows/**",
+    "scripts/ci/**",
+    "scripts/test_all.sh",
     "CONTRIBUTING.md",
     "SECURITY.md",
     "LICENSE",
@@ -73,6 +73,7 @@
         "scripts/release/**",
         "scripts/release_*.py",
         "scripts/test_release*.py",
+        "infra/release-runners/**",
         "docs/RELEASING.md"
       ]
     },

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -194,6 +194,48 @@ def make_shards(
     return shards
 
 
+def integration_test_targets(metadata: dict[str, Any], package_name: str) -> list[str]:
+    packages = [item for item in metadata.get("packages", []) if item.get("name") == package_name]
+    if len(packages) != 1:
+        raise PlanError(f"expected exactly one {package_name!r} package")
+    targets = []
+    for target in packages[0].get("targets", []):
+        if "test" not in target.get("kind", []) or target.get("required-features", []):
+            continue
+        name = target.get("name", "")
+        if not name or any(not (character.isalnum() or character in "_-") for character in name):
+            raise PlanError(f"unsafe integration target name: {name!r}")
+        targets.append(name)
+    if not targets or len(targets) != len(set(targets)):
+        raise PlanError(f"{package_name} integration target inventory is invalid")
+    return sorted(targets)
+
+
+def partition_named_targets(
+    targets: list[str], count: int, weights: dict[str, Any]
+) -> list[dict[str, Any]]:
+    if count < 1 or count > len(targets):
+        raise PlanError("target partition count is outside the target inventory")
+    partitions = [
+        {"targets": [], "estimated_seconds": 0} for _ in range(count)
+    ]
+    weighted = sorted(
+        ((max(1, int(weights.get(name, 5))), name) for name in targets),
+        key=lambda item: (-item[0], item[1]),
+    )
+    for weight, name in weighted:
+        destination = min(
+            partitions,
+            key=lambda item: (item["estimated_seconds"], len(item["targets"])),
+        )
+        destination["targets"].append(name)
+        destination["estimated_seconds"] += weight
+    for partition in partitions:
+        partition["targets"].sort()
+        partition["targets_csv"] = ",".join(partition["targets"])
+    return partitions
+
+
 def make_plan(
     *,
     root: Path,
@@ -203,7 +245,10 @@ def make_plan(
     base: str,
     head: str,
     candidate: str | None = None,
+    job_mode: str = "split",
 ) -> dict[str, Any]:
+    if job_mode not in {"split", "combined"}:
+        raise PlanError(f"unsupported shard job mode: {job_mode!r}")
     normalized = sorted({normalize_path(path) for path in paths})
     packages = workspace_packages(root, metadata)
     known_policy_paths = set(policy.get("known_policy_paths", []))
@@ -281,17 +326,50 @@ def make_plan(
         selected = reverse_closure(direct, packages)
         reason = "changed crates plus transitive reverse dependencies"
 
-    shards = make_shards(selected, policy)
+    shard_selection = set(selected)
+    sip_jobs: list[dict[str, Any]] = []
+    deferred_sip_targets: list[str] = []
+    if job_mode == "combined" and "rvoip-sip" in shard_selection:
+        shard_selection.remove("rvoip-sip")
+        all_sip_targets = integration_test_targets(metadata, "rvoip-sip")
+        deferred_sip_targets = sorted(set(policy.get("pr_deferred_sip_targets", [])))
+        unknown_deferred = sorted(set(deferred_sip_targets) - set(all_sip_targets))
+        if unknown_deferred:
+            raise PlanError(
+                "unknown deferred SIP test targets: " + ", ".join(unknown_deferred)
+            )
+        runnable_sip_targets = sorted(set(all_sip_targets) - set(deferred_sip_targets))
+        requested_partitions = max(1, int(policy.get("pr_sip_partitions", 3)))
+        partition_count = min(requested_partitions, len(runnable_sip_targets))
+        partitions = partition_named_targets(
+            runnable_sip_targets,
+            partition_count,
+            policy.get("pr_sip_target_weights", {}),
+        )
+        sip_jobs.append({"id": "core", "kind": "core", "targets_csv": ""})
+        sip_jobs.extend(
+            {
+                "id": f"integration-{index}",
+                "kind": "integration",
+                "targets_csv": partition["targets_csv"],
+                "estimated_seconds": partition["estimated_seconds"],
+            }
+            for index, partition in enumerate(partitions, start=1)
+        )
+
+    shards = make_shards(shard_selection, policy)
+    shard_checks = ("all",) if job_mode == "combined" else ("test", "clippy")
     shard_jobs = [
         {
-            "id": f"{shard['id']}-all",
+            "id": f"{shard['id']}-{check}",
             "shard_id": shard["id"],
-            "check": "all",
+            "check": check,
             "packages": shard["packages"],
             "packages_csv": shard["packages_csv"],
             "weight": shard["weight"],
         }
         for shard in shards
+        for check in shard_checks
     ]
     candidate_sha = (
         run(["git", "rev-parse", f"{candidate}^{{commit}}"], root).strip()
@@ -308,10 +386,13 @@ def make_plan(
         "candidate_sha": candidate_sha,
         "mode": mode,
         "reason": reason,
+        "job_mode": job_mode,
         "changed_files": normalized,
         "direct_crates": sorted(direct),
         "selected_crates": sorted(selected),
         "specialty_gates": specialty,
+        "sip_jobs": sip_jobs,
+        "deferred_sip_targets": deferred_sip_targets,
         "shards": shards,
         "shard_jobs": shard_jobs,
     }
@@ -320,6 +401,7 @@ def make_plan(
 def write_github_outputs(path: Path, plan: dict[str, Any]) -> None:
     shard_jobs = {"include": plan["shard_jobs"]}
     shards = {"include": plan["shards"]}
+    sip_jobs = {"include": plan.get("sip_jobs", [])}
     specialty = {"include": [{"gate": gate} for gate in plan["specialty_gates"]]}
     values = {
         "mode": plan["mode"],
@@ -327,6 +409,8 @@ def write_github_outputs(path: Path, plan: dict[str, Any]) -> None:
         "candidate_sha": plan["candidate_sha"] or "",
         "shard_jobs": json.dumps(shard_jobs, separators=(",", ":")),
         "shards": json.dumps(shards, separators=(",", ":")),
+        "sip_jobs": json.dumps(sip_jobs, separators=(",", ":")),
+        "sip_job_count": str(len(plan.get("sip_jobs", []))),
         "shard_job_count": str(len(plan["shard_jobs"])),
         "shard_count": str(len(plan["shards"])),
         "specialty": json.dumps(specialty, separators=(",", ":")),
@@ -352,6 +436,12 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--specialty-gate", action="append", default=[])
     result.add_argument("--metadata-file", type=Path)
     result.add_argument(
+        "--job-mode",
+        choices=("split", "combined"),
+        default="split",
+        help="emit separate test/clippy jobs or one warm combined job per shard",
+    )
+    result.add_argument(
         "--policy", type=Path, default=Path("scripts/ci/policy.json")
     )
     result.add_argument("--output", type=Path, default=Path("target/ci-plan/plan.json"))
@@ -376,6 +466,7 @@ def main(argv: list[str] | None = None) -> int:
             base=args.base,
             head=args.head,
             candidate=args.candidate,
+            job_mode=args.job_mode,
         )
         for gate in args.specialty_gate:
             if not gate or any(character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-" for character in gate):

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -130,7 +130,7 @@ def matches_any(path: str, patterns: Iterable[str]) -> bool:
 
 
 def documentation_path(path: str, known_policy_paths: set[str]) -> bool:
-    if path in known_policy_paths:
+    if matches_any(path, known_policy_paths):
         return True
     if path.startswith("docs/") and path.endswith((".md", ".txt")):
         return True
@@ -220,15 +220,13 @@ def make_plan(
             for project in projects
             if any(path.startswith(f"examples/{project}/") for path in normalized)
         }
-        # An API/facade change can affect every standalone example. A change
-        # contained within examples only needs the directly touched projects.
-        selected_examples = (
-            directly_changed
-            if directly_changed
-            and all(path.startswith("examples/") for path in normalized)
-            else set(projects)
-        )
-        specialty_set.update(f"example--{project}" for project in selected_examples)
+        # Changes contained within examples build only those projects. Public
+        # API/facade changes use one representative contract lane on PRs;
+        # Main Gate still builds every standalone example.
+        if directly_changed and all(path.startswith("examples/") for path in normalized):
+            specialty_set.update(f"example--{project}" for project in directly_changed)
+        else:
+            specialty_set.add("examples-contract")
     specialty = sorted(specialty_set)
 
     full_reasons = [
@@ -258,9 +256,13 @@ def make_plan(
         full_reasons.extend(unknown)
 
     if docs_only:
-        mode = "docs"
+        mode = (
+            "docs"
+            if all(path.endswith((".md", ".txt")) for path in normalized)
+            else "policy"
+        )
         selected: set[str] = set()
-        reason = "documentation and repository policy only"
+        reason = "documentation or repository policy only"
     elif full_reasons:
         mode = "full"
         selected = set(packages)
@@ -273,15 +275,14 @@ def make_plan(
     shards = make_shards(selected, policy)
     shard_jobs = [
         {
-            "id": f"{shard['id']}-{check}",
+            "id": f"{shard['id']}-all",
             "shard_id": shard["id"],
-            "check": check,
+            "check": "all",
             "packages": shard["packages"],
             "packages_csv": shard["packages_csv"],
             "weight": shard["weight"],
         }
         for shard in shards
-        for check in ("test", "clippy")
     ]
     candidate_sha = (
         run(["git", "rev-parse", f"{candidate}^{{commit}}"], root).strip()
@@ -309,12 +310,14 @@ def make_plan(
 
 def write_github_outputs(path: Path, plan: dict[str, Any]) -> None:
     shard_jobs = {"include": plan["shard_jobs"]}
+    shards = {"include": plan["shards"]}
     specialty = {"include": [{"gate": gate} for gate in plan["specialty_gates"]]}
     values = {
         "mode": plan["mode"],
         "reason": plan["reason"],
         "candidate_sha": plan["candidate_sha"] or "",
         "shard_jobs": json.dumps(shard_jobs, separators=(",", ":")),
+        "shards": json.dumps(shards, separators=(",", ":")),
         "shard_job_count": str(len(plan["shard_jobs"])),
         "shard_count": str(len(plan["shards"])),
         "specialty": json.dumps(specialty, separators=(",", ":")),

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -221,12 +221,21 @@ def make_plan(
             if any(path.startswith(f"examples/{project}/") for path in normalized)
         }
         # Changes contained within examples build only those projects. Public
-        # API/facade changes use one representative contract lane on PRs;
-        # Main Gate still builds every standalone example.
+        # API/facade changes use a small representative set in parallel on
+        # PRs; Main Gate still builds every standalone example.
         if directly_changed and all(path.startswith("examples/") for path in normalized):
             specialty_set.update(f"example--{project}" for project in directly_changed)
         else:
-            specialty_set.add("examples-contract")
+            representative_projects = policy.get("pr_example_projects", [])
+            unknown_projects = sorted(set(representative_projects) - set(projects))
+            if not representative_projects or unknown_projects:
+                raise PlanError(
+                    "PR example contract set is empty or unknown: "
+                    + ", ".join(unknown_projects)
+                )
+            specialty_set.update(
+                f"example--{project}" for project in representative_projects
+            )
     specialty = sorted(specialty_set)
 
     full_reasons = [

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -191,30 +191,6 @@ def specialty_commands(
         return [
             (["cargo", "build", "--manifest-path", str(manifest), "--locked"], None, None)
         ]
-    if gate == "examples-contract":
-        # A bounded cross-section for public facade/API compatibility on PRs.
-        # Main Gate builds all standalone examples before code can qualify for
-        # a release.
-        representative_examples = (
-            "01-quickstart-p2p",
-            "06-attended-transfer",
-            "11-ai-harness-demo",
-            "13-sip-to-amazon-connect",
-        )
-        return [
-            (
-                [
-                    "cargo",
-                    "build",
-                    "--manifest-path",
-                    str(root / "examples" / example / "Cargo.toml"),
-                    "--locked",
-                ],
-                None,
-                None,
-            )
-            for example in representative_examples
-        ]
     if gate == "examples-smoke":
         smoke_examples = (
             "01-quickstart-p2p",

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -191,6 +191,30 @@ def specialty_commands(
         return [
             (["cargo", "build", "--manifest-path", str(manifest), "--locked"], None, None)
         ]
+    if gate == "examples-contract":
+        # A bounded cross-section for public facade/API compatibility on PRs.
+        # Main Gate builds all standalone examples before code can qualify for
+        # a release.
+        representative_examples = (
+            "01-quickstart-p2p",
+            "06-attended-transfer",
+            "11-ai-harness-demo",
+            "13-sip-to-amazon-connect",
+        )
+        return [
+            (
+                [
+                    "cargo",
+                    "build",
+                    "--manifest-path",
+                    str(root / "examples" / example / "Cargo.toml"),
+                    "--locked",
+                ],
+                None,
+                None,
+            )
+            for example in representative_examples
+        ]
     if gate == "examples-smoke":
         smoke_examples = (
             "01-quickstart-p2p",

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -166,6 +166,13 @@ def sip_core_commands() -> list[tuple[list[str], Path | None, dict[str, str] | N
     ]
 
 
+def sip_pr_core_commands() -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
+    return [
+        *sip_core_commands(),
+        (["cargo", "clippy", "--locked", "-p", "rvoip-sip", "--all-targets"], None, None),
+    ]
+
+
 def sip_integration_commands(
     targets_csv: str,
 ) -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
@@ -460,6 +467,7 @@ def main(argv: list[str] | None = None) -> int:
             "specialty",
             "doctest",
             "sip-core",
+            "sip-pr-core",
             "sip-integration",
         ),
     )
@@ -488,6 +496,8 @@ def main(argv: list[str] | None = None) -> int:
             ]
         elif args.kind == "sip-core":
             commands = sip_core_commands()
+        elif args.kind == "sip-pr-core":
+            commands = sip_pr_core_commands()
         elif args.kind == "sip-integration":
             commands = sip_integration_commands(args.targets)
         else:

--- a/scripts/ci/test_aggregate_receipts.py
+++ b/scripts/ci/test_aggregate_receipts.py
@@ -29,7 +29,7 @@ class AggregateTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp.cleanup()
 
-    def write_plan(self, *, shards=None, shard_jobs=None, specialty=None) -> None:
+    def write_plan(self, *, shards=None, shard_jobs=None, specialty=None, sip_jobs=None) -> None:
         self.plan.write_text(
             json.dumps(
                 {
@@ -38,6 +38,7 @@ class AggregateTests(unittest.TestCase):
                     "shards": shards or [],
                     "shard_jobs": shard_jobs if shard_jobs is not None else [],
                     "specialty_gates": specialty or [],
+                    "sip_jobs": sip_jobs or [],
                 }
             )
         )
@@ -54,7 +55,7 @@ class AggregateTests(unittest.TestCase):
             )
         )
 
-    def invoke(self, *jobs: str) -> int:
+    def invoke(self, *jobs: str, shard_layout: str = "jobs") -> int:
         argv = [
             "--plan",
             str(self.plan),
@@ -62,9 +63,13 @@ class AggregateTests(unittest.TestCase):
             str(self.evidence),
             "--output",
             str(self.output),
+            "--shard-layout",
+            shard_layout,
         ]
         for job in jobs:
             argv.extend(["--job", job])
+        if not any(job.startswith("sip-tests=") for job in jobs):
+            argv.extend(["--job", "sip-tests=skipped"])
         return aggregate.main(argv)
 
     def test_docs_plan_accepts_skipped_matrix_jobs(self) -> None:
@@ -128,6 +133,43 @@ class AggregateTests(unittest.TestCase):
             1,
         )
         self.assertIn("instead of", json.loads(self.output.read_text())["failures"][0])
+
+    def test_main_layout_accepts_one_combined_receipt_per_shard(self) -> None:
+        self.write_plan(
+            shards=[{"id": "1"}],
+            shard_jobs=[
+                {"shard_id": "1", "check": "test"},
+                {"shard_id": "1", "check": "clippy"},
+            ],
+        )
+        self.write_receipt("policy")
+        self.write_receipt("shard-1")
+        self.assertEqual(
+            self.invoke(
+                "plan=success",
+                "policy=success",
+                "crate-tests=success",
+                "specialty=skipped",
+                shard_layout="shards",
+            ),
+            0,
+        )
+
+    def test_sip_lanes_are_required_and_bound_to_the_candidate(self) -> None:
+        self.write_plan(sip_jobs=[{"id": "core"}, {"id": "integration-1"}])
+        self.write_receipt("policy")
+        self.write_receipt("sip-core")
+        self.write_receipt("sip-integration-1")
+        self.assertEqual(
+            self.invoke(
+                "plan=success",
+                "policy=success",
+                "crate-tests=skipped",
+                "specialty=skipped",
+                "sip-tests=success",
+            ),
+            0,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -50,12 +50,14 @@ class PlannerTests(unittest.TestCase):
         self.policy = {
             "max_shards": 3,
             "target_shard_weight": 3,
-            "full_paths": ["Cargo.toml", "Cargo.lock", "scripts/ci/**"],
-            "known_policy_paths": ["README.md"],
+            "full_paths": ["Cargo.toml", "Cargo.lock"],
+            "known_policy_paths": ["README.md", ".github/workflows/**", "scripts/ci/**"],
             "specialty_rules": [
-                {"gate": "browser-smoke", "patterns": ["tests/browser/**"]}
+                {"gate": "browser-smoke", "patterns": ["tests/browser/**"]},
+                {"gate": "examples", "patterns": ["examples/**", "crates/delta/src/api/**"]},
+                {"gate": "release-tooling", "patterns": ["infra/release/**"]},
             ],
-            "example_projects": [],
+            "example_projects": ["one", "two"],
             "package_weights": {"alpha": 3, "beta": 2},
         }
 
@@ -89,12 +91,23 @@ class PlannerTests(unittest.TestCase):
         self.assertEqual(plan["shards"], [])
         self.assertEqual(plan["shard_jobs"], [])
 
-    def test_root_lockfile_and_planner_changes_select_full_workspace(self) -> None:
-        for path in ("Cargo.lock", "scripts/ci/policy.json"):
+    def test_root_manifest_and_lockfile_select_full_workspace(self) -> None:
+        for path in ("Cargo.toml", "Cargo.lock"):
             with self.subTest(path=path):
                 plan = self.plan(path)
                 self.assertEqual(plan["mode"], "full")
                 self.assertEqual(set(plan["selected_crates"]), {"alpha", "beta", "gamma", "delta"})
+
+    def test_ci_only_change_runs_policy_without_workspace_crates(self) -> None:
+        plan = self.plan("scripts/ci/pr_plan.py", ".github/workflows/pr-gate.yml")
+        self.assertEqual(plan["mode"], "policy")
+        self.assertEqual(plan["selected_crates"], [])
+        self.assertEqual(plan["shard_jobs"], [])
+
+    def test_ci_and_crate_change_remains_targeted(self) -> None:
+        plan = self.plan("scripts/ci/pr_plan.py", "crates/delta/src/lib.rs")
+        self.assertEqual(plan["mode"], "targeted")
+        self.assertEqual(plan["selected_crates"], ["delta"])
 
     def test_unmapped_source_path_fails_safe_to_full(self) -> None:
         plan = self.plan("crates/removed-crate/src/lib.rs")
@@ -106,6 +119,12 @@ class PlannerTests(unittest.TestCase):
         self.assertEqual(plan["mode"], "targeted")
         self.assertEqual(plan["selected_crates"], [])
         self.assertEqual(plan["specialty_gates"], ["browser-smoke"])
+
+    def test_release_runner_path_uses_specialty_instead_of_full_workspace(self) -> None:
+        plan = self.plan("infra/release/startup.sh")
+        self.assertEqual(plan["mode"], "targeted")
+        self.assertEqual(plan["selected_crates"], [])
+        self.assertEqual(plan["specialty_gates"], ["release-tooling"])
 
     def test_rename_records_old_and_new_paths(self) -> None:
         payload = b"R100\0crates/alpha/old.rs\0crates/beta/new.rs\0D\0crates/delta/gone.rs\0"
@@ -122,12 +141,11 @@ class PlannerTests(unittest.TestCase):
         self.assertEqual(sorted(flattened), ["alpha", "beta", "delta", "gamma"])
         self.assertLessEqual(len(first), 3)
 
-    def test_each_shard_has_parallel_test_and_clippy_jobs(self) -> None:
+    def test_each_shard_has_one_combined_test_and_clippy_job(self) -> None:
         plan = self.plan("Cargo.lock")
         expected = {
-            (shard["id"], check, shard["packages_csv"])
+            (shard["id"], "all", shard["packages_csv"])
             for shard in plan["shards"]
-            for check in ("test", "clippy")
         }
         actual = {
             (job["shard_id"], job["check"], job["packages_csv"])
@@ -142,8 +160,18 @@ class PlannerTests(unittest.TestCase):
         values = dict(line.split("=", 1) for line in path.read_text().splitlines())
         self.assertEqual(values["mode"], "targeted")
         jobs = json.loads(values["shard_jobs"])["include"]
-        self.assertEqual({job["check"] for job in jobs}, {"test", "clippy"})
+        self.assertEqual({job["check"] for job in jobs}, {"all"})
         self.assertTrue(all(job["packages"] == ["delta"] for job in jobs))
+        shards = json.loads(values["shards"])["include"]
+        self.assertEqual(shards, plan["shards"])
+
+    def test_public_api_change_uses_bounded_example_contract_lane(self) -> None:
+        plan = self.plan("crates/delta/src/api/client.rs")
+        self.assertEqual(plan["specialty_gates"], ["examples-contract"])
+
+    def test_example_only_change_builds_only_touched_project(self) -> None:
+        plan = self.plan("examples/two/src/main.rs")
+        self.assertEqual(plan["specialty_gates"], ["example--two"])
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import copy
 import json
 from pathlib import Path
 import sys
@@ -65,7 +66,7 @@ class PlannerTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp.cleanup()
 
-    def plan(self, *paths: str):
+    def plan(self, *paths: str, job_mode: str = "combined"):
         return pr_plan.make_plan(
             root=self.root,
             metadata=self.metadata,
@@ -74,6 +75,7 @@ class PlannerTests(unittest.TestCase):
             base="base",
             head="head",
             candidate=None,
+            job_mode=job_mode,
         )
 
     def test_direct_change_selects_all_reverse_dependency_kinds(self) -> None:
@@ -154,6 +156,13 @@ class PlannerTests(unittest.TestCase):
         }
         self.assertEqual(actual, expected)
 
+    def test_split_jobs_remain_available_for_gcp_workspace_workers(self) -> None:
+        plan = self.plan("Cargo.lock", job_mode="split")
+        self.assertEqual(
+            {job["check"] for job in plan["shard_jobs"]},
+            {"test", "clippy"},
+        )
+
     def test_github_outputs_are_single_line_json(self) -> None:
         path = self.root / "github-output"
         plan = self.plan("crates/delta/src/lib.rs")
@@ -165,6 +174,8 @@ class PlannerTests(unittest.TestCase):
         self.assertTrue(all(job["packages"] == ["delta"] for job in jobs))
         shards = json.loads(values["shards"])["include"]
         self.assertEqual(shards, plan["shards"])
+        self.assertEqual(values["sip_job_count"], "0")
+        self.assertEqual(json.loads(values["sip_jobs"])["include"], [])
 
     def test_public_api_change_uses_bounded_example_contract_set(self) -> None:
         plan = self.plan("crates/delta/src/api/client.rs")
@@ -178,6 +189,48 @@ class PlannerTests(unittest.TestCase):
         self.policy["pr_example_projects"] = ["missing"]
         with self.assertRaises(pr_plan.PlanError):
             self.plan("crates/delta/src/api/client.rs")
+
+    def test_sip_uses_partitioned_pr_lanes_and_defers_declared_long_target(self) -> None:
+        metadata = copy.deepcopy(self.metadata)
+        package_root = self.root / "crates" / "rvoip-sip"
+        package_root.mkdir(parents=True)
+        manifest = package_root / "Cargo.toml"
+        manifest.write_text("[package]\nname = 'rvoip-sip'\n")
+        package_id = f"path+file://{package_root}#rvoip-sip@1.0.0"
+        metadata["workspace_members"].append(package_id)
+        metadata["packages"].append(
+            {
+                "id": package_id,
+                "name": "rvoip-sip",
+                "manifest_path": str(manifest),
+                "dependencies": [],
+                "targets": [
+                    {"name": "rvoip_sip", "kind": ["lib"]},
+                    {"name": "audio_roundtrip_integration", "kind": ["test"]},
+                    {"name": "event_tests", "kind": ["test"]},
+                    {"name": "srtp_call_integration", "kind": ["test"]},
+                ],
+            }
+        )
+        policy = copy.deepcopy(self.policy)
+        policy["pr_deferred_sip_targets"] = ["audio_roundtrip_integration"]
+        policy["pr_sip_partitions"] = 2
+        plan = pr_plan.make_plan(
+            root=self.root,
+            metadata=metadata,
+            policy=policy,
+            paths=["crates/rvoip-sip/src/lib.rs"],
+            base="base",
+            head="head",
+            candidate=None,
+            job_mode="combined",
+        )
+        self.assertEqual(plan["deferred_sip_targets"], ["audio_roundtrip_integration"])
+        self.assertEqual([job["id"] for job in plan["sip_jobs"]], ["core", "integration-1", "integration-2"])
+        self.assertNotIn(
+            "rvoip-sip",
+            [package for shard in plan["shards"] for package in shard["packages"]],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -58,6 +58,7 @@ class PlannerTests(unittest.TestCase):
                 {"gate": "release-tooling", "patterns": ["infra/release/**"]},
             ],
             "example_projects": ["one", "two"],
+            "pr_example_projects": ["one"],
             "package_weights": {"alpha": 3, "beta": 2},
         }
 
@@ -165,13 +166,18 @@ class PlannerTests(unittest.TestCase):
         shards = json.loads(values["shards"])["include"]
         self.assertEqual(shards, plan["shards"])
 
-    def test_public_api_change_uses_bounded_example_contract_lane(self) -> None:
+    def test_public_api_change_uses_bounded_example_contract_set(self) -> None:
         plan = self.plan("crates/delta/src/api/client.rs")
-        self.assertEqual(plan["specialty_gates"], ["examples-contract"])
+        self.assertEqual(plan["specialty_gates"], ["example--one"])
 
     def test_example_only_change_builds_only_touched_project(self) -> None:
         plan = self.plan("examples/two/src/main.rs")
         self.assertEqual(plan["specialty_gates"], ["example--two"])
+
+    def test_invalid_pr_example_contract_set_fails_closed(self) -> None:
+        self.policy["pr_example_projects"] = ["missing"]
+        with self.assertRaises(pr_plan.PlanError):
+            self.plan("crates/delta/src/api/client.rs")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -60,15 +60,6 @@ class RunChecksTests(unittest.TestCase):
             5,
         )
 
-    def test_example_contract_is_one_bounded_representative_lane(self) -> None:
-        commands = run_checks.specialty_commands("examples-contract", Path("/workspace"))
-        manifests = [command[0][command[0].index("--manifest-path") + 1] for command in commands]
-        self.assertEqual(len(manifests), 4)
-        self.assertTrue(any("01-quickstart-p2p" in manifest for manifest in manifests))
-        self.assertTrue(any("06-attended-transfer" in manifest for manifest in manifests))
-        self.assertTrue(any("11-ai-harness-demo" in manifest for manifest in manifests))
-        self.assertTrue(any("13-sip-to-amazon-connect" in manifest for manifest in manifests))
-
     def test_vcon_gate_contains_live_store_and_boundary_checks(self) -> None:
         commands = run_checks.specialty_commands("vcon-postgres", Path("/workspace"))
         argv = [item[0] for item in commands]

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -47,6 +47,12 @@ class RunChecksTests(unittest.TestCase):
             ],
         )
 
+    def test_pr_sip_core_reuses_build_before_clippy(self) -> None:
+        commands = run_checks.sip_pr_core_commands()
+        self.assertEqual(commands[0][0][0:2], ["cargo", "test"])
+        self.assertEqual(commands[1][0][0:2], ["cargo", "clippy"])
+        self.assertIn("--all-targets", commands[1][0])
+
     def test_sip_target_arguments_reject_shell_metacharacters(self) -> None:
         with self.assertRaises(run_checks.CheckError):
             run_checks.sip_integration_commands("safe; touch compromised")

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -60,6 +60,15 @@ class RunChecksTests(unittest.TestCase):
             5,
         )
 
+    def test_example_contract_is_one_bounded_representative_lane(self) -> None:
+        commands = run_checks.specialty_commands("examples-contract", Path("/workspace"))
+        manifests = [command[0][command[0].index("--manifest-path") + 1] for command in commands]
+        self.assertEqual(len(manifests), 4)
+        self.assertTrue(any("01-quickstart-p2p" in manifest for manifest in manifests))
+        self.assertTrue(any("06-attended-transfer" in manifest for manifest in manifests))
+        self.assertTrue(any("11-ai-harness-demo" in manifest for manifest in manifests))
+        self.assertTrue(any("13-sip-to-amazon-connect" in manifest for manifest in manifests))
+
     def test_vcon_gate_contains_live_store_and_boundary_checks(self) -> None:
         commands = run_checks.specialty_commands("vcon-postgres", Path("/workspace"))
         argv = [item[0] for item in commands]

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -26,6 +26,12 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn("contents: write", text)
         self.assertNotIn("pull_request_target", text)
 
+    def test_pr_gate_reuses_each_shard_build_for_tests_and_lint(self) -> None:
+        text = (ROOT / ".github/workflows/pr-gate.yml").read_text()
+        self.assertIn("run_checks.py shard", text)
+        self.assertIn("shard-${{ matrix.shard_id }}-all", text)
+        self.assertNotIn("run_checks.py shard-${{ matrix.check }}", text)
+
     def test_main_release_tooling_installs_its_fuzz_toolchain(self) -> None:
         text = (ROOT / ".github/workflows/main-ci.yml").read_text()
         specialty = text.split("\n  specialty:\n", maxsplit=1)[1].split(

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -46,6 +46,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("Install nightly for release fuzz validation", specialty)
         self.assertIn("cargo-fuzz@0.13.2", specialty)
         self.assertGreaterEqual(specialty.count("matrix.gate == 'release-tooling'"), 2)
+        self.assertIn("max-parallel: 6", specialty)
 
     def test_parallel_gcp_workspace_is_ephemeral_and_fail_closed(self) -> None:
         workflow = (ROOT / ".github/workflows/gcp-qualification-pilot.yml").read_text()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -31,6 +31,12 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("run_checks.py shard", text)
         self.assertIn("shard-${{ matrix.shard_id }}-all", text)
         self.assertNotIn("run_checks.py shard-${{ matrix.check }}", text)
+        self.assertIn("sip-pr-core", text)
+        self.assertIn("sip-integration", text)
+
+    def test_main_aggregates_one_receipt_per_combined_shard(self) -> None:
+        text = (ROOT / ".github/workflows/main-ci.yml").read_text()
+        self.assertIn("--shard-layout shards", text)
 
     def test_main_release_tooling_installs_its_fuzz_toolchain(self) -> None:
         text = (ROOT / ".github/workflows/main-ci.yml").read_text()


### PR DESCRIPTION
## Problem

Small pull requests currently expand into enough independent Actions jobs to exhaust the hosted-runner concurrency pool. PR #120 produced 24 matrix jobs, and its unpartitioned SIP test lane was still running after 18 minutes.

## Change

- cap ordinary affected-crate work at four shards;
- run tests and Clippy serially on the same warm shard build graph;
- split the large SIP inventory into one core lane and three duration-balanced integration lanes;
- defer the ten-minute audio round-trip target to exhaustive Main Gate and release qualification;
- replace all-example PR fanout with three representative example builds in parallel;
- keep all-example, all-crate, doctest, feature, and specialty coverage on Main Gate;
- treat CI-policy-only changes as policy tests instead of a 44-crate build;
- map release-runner infrastructure to the release-tooling specialty gate;
- fix Main Gate receipt reconciliation and its missing shard output;
- add planner, command, receipt, and workflow-policy regression tests.

## Verification

- 45 CI planner/receipt/workflow tests pass.
- Formatting, JSON validation, workflow YAML parsing, and diff hygiene pass.
- Replanning PR #120 creates four ordinary shards, four SIP lanes, three example contracts, and policy: 12 peak jobs instead of 25, with long work partitioned.
- Replanning PR #121 changes it from a full 44-crate selection to targeted lanes plus release-tooling.
- Default split planner output remains compatible with the GCP workspace pilot.

## Risk

Main Gate remains exhaustive before release qualification. The deferred SIP target is not waived: it runs after merge and again for the exact release candidate. Performance and soak requirements remain on dedicated GCP workers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PRs run less SIP and example coverage than before merge (deferred integration target and representative examples), so regressions could slip until Main Gate; planner/receipt contract changes could false-fail or false-pass gates if misconfigured.
> 
> **Overview**
> **Reduces PR Actions job fanout** by capping crate shards at four, merging per-shard **test + Clippy** into one warm-graph job (`--job-mode combined`), and adding dedicated **SIP lanes** (core + duration-balanced integration partitions) instead of pulling all of `rvoip-sip` through crate shards.
> 
> **PR selection policy** now treats CI-only edits as **policy** runs (planner/policy tests, no 44-crate build), moves workflow/CI paths out of full-workspace triggers, uses **three representative example builds** for public API–driven example gates (full example matrix stays on Main Gate), and **defers** the long `audio_roundtrip_integration` SIP target to Main Gate/release. **Receipt reconciliation** expects SIP lane receipts, supports one combined receipt per shard on Main Gate (`--shard-layout shards`), and the PR gate wires in the new `sip-tests` matrix; Main Gate specialty jobs get **`max-parallel: 6`**.
> 
> `CONTRIBUTING.md` and CI unit/workflow-policy tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e9e30a36e0e886da6143478e584021b110d47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->