### PR TITLE
ci: deduplicate SIP fixture builds

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -260,11 +260,27 @@ jobs:
           sudo apt-get update && sudo apt-get install -y
           libasound2-dev libopus-dev protobuf-compiler pkg-config cmake lsof
 
-      - name: Test and lint SIP core
-        if: matrix.kind == 'core'
+      - name: Test SIP library, binaries, and examples
+        if: matrix.kind == 'core-test'
         run: >-
-          python3 scripts/ci/run_checks.py sip-pr-core
+          python3 scripts/ci/run_checks.py sip-core
           --name sip-${{ matrix.id }}
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Lint every SIP target
+        if: matrix.kind == 'clippy'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-clippy
+          --name sip-${{ matrix.id }}
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Build and run SIP process fixtures once
+        if: matrix.kind == 'fixtures'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-fixtures
+          --name sip-${{ matrix.id }}
+          --targets '${{ matrix.targets_csv }}'
+          --examples '${{ matrix.examples_csv }}'
           --output target/ci-receipts/sip-${{ matrix.id }}.json
 
       - name: Run bounded SIP integration partition

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,12 @@ more than four shards and runs tests and Clippy on the same warm build graph.
 Public API changes compile a representative example contract set on the PR;
 the Main Gate still tests all 44 crates, doctests, and every standalone
 example. The large SIP integration inventory is duration-balanced across
-three PR lanes; its ten-minute audio round-trip target runs on Main Gate and
-release qualification instead of holding every SIP PR open. Changes to shared
-or unmapped build inputs deliberately select the full workspace, while
-CI-policy-only changes run the planner and policy tests.
+bounded PR lanes. Process-based fixtures share one cache-backed lane so their
+example binaries are built once, while SIP core tests and Clippy run in
+parallel. The ten-minute audio round-trip target runs on Main Gate and release
+qualification instead of holding every SIP PR open. Changes to shared or
+unmapped build inputs deliberately select the full workspace, while CI-policy-
+only changes run the planner and policy tests.
 
 ## Pull request expectations
 

--- a/crates/sip/rvoip-sip/tests/support/mod.rs
+++ b/crates/sip/rvoip-sip/tests/support/mod.rs
@@ -42,6 +42,7 @@ pub use traces::{
 };
 
 const ISOLATED_EXAMPLE_TARGET: &str = "rvoip-sip-integration-examples";
+const PREBUILT_EXAMPLE_DIR_ENV: &str = "RVOIP_SIP_PREBUILT_EXAMPLE_DIR";
 
 fn cargo_bin() -> String {
     env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
@@ -62,10 +63,30 @@ pub fn isolated_example_target_dir() -> PathBuf {
     outer_target_dir.join(ISOLATED_EXAMPLE_TARGET)
 }
 
+fn prebuilt_example_dir() -> Option<PathBuf> {
+    env::var_os(PREBUILT_EXAMPLE_DIR_ENV).map(PathBuf::from)
+}
+
+fn example_path(directory: &Path, name: &str) -> PathBuf {
+    directory.join(format!("{name}{}", env::consts::EXE_SUFFIX))
+}
+
 /// Build the named process-fixture examples without contending on the outer
 /// `cargo test` target lock.
 pub fn build_examples(names: &[&str]) {
     assert!(!names.is_empty(), "at least one example must be requested");
+
+    if let Some(directory) = prebuilt_example_dir() {
+        for name in names {
+            let binary = example_path(&directory, name);
+            assert!(
+                binary.is_file(),
+                "prebuilt example binary is missing: {}",
+                binary.display()
+            );
+        }
+        return;
+    }
 
     let target_dir = isolated_example_target_dir();
     let mut command = Command::new(cargo_bin());
@@ -88,10 +109,9 @@ pub fn build_examples(names: &[&str]) {
 
 /// Resolve one example produced by [`build_examples`] for direct execution.
 pub fn example_binary(name: &str) -> PathBuf {
-    let binary = isolated_example_target_dir()
-        .join("debug")
-        .join("examples")
-        .join(format!("{name}{}", env::consts::EXE_SUFFIX));
+    let directory = prebuilt_example_dir()
+        .unwrap_or_else(|| isolated_example_target_dir().join("debug").join("examples"));
+    let binary = example_path(&directory, name);
     assert!(
         binary.is_file(),
         "built example binary is missing: {}",

--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -49,11 +49,52 @@
   "pr_deferred_sip_targets": [
     "audio_roundtrip_integration"
   ],
+  "pr_sip_fixture_examples": {
+    "audio_roundtrip_integration": [
+      "stream_peer_audio_alice",
+      "stream_peer_audio_bob"
+    ],
+    "blind_transfer_integration": [
+      "stream_peer_blind_transfer_alice",
+      "stream_peer_blind_transfer_bob",
+      "stream_peer_blind_transfer_charlie"
+    ],
+    "bridge_roundtrip_integration": [
+      "unified_b2bua_bridge_alice",
+      "unified_b2bua_bridge_carol",
+      "unified_b2bua_bridge_peer"
+    ],
+    "cancel_integration": [
+      "regression_cancel_alice",
+      "regression_cancel_bob"
+    ],
+    "endpoint_audio_roundtrip_integration": [
+      "endpoint_audio_roundtrip"
+    ],
+    "glare_retry_integration": [
+      "regression_glare_retry_alice",
+      "regression_glare_retry_bob"
+    ],
+    "notify_send_integration": [
+      "regression_notify_send_alice",
+      "regression_notify_send_bob"
+    ],
+    "prack_integration": [
+      "regression_prack_alice",
+      "regression_prack_bob"
+    ],
+    "session_timer_failure_integration": [
+      "regression_session_timer_failure_alice",
+      "regression_session_timer_failure_bob"
+    ],
+    "session_timer_integration": [
+      "regression_session_timer_alice",
+      "regression_session_timer_bob"
+    ]
+  },
   "pr_sip_target_weights": {
     "endpoint_unified_auth": 90,
-    "blind_transfer_integration": 55,
-    "bridge_roundtrip_integration": 35,
-    "endpoint_audio_roundtrip_integration": 20
+    "invite_planner_retention_qualification": 20
   },
   "specialty_rules": [
     {

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -338,15 +338,71 @@ def make_plan(
             raise PlanError(
                 "unknown deferred SIP test targets: " + ", ".join(unknown_deferred)
             )
-        runnable_sip_targets = sorted(set(all_sip_targets) - set(deferred_sip_targets))
+        fixture_examples = policy.get("pr_sip_fixture_examples", {})
+        if not isinstance(fixture_examples, dict):
+            raise PlanError("pr_sip_fixture_examples must be an object")
+        unknown_fixture_targets = sorted(set(fixture_examples) - set(all_sip_targets))
+        if unknown_fixture_targets:
+            raise PlanError(
+                "unknown SIP process-fixture targets: "
+                + ", ".join(unknown_fixture_targets)
+            )
+        for target, examples in fixture_examples.items():
+            if (
+                not isinstance(examples, list)
+                or not examples
+                or any(
+                    not isinstance(example, str)
+                    or not example
+                    or any(
+                        not (character.isalnum() or character in "_-")
+                        for character in example
+                    )
+                    for example in examples
+                )
+            ):
+                raise PlanError(
+                    f"SIP process-fixture target {target!r} has invalid examples"
+                )
+        runnable_sip_targets = set(all_sip_targets) - set(deferred_sip_targets)
+        fixture_targets = sorted(runnable_sip_targets & set(fixture_examples))
+        regular_sip_targets = sorted(runnable_sip_targets - set(fixture_targets))
         requested_partitions = max(1, int(policy.get("pr_sip_partitions", 3)))
-        partition_count = min(requested_partitions, len(runnable_sip_targets))
-        partitions = partition_named_targets(
-            runnable_sip_targets,
-            partition_count,
-            policy.get("pr_sip_target_weights", {}),
+        partition_count = min(requested_partitions, len(regular_sip_targets))
+        partitions = (
+            partition_named_targets(
+                regular_sip_targets,
+                partition_count,
+                policy.get("pr_sip_target_weights", {}),
+            )
+            if partition_count
+            else []
         )
-        sip_jobs.append({"id": "core", "kind": "core", "targets_csv": ""})
+        # Keep the two independent compile-heavy commands parallel. Process
+        # fixture tests share a stable lane so their example binaries are
+        # built once instead of rebuilding the dependency graph per shard.
+        sip_jobs.extend(
+            [
+                {"id": "core-test", "kind": "core-test", "targets_csv": ""},
+                {"id": "clippy", "kind": "clippy", "targets_csv": ""},
+            ]
+        )
+        if fixture_targets:
+            examples = sorted(
+                {
+                    example
+                    for target in fixture_targets
+                    for example in fixture_examples[target]
+                }
+            )
+            sip_jobs.append(
+                {
+                    "id": "fixtures",
+                    "kind": "fixtures",
+                    "targets_csv": ",".join(fixture_targets),
+                    "examples_csv": ",".join(examples),
+                }
+            )
         sip_jobs.extend(
             {
                 "id": f"integration-{index}",

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -59,6 +59,9 @@ def command_record(
         exit_code = 127
     finally:
         print("::endgroup::", flush=True)
+    environment_overrides = {
+        key: value for key, value in (env or {}).items() if os.environ.get(key) != value
+    }
     return {
         "argv": argv,
         "working_directory": (cwd or root).relative_to(root).as_posix()
@@ -67,6 +70,7 @@ def command_record(
         "started_at": started,
         "duration_seconds": round(time.monotonic() - start, 3),
         "exit_code": exit_code,
+        "environment_overrides": environment_overrides,
     }
 
 
@@ -166,10 +170,13 @@ def sip_core_commands() -> list[tuple[list[str], Path | None, dict[str, str] | N
     ]
 
 
-def sip_pr_core_commands() -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
+def sip_clippy_commands() -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
     return [
-        *sip_core_commands(),
-        (["cargo", "clippy", "--locked", "-p", "rvoip-sip", "--all-targets"], None, None),
+        (
+            ["cargo", "clippy", "--locked", "-p", "rvoip-sip", "--all-targets"],
+            None,
+            None,
+        )
     ]
 
 
@@ -183,6 +190,36 @@ def sip_integration_commands(
     for target in targets:
         argv.extend(("--test", target))
     return [(argv, None, None)]
+
+
+def sip_fixture_commands(
+    targets_csv: str,
+    examples_csv: str,
+    root: Path,
+) -> list[tuple[list[str], Path | None, dict[str, str] | None]]:
+    targets = sorted(set(filter(None, targets_csv.split(","))))
+    examples = sorted(set(filter(None, examples_csv.split(","))))
+    if not targets or any(not TARGET.fullmatch(target) for target in targets):
+        raise CheckError(f"invalid SIP process-fixture target selection: {targets_csv!r}")
+    if not examples or any(not TARGET.fullmatch(example) for example in examples):
+        raise CheckError(f"invalid SIP process-fixture example selection: {examples_csv!r}")
+
+    target_root = Path(os.environ.get("CARGO_TARGET_DIR", root / "target"))
+    if not target_root.is_absolute():
+        target_root = root / target_root
+    prebuilt_dir = target_root / "debug" / "examples"
+    fixture_env = {
+        **os.environ,
+        "RVOIP_SIP_PREBUILT_EXAMPLE_DIR": str(prebuilt_dir),
+    }
+
+    build = ["cargo", "build", "--locked", "-p", "rvoip-sip"]
+    for example in examples:
+        build.extend(("--example", example))
+    test = ["cargo", "test", "--locked", "-p", "rvoip-sip"]
+    for target in targets:
+        test.extend(("--test", target))
+    return [(build, None, None), (test, None, fixture_env)]
 
 
 def specialty_commands(
@@ -467,14 +504,16 @@ def main(argv: list[str] | None = None) -> int:
             "specialty",
             "doctest",
             "sip-core",
-            "sip-pr-core",
+            "sip-clippy",
             "sip-integration",
+            "sip-fixtures",
         ),
     )
     parser.add_argument("--name", required=True)
     parser.add_argument("--packages", default="")
     parser.add_argument("--gate", default="")
     parser.add_argument("--targets", default="")
+    parser.add_argument("--examples", default="")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
     root = Path(__file__).resolve().parents[2]
@@ -496,10 +535,12 @@ def main(argv: list[str] | None = None) -> int:
             ]
         elif args.kind == "sip-core":
             commands = sip_core_commands()
-        elif args.kind == "sip-pr-core":
-            commands = sip_pr_core_commands()
+        elif args.kind == "sip-clippy":
+            commands = sip_clippy_commands()
         elif args.kind == "sip-integration":
             commands = sip_integration_commands(args.targets)
+        elif args.kind == "sip-fixtures":
+            commands = sip_fixture_commands(args.targets, args.examples, root)
         else:
             if args.gate == "vcon-postgres":
                 postgres_name = start_postgres(root, records)

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -207,6 +207,7 @@ class PlannerTests(unittest.TestCase):
                 "targets": [
                     {"name": "rvoip_sip", "kind": ["lib"]},
                     {"name": "audio_roundtrip_integration", "kind": ["test"]},
+                    {"name": "cancel_integration", "kind": ["test"]},
                     {"name": "event_tests", "kind": ["test"]},
                     {"name": "srtp_call_integration", "kind": ["test"]},
                 ],
@@ -214,6 +215,9 @@ class PlannerTests(unittest.TestCase):
         )
         policy = copy.deepcopy(self.policy)
         policy["pr_deferred_sip_targets"] = ["audio_roundtrip_integration"]
+        policy["pr_sip_fixture_examples"] = {
+            "cancel_integration": ["cancel_alice", "cancel_bob"]
+        }
         policy["pr_sip_partitions"] = 2
         plan = pr_plan.make_plan(
             root=self.root,
@@ -226,11 +230,55 @@ class PlannerTests(unittest.TestCase):
             job_mode="combined",
         )
         self.assertEqual(plan["deferred_sip_targets"], ["audio_roundtrip_integration"])
-        self.assertEqual([job["id"] for job in plan["sip_jobs"]], ["core", "integration-1", "integration-2"])
+        self.assertEqual(
+            [job["id"] for job in plan["sip_jobs"]],
+            ["core-test", "clippy", "fixtures", "integration-1", "integration-2"],
+        )
+        fixture_job = next(job for job in plan["sip_jobs"] if job["id"] == "fixtures")
+        self.assertEqual(fixture_job["targets_csv"], "cancel_integration")
+        self.assertEqual(fixture_job["examples_csv"], "cancel_alice,cancel_bob")
+        assigned = {
+            target
+            for job in plan["sip_jobs"]
+            if job["kind"] == "integration"
+            for target in job["targets_csv"].split(",")
+        }
+        self.assertEqual(assigned, {"event_tests", "srtp_call_integration"})
         self.assertNotIn(
             "rvoip-sip",
             [package for shard in plan["shards"] for package in shard["packages"]],
         )
+
+    def test_unknown_sip_fixture_target_fails_closed(self) -> None:
+        metadata = copy.deepcopy(self.metadata)
+        package_root = self.root / "crates" / "rvoip-sip"
+        package_root.mkdir(parents=True)
+        manifest = package_root / "Cargo.toml"
+        manifest.write_text("[package]\nname = 'rvoip-sip'\n")
+        package_id = f"path+file://{package_root}#rvoip-sip@1.0.0"
+        metadata["workspace_members"].append(package_id)
+        metadata["packages"].append(
+            {
+                "id": package_id,
+                "name": "rvoip-sip",
+                "manifest_path": str(manifest),
+                "dependencies": [],
+                "targets": [{"name": "event_tests", "kind": ["test"]}],
+            }
+        )
+        policy = copy.deepcopy(self.policy)
+        policy["pr_sip_fixture_examples"] = {"missing": ["fixture"]}
+        with self.assertRaises(pr_plan.PlanError):
+            pr_plan.make_plan(
+                root=self.root,
+                metadata=metadata,
+                policy=policy,
+                paths=["crates/rvoip-sip/src/lib.rs"],
+                base="base",
+                head="head",
+                candidate=None,
+                job_mode="combined",
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -47,15 +47,38 @@ class RunChecksTests(unittest.TestCase):
             ],
         )
 
-    def test_pr_sip_core_reuses_build_before_clippy(self) -> None:
-        commands = run_checks.sip_pr_core_commands()
-        self.assertEqual(commands[0][0][0:2], ["cargo", "test"])
-        self.assertEqual(commands[1][0][0:2], ["cargo", "clippy"])
-        self.assertIn("--all-targets", commands[1][0])
+    def test_pr_sip_core_and_clippy_are_independent_lanes(self) -> None:
+        core = run_checks.sip_core_commands()
+        clippy = run_checks.sip_clippy_commands()
+        self.assertEqual(len(core), 1)
+        self.assertEqual(core[0][0][0:2], ["cargo", "test"])
+        self.assertEqual(len(clippy), 1)
+        self.assertEqual(clippy[0][0][0:2], ["cargo", "clippy"])
+        self.assertIn("--all-targets", clippy[0][0])
+
+    def test_sip_fixture_lane_prebuilds_examples_in_the_shared_target(self) -> None:
+        root = Path("/workspace")
+        commands = run_checks.sip_fixture_commands(
+            "cancel_integration,blind_transfer_integration",
+            "cancel_bob,cancel_alice",
+            root,
+        )
+        self.assertEqual(commands[0][0][0:2], ["cargo", "build"])
+        self.assertEqual(
+            commands[0][0][-4:],
+            ["--example", "cancel_alice", "--example", "cancel_bob"],
+        )
+        self.assertEqual(commands[1][0][0:2], ["cargo", "test"])
+        self.assertEqual(
+            commands[1][2]["RVOIP_SIP_PREBUILT_EXAMPLE_DIR"],
+            "/workspace/target/debug/examples",
+        )
 
     def test_sip_target_arguments_reject_shell_metacharacters(self) -> None:
         with self.assertRaises(run_checks.CheckError):
             run_checks.sip_integration_commands("safe; touch compromised")
+        with self.assertRaises(run_checks.CheckError):
+            run_checks.sip_fixture_commands("safe", "unsafe;example", Path("/workspace"))
 
     def test_example_smoke_preserves_the_hardware_free_matrix(self) -> None:
         commands = run_checks.specialty_commands("examples-smoke", Path("/workspace"))

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import re
+import tomllib
 import unittest
 
 
@@ -31,8 +33,30 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("run_checks.py shard", text)
         self.assertIn("shard-${{ matrix.shard_id }}-all", text)
         self.assertNotIn("run_checks.py shard-${{ matrix.check }}", text)
-        self.assertIn("sip-pr-core", text)
+        self.assertIn("run_checks.py sip-core", text)
+        self.assertIn("run_checks.py sip-clippy", text)
+        self.assertIn("run_checks.py sip-fixtures", text)
         self.assertIn("sip-integration", text)
+
+    def test_every_sip_process_fixture_is_prebuilt_by_the_dedicated_lane(self) -> None:
+        policy = json.loads((ROOT / "scripts/ci/policy.json").read_text())
+        mapping = policy["pr_sip_fixture_examples"]
+        test_root = ROOT / "crates/sip/rvoip-sip/tests"
+        fixture_targets = {
+            path.stem
+            for path in test_root.glob("*.rs")
+            if "build_examples(" in path.read_text()
+        }
+        self.assertEqual(set(mapping), fixture_targets)
+
+        manifest = tomllib.loads(
+            (ROOT / "crates/sip/rvoip-sip/Cargo.toml").read_text()
+        )
+        declared_examples = {item["name"] for item in manifest.get("example", [])}
+        mapped_examples = {
+            example for examples in mapping.values() for example in examples
+        }
+        self.assertEqual(mapped_examples - declared_examples, set())
 
     def test_main_aggregates_one_receipt_per_combined_shard(self) -> None:
         text = (ROOT / ".github/workflows/main-ci.yml").read_text()


### PR DESCRIPTION
## Summary

- split SIP core tests and Clippy into independent PR lanes
- collect process-based SIP tests into one stable fixture lane
- prebuild every required fixture example once in the normal Cargo target directory
- keep ordinary SIP integration targets duration-balanced across three lanes
- retain the long audio round-trip test on Main/release qualification

## Root cause

The measured PR run compiled the SIP test graph in about 7m40s, then three separate integration partitions each rebuilt the same fixture dependency graph in an isolated Cargo target. `cancel_integration`, `blind_transfer_integration`, and `bridge_roundtrip_integration` consequently each spent roughly six minutes paying the same startup cost. The old core lane also serialized core tests and all-target Clippy.

## Safety

No test, threshold, workload, or release requirement is weakened. A fail-closed policy test requires every integration target that calls `build_examples` to remain mapped to the dedicated fixture lane, and every mapped example must exist in the Cargo manifest.

## Validation

- 48 CI planner, receipt, workflow-policy, and command-runner tests pass
- workflow YAML parses
- Rust formatting and diff hygiene pass
- this draft PR is the remote timing proof for the new topology

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI orchestration and test scaffolding; coverage is preserved via stricter policy tests rather than weakened gates.
> 
> **Overview**
> **PR Gate SIP lanes** no longer run a single combined `sip-pr-core` step. **Core library/binary/example tests** and **all-target Clippy** are separate matrix jobs (`core-test`, `clippy`). **Process-fixture integration tests** are pulled out of the duration-balanced integration shards into a dedicated **`fixtures`** job.
> 
> The planner reads **`pr_sip_fixture_examples`** in `policy.json`, validates targets/examples fail-closed, builds one deduplicated example list for the fixture lane, and only **non-fixture** integration targets stay in the three integration partitions (deferred long audio test unchanged).
> 
> **`sip-fixtures`** in `run_checks.py` runs `cargo build --example …` once into the normal `target/debug/examples`, then runs the mapped `--test` targets with **`RVOIP_SIP_PREBUILT_EXAMPLE_DIR`** set. Integration test **`build_examples`** / **`example_binary`** skip per-shard isolated rebuilds when that env var is present.
> 
> **Safety nets:** workflow policy test requires every test file that calls `build_examples` to appear in the policy map and every mapped example to exist in `Cargo.toml`; planner tests cover unknown fixture targets. Command receipts now record **`environment_overrides`**. **CONTRIBUTING.md** documents the new topology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5bdeb6fd69e111bb1cf27a3cfd31a4a58f30eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->