### PR TITLE
ci: split full Main SIP coverage

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -28,6 +28,8 @@ jobs:
       shard_count: ${{ steps.plan.outputs.shard_count }}
       specialty: ${{ steps.plan.outputs.specialty }}
       specialty_count: ${{ steps.plan.outputs.specialty_count }}
+      sip_jobs: ${{ steps.plan.outputs.sip_jobs }}
+      sip_job_count: ${{ steps.plan.outputs.sip_job_count }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -43,6 +45,8 @@ jobs:
             --base HEAD
             --head HEAD
             --changed-file Cargo.lock
+            --job-mode combined
+            --deferred-sip-mode separate
             --github-output "$GITHUB_OUTPUT"
             --specialty-gate release-tooling
             --specialty-gate rtp-interop
@@ -169,6 +173,74 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+  sip-tests:
+    name: Full SIP ${{ matrix.id }}
+    needs: plan
+    if: needs.plan.outputs.sip_job_count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.sip_jobs) }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.91.0
+          components: clippy
+
+      - name: Restore SIP lane cache
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          shared-key: main-sip-${{ matrix.id }}
+
+      - name: Install system dependencies
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          libasound2-dev libopus-dev protobuf-compiler pkg-config cmake lsof
+
+      - name: Test SIP library, binaries, and examples
+        if: matrix.kind == 'core-test'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-core
+          --name sip-${{ matrix.id }}
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Lint every SIP target
+        if: matrix.kind == 'clippy'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-clippy
+          --name sip-${{ matrix.id }}
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Build and run SIP process fixtures once
+        if: matrix.kind == 'fixtures'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-fixtures
+          --name sip-${{ matrix.id }}
+          --targets '${{ matrix.targets_csv }}'
+          --examples '${{ matrix.examples_csv }}'
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Run bounded SIP integration partition
+        if: matrix.kind == 'integration'
+        run: >-
+          python3 scripts/ci/run_checks.py sip-integration
+          --name sip-${{ matrix.id }}
+          --targets '${{ matrix.targets_csv }}'
+          --output target/ci-receipts/sip-${{ matrix.id }}.json
+
+      - name: Upload SIP lane receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: main-evidence-sip-${{ matrix.id }}
+          path: target/ci-receipts/sip-${{ matrix.id }}.json
+          retention-days: 30
+          if-no-files-found: warn
+
   specialty:
     name: Full specialty ${{ matrix.gate }}
     needs: plan
@@ -218,7 +290,7 @@ jobs:
   main-gate:
     name: Main Gate
     if: always()
-    needs: [plan, policy, crate-tests, doctest, specialty]
+    needs: [plan, policy, crate-tests, doctest, specialty, sip-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -239,6 +311,7 @@ jobs:
             --job 'plan=${{ needs.plan.result }}' \
             --job 'policy=${{ needs.policy.result }}' \
             --job 'crate-tests=${{ needs.crate-tests.result }}' \
+            --job 'sip-tests=${{ needs.sip-tests.result }}' \
             --job 'specialty=${{ needs.specialty.result }}' \
             --job 'doctest=${{ needs.doctest.result }}' \
             --required-job doctest \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ specialty gates declared for the changed paths. It balances that work into no
 more than four shards and runs tests and Clippy on the same warm build graph.
 Public API changes compile a representative example contract set on the PR;
 the Main Gate still tests all 44 crates, doctests, and every standalone
-example. The large SIP integration inventory is duration-balanced across
+example. Main also runs the deferred long SIP target in its own lane instead
+of returning it to a monolithic workspace shard. The large SIP integration inventory is duration-balanced across
 bounded PR lanes. Process-based fixtures share one cache-backed lane so their
 example binaries are built once, while SIP core tests and Clippy run in
 parallel. The ten-minute audio round-trip target runs on Main Gate and release

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -246,9 +246,12 @@ def make_plan(
     head: str,
     candidate: str | None = None,
     job_mode: str = "split",
+    deferred_sip_mode: str = "defer",
 ) -> dict[str, Any]:
     if job_mode not in {"split", "combined"}:
         raise PlanError(f"unsupported shard job mode: {job_mode!r}")
+    if deferred_sip_mode not in {"defer", "separate"}:
+        raise PlanError(f"unsupported deferred SIP mode: {deferred_sip_mode!r}")
     normalized = sorted({normalize_path(path) for path in paths})
     packages = workspace_packages(root, metadata)
     known_policy_paths = set(policy.get("known_policy_paths", []))
@@ -329,11 +332,16 @@ def make_plan(
     shard_selection = set(selected)
     sip_jobs: list[dict[str, Any]] = []
     deferred_sip_targets: list[str] = []
+    separate_sip_targets: list[str] = []
     if job_mode == "combined" and "rvoip-sip" in shard_selection:
         shard_selection.remove("rvoip-sip")
         all_sip_targets = integration_test_targets(metadata, "rvoip-sip")
-        deferred_sip_targets = sorted(set(policy.get("pr_deferred_sip_targets", [])))
-        unknown_deferred = sorted(set(deferred_sip_targets) - set(all_sip_targets))
+        declared_deferred_sip_targets = sorted(
+            set(policy.get("pr_deferred_sip_targets", []))
+        )
+        unknown_deferred = sorted(
+            set(declared_deferred_sip_targets) - set(all_sip_targets)
+        )
         if unknown_deferred:
             raise PlanError(
                 "unknown deferred SIP test targets: " + ", ".join(unknown_deferred)
@@ -364,7 +372,15 @@ def make_plan(
                 raise PlanError(
                     f"SIP process-fixture target {target!r} has invalid examples"
                 )
-        runnable_sip_targets = set(all_sip_targets) - set(deferred_sip_targets)
+        deferred_sip_targets = (
+            declared_deferred_sip_targets if deferred_sip_mode == "defer" else []
+        )
+        separate_sip_targets = (
+            declared_deferred_sip_targets if deferred_sip_mode == "separate" else []
+        )
+        runnable_sip_targets = (
+            set(all_sip_targets) - set(declared_deferred_sip_targets)
+        )
         fixture_targets = sorted(runnable_sip_targets & set(fixture_examples))
         regular_sip_targets = sorted(runnable_sip_targets - set(fixture_targets))
         requested_partitions = max(1, int(policy.get("pr_sip_partitions", 3)))
@@ -412,6 +428,27 @@ def make_plan(
             }
             for index, partition in enumerate(partitions, start=1)
         )
+        for target in separate_sip_targets:
+            if target in fixture_examples:
+                sip_jobs.append(
+                    {
+                        "id": f"long-{target}",
+                        "kind": "fixtures",
+                        "targets_csv": target,
+                        "examples_csv": ",".join(sorted(set(fixture_examples[target]))),
+                    }
+                )
+            else:
+                sip_jobs.append(
+                    {
+                        "id": f"long-{target}",
+                        "kind": "integration",
+                        "targets_csv": target,
+                        "estimated_seconds": int(
+                            policy.get("pr_sip_target_weights", {}).get(target, 5)
+                        ),
+                    }
+                )
 
     shards = make_shards(shard_selection, policy)
     shard_checks = ("all",) if job_mode == "combined" else ("test", "clippy")
@@ -449,6 +486,7 @@ def make_plan(
         "specialty_gates": specialty,
         "sip_jobs": sip_jobs,
         "deferred_sip_targets": deferred_sip_targets,
+        "separate_sip_targets": separate_sip_targets,
         "shards": shards,
         "shard_jobs": shard_jobs,
     }
@@ -498,6 +536,12 @@ def parser() -> argparse.ArgumentParser:
         help="emit separate test/clippy jobs or one warm combined job per shard",
     )
     result.add_argument(
+        "--deferred-sip-mode",
+        choices=("defer", "separate"),
+        default="defer",
+        help="defer long SIP targets from PRs or run each in its own lane",
+    )
+    result.add_argument(
         "--policy", type=Path, default=Path("scripts/ci/policy.json")
     )
     result.add_argument("--output", type=Path, default=Path("target/ci-plan/plan.json"))
@@ -523,6 +567,7 @@ def main(argv: list[str] | None = None) -> int:
             head=args.head,
             candidate=args.candidate,
             job_mode=args.job_mode,
+            deferred_sip_mode=args.deferred_sip_mode,
         )
         for gate in args.specialty_gate:
             if not gate or any(character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-" for character in gate):

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -280,6 +280,55 @@ class PlannerTests(unittest.TestCase):
                 job_mode="combined",
             )
 
+    def test_main_runs_pr_deferred_sip_target_in_a_separate_lane(self) -> None:
+        metadata = copy.deepcopy(self.metadata)
+        package_root = self.root / "crates" / "rvoip-sip"
+        package_root.mkdir(parents=True)
+        manifest = package_root / "Cargo.toml"
+        manifest.write_text("[package]\nname = 'rvoip-sip'\n")
+        package_id = f"path+file://{package_root}#rvoip-sip@1.0.0"
+        metadata["workspace_members"].append(package_id)
+        metadata["packages"].append(
+            {
+                "id": package_id,
+                "name": "rvoip-sip",
+                "manifest_path": str(manifest),
+                "dependencies": [],
+                "targets": [
+                    {"name": "audio_roundtrip_integration", "kind": ["test"]},
+                    {"name": "event_tests", "kind": ["test"]},
+                ],
+            }
+        )
+        policy = copy.deepcopy(self.policy)
+        policy["pr_deferred_sip_targets"] = ["audio_roundtrip_integration"]
+        policy["pr_sip_fixture_examples"] = {
+            "audio_roundtrip_integration": ["audio_alice", "audio_bob"]
+        }
+        plan = pr_plan.make_plan(
+            root=self.root,
+            metadata=metadata,
+            policy=policy,
+            paths=["Cargo.lock"],
+            base="base",
+            head="head",
+            candidate=None,
+            job_mode="combined",
+            deferred_sip_mode="separate",
+        )
+        self.assertEqual(plan["deferred_sip_targets"], [])
+        self.assertEqual(
+            plan["separate_sip_targets"], ["audio_roundtrip_integration"]
+        )
+        long_job = next(
+            job
+            for job in plan["sip_jobs"]
+            if job["id"] == "long-audio_roundtrip_integration"
+        )
+        self.assertEqual(long_job["kind"], "fixtures")
+        self.assertEqual(long_job["targets_csv"], "audio_roundtrip_integration")
+        self.assertEqual(long_job["examples_csv"], "audio_alice,audio_bob")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -61,6 +61,14 @@ class WorkflowPolicyTests(unittest.TestCase):
     def test_main_aggregates_one_receipt_per_combined_shard(self) -> None:
         text = (ROOT / ".github/workflows/main-ci.yml").read_text()
         self.assertIn("--shard-layout shards", text)
+        self.assertIn("--job-mode combined", text)
+        self.assertIn("--deferred-sip-mode separate", text)
+        self.assertIn("Full SIP ${{ matrix.id }}", text)
+        self.assertIn("run_checks.py sip-core", text)
+        self.assertIn("run_checks.py sip-clippy", text)
+        self.assertIn("run_checks.py sip-fixtures", text)
+        self.assertIn("run_checks.py sip-integration", text)
+        self.assertIn("--job 'sip-tests=${{ needs.sip-tests.result }}'", text)
 
     def test_main_release_tooling_installs_its_fuzz_toolchain(self) -> None:
         text = (ROOT / ".github/workflows/main-ci.yml").read_text()


### PR DESCRIPTION
## Summary

- remove `rvoip-sip` from the generic full-workspace shard while retaining it in the 44-crate inventory
- run SIP core tests, all-target Clippy, shared process fixtures, and ordinary integrations in independent Main lanes
- run the PR-deferred ten-minute audio round trip in its own full-Main lane
- require every SIP receipt in the final Main Gate aggregate

## Root cause

The current Main run kept all rvoip-sip tests and Clippy inside one generic shard. That shard remained active beyond 30 minutes after every other ordinary shard finished, recreating the same serial bottleneck removed from PR verification.

## Coverage

No Main test is deferred or omitted. The plan selects all 44 crates, puts 43 in four duration-balanced generic shards, and assigns the complete default-feature rvoip-sip inventory across seven SIP lanes. The long audio target is included separately rather than returned to a monolith.

## Validation

- 49 CI planner, receipt, workflow-policy, and command-runner tests pass
- actual Main plan selects 44 crates, 43 generic-shard packages, and seven SIP lanes
- deferred SIP list is empty for Main and the audio target appears exactly once
- workflow YAML, formatting, JSON, and diff hygiene pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI planning and GitHub Actions wiring; test coverage is preserved but orchestration complexity increases slightly.
> 
> **Overview**
> **Main Gate** no longer runs all `rvoip-sip` work inside one generic crate shard. The planner uses `--job-mode combined` with `--deferred-sip-mode separate`, keeps `rvoip-sip` out of the four duration-balanced shards, and emits **SIP matrix jobs** (core tests, all-target Clippy, shared process fixtures, integration partitions, plus a dedicated lane per PR-deferred long target such as `audio_roundtrip_integration`).
> 
> A new **`sip-tests`** workflow job runs those lanes in parallel, uploads per-lane receipts, and **Main Gate** reconciliation now requires the `sip-tests` job result alongside existing shards. `pr_plan.py` gains `deferred_sip_mode` (`defer` vs `separate`) and `separate_sip_targets` in the plan output; **CONTRIBUTING** documents that Main runs deferred long SIP targets in their own lane rather than in a monolithic shard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020608c9f4421f77e1223ae53df054c3d2b7084f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->