### PR TITLE
ci: launch release GCP shards from one controller

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -46,6 +46,7 @@ jobs:
         run: >-
           python3 -m unittest
           scripts/test_release.py
+          scripts/test_release_gcp_fanout.py
           scripts/test_release_gates.py
           scripts/test_release_carry_forward_attestation.py
           scripts/test_release_exception_attestation.py

--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -290,7 +290,7 @@ jobs:
           PY
 
   gate-gcp:
-    name: ${{ matrix.resource_class }} / ${{ matrix.id }}
+    name: Run all ephemeral GCP release shards
     if: needs.plan.outputs.gcp_shard_count != '0'
     needs: [plan, preflight-gcp]
     runs-on: ubuntu-latest
@@ -298,9 +298,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.plan.outputs.gcp_matrix) }}
     steps:
       - name: Check out controller definition
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -316,17 +313,34 @@ jobs:
       - name: Install Google Cloud CLI
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
-      - name: Create an ephemeral release worker
-        id: worker
+      - name: Bind every worker to the exact candidate and gate shard
         env:
           CANDIDATE: ${{ needs.plan.outputs.candidate_sha }}
           ENVIRONMENT_ID: ${{ needs.plan.outputs.environment_id }}
-          GATES: ${{ matrix.gates_csv }}
-          SHARD_ID: ${{ matrix.id }}
-          RESOURCE_CLASS: ${{ matrix.resource_class }}
-          MACHINE_TYPE: ${{ matrix.machine_type }}
-          DISK_TYPE: ${{ matrix.disk_type }}
-          DISK_SIZE_GB: ${{ matrix.disk_size_gb }}
+          GCP_MATRIX: ${{ needs.plan.outputs.gcp_matrix }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/gcp-controller
+          printf '%s\n' "$GCP_MATRIX" > target/gcp-controller/matrix.json
+          python3 scripts/release/gcp_fanout.py prepare \
+            --matrix target/gcp-controller/matrix.json \
+            --candidate "$CANDIDATE" \
+            --environment-id "$ENVIRONMENT_ID" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --output target/gcp-controller/workers.json
+          {
+            echo "## Ephemeral GCP fanout"
+            echo
+            echo "- GitHub controller jobs: 1"
+            echo "- GCP workers: $(jq -r .worker_count target/gcp-controller/workers.json)"
+            echo "- N2 vCPUs: $(jq -r .required_vcpus target/gcp-controller/workers.json)"
+            echo "- Idle workers retained after the run: 0"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create every ephemeral release worker concurrently
+        env:
+          CANDIDATE: ${{ needs.plan.outputs.candidate_sha }}
           PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
           ZONE: ${{ vars.RVOIP_GCP_ZONE }}
           NETWORK: ${{ vars.RVOIP_GCP_NETWORK }}
@@ -335,94 +349,193 @@ jobs:
           RUNNER_SERVICE_ACCOUNT: ${{ vars.RVOIP_GCP_RUNNER_SERVICE_ACCOUNT }}
         run: |
           set -euo pipefail
-          worker="rvoip-rel-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${SHARD_ID}"
-          prefix="release/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/${SHARD_ID}"
-          gates_b64="$(printf '%s' "$GATES" | base64 -w0)"
-          environment_b64="$(printf '%s' "$ENVIRONMENT_ID" | base64 -w0)"
-          echo "name=$worker" >> "$GITHUB_OUTPUT"
-          echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
-          gcloud compute instances create "$worker" \
-            --project "$PROJECT" \
-            --zone "$ZONE" \
-            --machine-type "$MACHINE_TYPE" \
-            --network "$NETWORK" \
-            --subnet "$SUBNET" \
-            --image-family ubuntu-2404-lts-amd64 \
-            --image-project ubuntu-os-cloud \
-            --boot-disk-type "$DISK_TYPE" \
-            --boot-disk-size "${DISK_SIZE_GB}GB" \
-            --boot-disk-auto-delete \
-            --service-account "$RUNNER_SERVICE_ACCOUNT" \
-            --scopes cloud-platform \
-            --shielded-secure-boot \
-            --shielded-vtpm \
-            --shielded-integrity-monitoring \
-            --labels rvoip-role=release-gate,managed-by=github-actions \
-            --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${SHARD_ID},rvoip-resource-class=${RESOURCE_CLASS},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
-            --metadata-from-file startup-script=infra/release-runners/gcp-release-startup.sh
+          mkdir -p target/gcp-controller/create-logs
+          pids=()
+          while IFS= read -r descriptor; do
+            shard_id="$(jq -r .id <<< "$descriptor")"
+            worker="$(jq -r .name <<< "$descriptor")"
+            prefix="$(jq -r .prefix <<< "$descriptor")"
+            resource_class="$(jq -r .resource_class <<< "$descriptor")"
+            machine_type="$(jq -r .machine_type <<< "$descriptor")"
+            disk_type="$(jq -r .disk_type <<< "$descriptor")"
+            disk_size_gb="$(jq -r .disk_size_gb <<< "$descriptor")"
+            gates_b64="$(jq -r .gates_b64 <<< "$descriptor")"
+            environment_b64="$(jq -r .environment_b64 <<< "$descriptor")"
+            (
+              gcloud compute instances create "$worker" \
+                --project "$PROJECT" \
+                --zone "$ZONE" \
+                --machine-type "$machine_type" \
+                --network "$NETWORK" \
+                --subnet "$SUBNET" \
+                --image-family ubuntu-2404-lts-amd64 \
+                --image-project ubuntu-os-cloud \
+                --boot-disk-type "$disk_type" \
+                --boot-disk-size "${disk_size_gb}GB" \
+                --boot-disk-auto-delete \
+                --service-account "$RUNNER_SERVICE_ACCOUNT" \
+                --scopes cloud-platform \
+                --shielded-secure-boot \
+                --shielded-vtpm \
+                --shielded-integrity-monitoring \
+                --labels rvoip-role=release-gate,managed-by=github-actions \
+                --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${shard_id},rvoip-resource-class=${resource_class},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
+                --metadata-from-file startup-script=infra/release-runners/gcp-release-startup.sh
+            ) > "target/gcp-controller/create-logs/${shard_id}.log" 2>&1 &
+            pids+=("$!")
+          done < <(jq -c '.workers[]' target/gcp-controller/workers.json)
 
-      - name: Wait for immutable worker evidence
-        env:
-          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
-          ZONE: ${{ vars.RVOIP_GCP_ZONE }}
-          BUCKET: ${{ vars.RVOIP_GCP_EVIDENCE_BUCKET }}
-          WORKER: ${{ steps.worker.outputs.name }}
-          PREFIX: ${{ steps.worker.outputs.prefix }}
-        run: |
-          set -euo pipefail
-          for attempt in $(seq 1 340); do
-            if gcloud storage cat "gs://${BUCKET}/${PREFIX}/result.json" > result.json 2>/dev/null; then
-              exit 0
-            fi
-            state="$(gcloud compute instances describe "$WORKER" --project "$PROJECT" --zone "$ZONE" --format='value(status)' 2>/dev/null || true)"
-            if [[ "$state" == TERMINATED ]]; then
-              echo "worker terminated without uploading a result" >&2
-              exit 1
-            fi
-            sleep 30
+          status=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || status=1
           done
-          echo "release shard exceeded its 170-minute evidence deadline" >&2
-          exit 1
-
-      - name: Download and verify shard evidence
-        if: always() && steps.worker.outputs.prefix != ''
-        env:
-          BUCKET: ${{ vars.RVOIP_GCP_EVIDENCE_BUCKET }}
-          PREFIX: ${{ steps.worker.outputs.prefix }}
-          CANDIDATE: ${{ needs.plan.outputs.candidate_sha }}
-          SHARD_ID: ${{ matrix.id }}
-        run: |
-          set -euo pipefail
-          gcloud storage cp "gs://${BUCKET}/${PREFIX}/qualification.log" qualification.log || true
-          test -f result.json
-          gcloud storage cp "gs://${BUCKET}/${PREFIX}/release-shard.tar.gz" release-shard.tar.gz
-          echo "$(jq -r .evidence_archive_sha256 result.json)  release-shard.tar.gz" | sha256sum --check
-          mkdir -p target
-          tar -C target -xzf release-shard.tar.gz
-          jq -e \
-            --arg candidate "$CANDIDATE" \
-            --arg shard "$SHARD_ID" \
-            '.candidate_sha == $candidate and .shard_id == $shard and .status == "PASS" and .publishing_attempted == false' \
-            result.json
-
-      - name: Delete worker and attached disk
-        if: always() && steps.worker.outputs.name != ''
-        env:
-          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
-          ZONE: ${{ vars.RVOIP_GCP_ZONE }}
-          WORKER: ${{ steps.worker.outputs.name }}
-        run: |
-          if gcloud compute instances describe "$WORKER" --project "$PROJECT" --zone "$ZONE" >/dev/null 2>&1; then
-            gcloud compute instances delete "$WORKER" --project "$PROJECT" --zone "$ZONE" --quiet
+          if (( status != 0 )); then
+            tail -n 100 target/gcp-controller/create-logs/*.log
+            exit "$status"
           fi
 
-      - name: Upload GCP shard evidence
+      - name: Wait for every immutable worker result
+        env:
+          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
+          ZONE: ${{ vars.RVOIP_GCP_ZONE }}
+          BUCKET: ${{ vars.RVOIP_GCP_EVIDENCE_BUCKET }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/gcp-controller/downloads
+          expected="$(jq -r .worker_count target/gcp-controller/workers.json)"
+          object_root="gs://${BUCKET}/release/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          run_prefix="rvoip-rel-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-"
+          for attempt in $(seq 1 340); do
+            gcloud storage ls --recursive "${object_root}/" \
+              > target/gcp-controller/objects.txt 2>/dev/null || true
+            gcloud compute instances list \
+              --project "$PROJECT" \
+              --filter="name~'^${run_prefix}'" \
+              --format='csv[no-heading](name,status)' \
+              > target/gcp-controller/states.csv
+            completed=0
+            terminated_without_result=()
+            while IFS= read -r descriptor; do
+              shard_id="$(jq -r .id <<< "$descriptor")"
+              worker="$(jq -r .name <<< "$descriptor")"
+              prefix="$(jq -r .prefix <<< "$descriptor")"
+              directory="target/gcp-controller/downloads/${shard_id}"
+              result_uri="gs://${BUCKET}/${prefix}/result.json"
+              mkdir -p "$directory"
+              if [[ ! -f "${directory}/result.json" ]] \
+                && grep -Fqx "$result_uri" target/gcp-controller/objects.txt; then
+                gcloud storage cp "$result_uri" "${directory}/result.json"
+              fi
+              if [[ -f "${directory}/result.json" ]]; then
+                completed=$((completed + 1))
+                continue
+              fi
+              state="$(awk -F, -v worker="$worker" '$1 == worker { print $2 }' target/gcp-controller/states.csv)"
+              if [[ "$state" == TERMINATED ]]; then
+                # The result upload and instance-state update can cross between
+                # the two bulk polls. Check the exact object once more before
+                # treating a stopped worker as an evidence failure.
+                if gcloud storage cp "$result_uri" "${directory}/result.json" 2>/dev/null; then
+                  completed=$((completed + 1))
+                  continue
+                fi
+                terminated_without_result+=("$worker")
+              fi
+            done < <(jq -c '.workers[]' target/gcp-controller/workers.json)
+            settled=$((completed + ${#terminated_without_result[@]}))
+            if (( settled == expected )); then
+              if (( ${#terminated_without_result[@]} != 0 )); then
+                printf '%s\n' "${terminated_without_result[@]}" \
+                  > target/gcp-controller/terminated-without-result.txt
+                echo "GCP workers terminated without immutable results: ${terminated_without_result[*]}" >&2
+              fi
+              exit 0
+            fi
+            echo "GCP release evidence: ${completed} complete, ${#terminated_without_result[@]} failed without a result, ${expected} total (poll ${attempt}/340)"
+            sleep 30
+          done
+          echo "GCP release fanout exceeded its 170-minute evidence deadline" >&2
+          exit 1
+
+      - name: Download and verify every shard evidence bundle
+        if: always()
+        env:
+          BUCKET: ${{ vars.RVOIP_GCP_EVIDENCE_BUCKET }}
+        run: |
+          set -euo pipefail
+          pids=()
+          while IFS= read -r descriptor; do
+            shard_id="$(jq -r .id <<< "$descriptor")"
+            prefix="$(jq -r .prefix <<< "$descriptor")"
+            directory="target/gcp-controller/downloads/${shard_id}"
+            (
+              mkdir -p "$directory"
+              if [[ ! -f "${directory}/result.json" ]]; then
+                gcloud storage cp \
+                  "gs://${BUCKET}/${prefix}/result.json" \
+                  "${directory}/result.json" || true
+              fi
+              if [[ -f "${directory}/result.json" ]]; then
+                gcloud storage cp \
+                  "gs://${BUCKET}/${prefix}/release-shard.tar.gz" \
+                  "${directory}/release-shard.tar.gz"
+                gcloud storage cp \
+                  "gs://${BUCKET}/${prefix}/qualification.log" \
+                  "${directory}/qualification.log" || true
+              fi
+            ) > "target/gcp-controller/download-${shard_id}.log" 2>&1 &
+            pids+=("$!")
+          done < <(jq -c '.workers[]' target/gcp-controller/workers.json)
+
+          status=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || status=1
+          done
+          if (( status != 0 )); then
+            tail -n 100 target/gcp-controller/download-*.log
+          fi
+          python3 scripts/release/gcp_fanout.py verify \
+            --manifest target/gcp-controller/workers.json \
+            --downloads target/gcp-controller/downloads \
+            --output target/release-shard
+
+      - name: Delete all workers and attached disks
+        if: always()
+        env:
+          PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
+          ZONE: ${{ vars.RVOIP_GCP_ZONE }}
+        run: |
+          set -euo pipefail
+          run_prefix="rvoip-rel-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-"
+          mapfile -t workers < <(
+            gcloud compute instances list \
+              --project "$PROJECT" \
+              --filter="labels.managed-by=github-actions AND name~'^${run_prefix}'" \
+              --format='value(name)'
+          )
+          if (( ${#workers[@]} != 0 )); then
+            gcloud compute instances delete "${workers[@]}" \
+              --project "$PROJECT" \
+              --zone "$ZONE" \
+              --quiet
+          fi
+
+      - name: Upload merged GCP shard evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: release-gate-shard-${{ matrix.id }}
+          name: release-gate-shard-gcp-controller
           path: target/release-shard/
           retention-days: 90
+          if-no-files-found: warn
+
+      - name: Upload GCP controller diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-gcp-controller-${{ github.run_id }}-${{ github.run_attempt }}
+          path: target/gcp-controller/
+          retention-days: 30
           if-no-files-found: warn
 
   cleanup-gcp:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -62,16 +62,22 @@ crates.io, so archive hashes are completed during the topological publication
 run.
 
 The `remote-core` profile uses GitHub-hosted runners. The complete
-`remote-release` profile also schedules performance, soak, and PBX/SIPp gates
-to ephemeral runners with the labels `self-hosted`, `rvoip-release`, and the
-resource class (`gcp-performance`, `gcp-performance-soak`, or `gcp-interop`).
-Those runners must be provisioned separately with workload identity and a
-single-job cleanup policy; they never receive the crates.io token. The
-`remote-release` workflow also requires the repository variable
-`RVOIP_GCP_RUNNERS_READY=true`, which should be set only after that fleet is
-verified. Until then, use `remote-core` for dry runs and retain the legacy beta
-wrapper for the unautomated specialty evidence rather than treating a queued
-job as a release result.
+`remote-release` profile sends performance, soak, and PBX/SIPp gates to real
+ephemeral Compute Engine workers. One GitHub controller creates all planned
+workers concurrently through workload identity, monitors their immutable GCS
+results, verifies and merges their evidence, and deletes every instance and
+auto-delete disk. A separate cleanup job sweeps interrupted runs. The workers
+never receive the crates.io token and no release worker remains provisioned
+between qualifications.
+
+The current full profile is balanced across seven `n2-standard-8` performance
+workers, nine `n2-standard-4` soak workers, and one `n2-standard-4`
+interoperability worker. These are real performance machines; the workflow
+does not substitute GitHub-hosted capacity or reduce workloads and thresholds.
+The one-hour soak establishes a physical lower bound of one hour for a fresh
+qualification, plus provisioning, build, evidence, and cleanup time. Gates
+whose exact source, dependency, definition, environment, and threshold digests
+remain unchanged may reuse successful prior evidence on a later candidate.
 
 This verification is the version/package delta boundary. It does not claim
 that a prior beta run exercised a later version-only commit.

--- a/infra/release-runners/README.md
+++ b/infra/release-runners/README.md
@@ -17,3 +17,11 @@ profile publishes crates, creates a tag, or creates a GitHub release.
 This pilot does not claim coverage for the external PBX, long-soak, or
 performance gates that still require structured remote replacements. The
 `remote-release` profile remains fail-closed until those mappings exist.
+
+The protected `Release qualification` workflow uses the same ephemeral model
+for the complete gate catalog. A single GitHub controller launches every
+duration-balanced GCP shard concurrently, rather than consuming one GitHub job
+slot per cloud worker. Each worker is bound to one candidate SHA and gate list,
+uploads an immutable result and evidence archive, shuts down, and is deleted
+with its auto-delete disk. Controller and follow-up sweep cleanup both run on
+failure; there is no idle release fleet.

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -263,6 +263,7 @@ def specialty_commands(
                     "scripts/test_release.py",
                     "scripts/test_release_carry_forward_attestation.py",
                     "scripts/test_release_exception_attestation.py",
+                    "scripts/test_release_gcp_fanout.py",
                     "scripts/test_release_gates.py",
                 ],
                 None,

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -120,11 +120,15 @@ class WorkflowPolicyTests(unittest.TestCase):
     def test_release_workers_install_interop_tools_only_for_interop(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
         startup = (ROOT / "infra/release-runners/gcp-release-startup.sh").read_text()
+        fanout = (ROOT / "scripts/release/gcp_fanout.py").read_text()
 
-        self.assertIn("RESOURCE_CLASS: ${{ matrix.resource_class }}", workflow)
-        self.assertIn("rvoip-resource-class=${RESOURCE_CLASS}", workflow)
+        self.assertIn('resource_class="$(jq -r .resource_class', workflow)
+        self.assertIn("rvoip-resource-class=${resource_class}", workflow)
         self.assertIn('RESOURCE_CLASS="$(metadata rvoip-resource-class)"', startup)
         self.assertIn('if [[ "$RESOURCE_CLASS" == "gcp-interop" ]]', startup)
+        self.assertIn('"gcp-interop": "n2-standard-4"', fanout)
+        self.assertIn('"gcp-performance": "n2-standard-8"', fanout)
+        self.assertIn('"gcp-performance-soak": "n2-standard-4"', fanout)
         self.assertIn("sip-tester", startup)
         self.assertIn("tshark", startup)
         self.assertIn("docker-compose-v2", startup)
@@ -136,6 +140,23 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('test "$(ulimit -n)" -ge 262144', startup)
         self.assertIn("-name '*.jsonl'", startup)
         self.assertNotRegex(startup, r"apt-get install[^\n]*\bsipp\b")
+
+    def test_release_gcp_workers_do_not_consume_one_github_job_each(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        controller = workflow.split("\n  gate-gcp:\n", maxsplit=1)[1].split(
+            "\n  cleanup-gcp:\n", maxsplit=1
+        )[0]
+
+        self.assertNotIn("strategy:", controller)
+        self.assertNotIn("matrix: ${{ fromJSON", controller)
+        self.assertIn("Run all ephemeral GCP release shards", controller)
+        self.assertIn("gcp_fanout.py prepare", controller)
+        self.assertIn("Create every ephemeral release worker concurrently", controller)
+        self.assertIn('pids+=("$!")', controller)
+        self.assertIn("Wait for every immutable worker result", controller)
+        self.assertIn("gcp_fanout.py verify", controller)
+        self.assertIn("Delete all workers and attached disks", controller)
+        self.assertIn("release-gate-shard-gcp-controller", controller)
 
     def test_release_pbx_lifecycle_uses_tracked_templates(self) -> None:
         lifecycle = (ROOT / "infra/release-runners/interop-lifecycle.sh").read_text()

--- a/scripts/release/gcp_fanout.py
+++ b/scripts/release/gcp_fanout.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Prepare and verify one-controller, many-worker GCP release fanout."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import tarfile
+import tempfile
+from typing import Any
+
+
+MANIFEST_SCHEMA = "rvoip-gcp-release-fanout-v1"
+RESULT_SCHEMA = "rvoip-gcp-release-shard-v1"
+COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+RUN_NUMBER = re.compile(r"^[1-9][0-9]*$")
+SHARD_ID = re.compile(r"^[a-z0-9][a-z0-9-]{0,47}$")
+GATE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RESOURCE_MACHINES = {
+    "gcp-interop": "n2-standard-4",
+    "gcp-performance": "n2-standard-8",
+    "gcp-performance-soak": "n2-standard-4",
+}
+MACHINE_VCPUS = {
+    "n2-standard-4": 4,
+    "n2-standard-8": 8,
+}
+
+
+class FanoutError(RuntimeError):
+    """A release fanout invariant failed closed."""
+
+
+def load_json(path: Path, description: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise FanoutError(f"cannot read {description} {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise FanoutError(f"{description} must be a JSON object: {path}")
+    return payload
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def require_string(record: dict[str, Any], key: str, description: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        raise FanoutError(f"{description} requires a non-empty {key}")
+    return value
+
+
+def prepare_manifest(
+    *,
+    matrix: dict[str, Any],
+    candidate: str,
+    environment_id: str,
+    run_id: str,
+    run_attempt: str,
+) -> dict[str, Any]:
+    if not COMMIT_SHA.fullmatch(candidate):
+        raise FanoutError("candidate must be a full lowercase commit SHA")
+    if not environment_id:
+        raise FanoutError("environment id must not be empty")
+    if not RUN_NUMBER.fullmatch(run_id) or not RUN_NUMBER.fullmatch(run_attempt):
+        raise FanoutError("GitHub run id and attempt must be positive integers")
+    include = matrix.get("include")
+    if not isinstance(include, list) or not include:
+        raise FanoutError("GCP matrix must contain at least one worker")
+
+    workers = []
+    seen_shards: set[str] = set()
+    for raw in include:
+        if not isinstance(raw, dict):
+            raise FanoutError("every GCP matrix entry must be an object")
+        shard_id = require_string(raw, "id", "GCP matrix entry")
+        if not SHARD_ID.fullmatch(shard_id):
+            raise FanoutError(f"unsafe GCP shard id: {shard_id!r}")
+        if shard_id in seen_shards:
+            raise FanoutError(f"duplicate GCP shard id: {shard_id}")
+        seen_shards.add(shard_id)
+
+        resource_class = require_string(raw, "resource_class", shard_id)
+        expected_machine = RESOURCE_MACHINES.get(resource_class)
+        if expected_machine is None:
+            raise FanoutError(f"{shard_id} has unsupported resource class {resource_class!r}")
+        machine_type = require_string(raw, "machine_type", shard_id)
+        if machine_type != expected_machine:
+            raise FanoutError(
+                f"{shard_id} must use {expected_machine}, not {machine_type}"
+            )
+        disk_type = require_string(raw, "disk_type", shard_id)
+        if disk_type != "pd-standard":
+            raise FanoutError(f"{shard_id} must use pd-standard storage")
+        disk_size_gb = raw.get("disk_size_gb")
+        if disk_size_gb != 200:
+            raise FanoutError(f"{shard_id} must use a 200 GB boot disk")
+
+        gates_csv = require_string(raw, "gates_csv", shard_id)
+        gates = gates_csv.split(",")
+        if any(not GATE_ID.fullmatch(gate) for gate in gates):
+            raise FanoutError(f"{shard_id} contains an unsafe or empty gate id")
+        if len(gates) != len(set(gates)):
+            raise FanoutError(f"{shard_id} contains duplicate gate ids")
+
+        worker_name = f"rvoip-rel-{run_id}-{run_attempt}-{shard_id}"
+        if len(worker_name) > 63:
+            raise FanoutError(f"worker name exceeds the GCE 63-character limit: {worker_name}")
+        prefix = f"release/{run_id}-{run_attempt}/{shard_id}"
+        workers.append(
+            {
+                "id": shard_id,
+                "name": worker_name,
+                "prefix": prefix,
+                "resource_class": resource_class,
+                "machine_type": machine_type,
+                "disk_type": disk_type,
+                "disk_size_gb": disk_size_gb,
+                "gates": gates,
+                "gates_csv": gates_csv,
+                "gates_b64": base64.b64encode(gates_csv.encode()).decode(),
+                "environment_b64": base64.b64encode(environment_id.encode()).decode(),
+            }
+        )
+
+    workers.sort(key=lambda item: item["id"])
+    return {
+        "schema": MANIFEST_SCHEMA,
+        "candidate_sha": candidate,
+        "environment_id": environment_id,
+        "github_run_id": run_id,
+        "github_run_attempt": run_attempt,
+        "worker_count": len(workers),
+        "required_vcpus": sum(MACHINE_VCPUS[item["machine_type"]] for item in workers),
+        "workers": workers,
+    }
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        raise FanoutError("unsupported GCP fanout manifest schema")
+    regenerated = prepare_manifest(
+        matrix={
+            "include": [
+                {
+                    "id": worker.get("id"),
+                    "resource_class": worker.get("resource_class"),
+                    "machine_type": worker.get("machine_type"),
+                    "disk_type": worker.get("disk_type"),
+                    "disk_size_gb": worker.get("disk_size_gb"),
+                    "gates_csv": worker.get("gates_csv"),
+                }
+                for worker in manifest.get("workers", [])
+                if isinstance(worker, dict)
+            ]
+        },
+        candidate=require_string(manifest, "candidate_sha", "fanout manifest"),
+        environment_id=require_string(manifest, "environment_id", "fanout manifest"),
+        run_id=require_string(manifest, "github_run_id", "fanout manifest"),
+        run_attempt=require_string(manifest, "github_run_attempt", "fanout manifest"),
+    )
+    if regenerated != manifest:
+        raise FanoutError("GCP fanout manifest is inconsistent or has been altered")
+
+
+def safe_archive_members(archive: Path) -> list[tarfile.TarInfo]:
+    try:
+        with tarfile.open(archive, "r:gz") as bundle:
+            members = bundle.getmembers()
+    except (OSError, tarfile.TarError) as error:
+        raise FanoutError(f"cannot read evidence archive {archive}: {error}") from error
+    if not members:
+        raise FanoutError(f"evidence archive is empty: {archive}")
+    for member in members:
+        path = PurePosixPath(member.name)
+        if (
+            path.is_absolute()
+            or ".." in path.parts
+            or not path.parts
+            or path.parts[0] != "release-shard"
+        ):
+            raise FanoutError(f"unsafe evidence archive path: {member.name!r}")
+        if not (member.isdir() or member.isfile()):
+            raise FanoutError(f"unsupported evidence archive member: {member.name!r}")
+    return members
+
+
+def merge_archive(archive: Path, destination: Path) -> None:
+    members = safe_archive_members(archive)
+    with tarfile.open(archive, "r:gz") as bundle:
+        for member in members:
+            relative = PurePosixPath(member.name).relative_to("release-shard")
+            target = destination.joinpath(*relative.parts)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if target.exists():
+                raise FanoutError(f"duplicate evidence path across GCP shards: {relative}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise FanoutError(f"cannot extract evidence member: {member.name}")
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+
+
+def validate_result(
+    *, worker: dict[str, Any], result: dict[str, Any], manifest: dict[str, Any]
+) -> bool:
+    shard = worker["id"]
+    expected_run = f"{manifest['github_run_id']}-{manifest['github_run_attempt']}"
+    checks = {
+        "schema": (result.get("schema"), RESULT_SCHEMA),
+        "candidate_sha": (result.get("candidate_sha"), manifest["candidate_sha"]),
+        "github_run_id": (result.get("github_run_id"), expected_run),
+        "shard_id": (result.get("shard_id"), shard),
+        "gates": (result.get("gates"), sorted(worker["gates"])),
+        "publishing_attempted": (result.get("publishing_attempted"), False),
+    }
+    failures = [
+        f"{key}: expected {expected!r}, got {actual!r}"
+        for key, (actual, expected) in checks.items()
+        if actual != expected
+    ]
+    archive_sha = result.get("evidence_archive_sha256")
+    if not isinstance(archive_sha, str) or not re.fullmatch(r"[0-9a-f]{64}", archive_sha):
+        failures.append("evidence_archive_sha256 is missing or invalid")
+    if failures:
+        raise FanoutError(f"{shard} result failed verification:\n- " + "\n- ".join(failures))
+    status = result.get("status")
+    exit_code = result.get("exit_code")
+    if status == "PASS" and exit_code == 0:
+        return True
+    if status == "FAIL" and isinstance(exit_code, int) and exit_code != 0:
+        return False
+    raise FanoutError(
+        f"{shard} result has inconsistent status {status!r} and exit code {exit_code!r}"
+    )
+
+
+def verify_fanout(
+    *, manifest: dict[str, Any], downloads: Path, output: Path
+) -> dict[str, Any]:
+    validate_manifest(manifest)
+    if output.exists():
+        raise FanoutError(f"refusing to overwrite existing evidence directory: {output}")
+    if not downloads.is_dir():
+        raise FanoutError(f"GCP download directory does not exist: {downloads}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}-", dir=output.parent))
+    try:
+        controller = staging / "_gcp-controller"
+        controller.mkdir()
+        errors: list[str] = []
+        failed_shards: list[str] = []
+        trusted_shards: list[str] = []
+        for worker in manifest["workers"]:
+            shard = worker["id"]
+            shard_dir = downloads / shard
+            result_path = shard_dir / "result.json"
+            archive_path = shard_dir / "release-shard.tar.gz"
+            try:
+                result = load_json(result_path, f"{shard} result")
+                passed = validate_result(
+                    worker=worker, result=result, manifest=manifest
+                )
+            except FanoutError as error:
+                errors.append(str(error))
+                failed_shards.append(shard)
+                continue
+
+            shard_controller = controller / worker["id"]
+            shard_controller.mkdir()
+            shutil.copy2(result_path, shard_controller / "result.json")
+            log = result_path.with_name("qualification.log")
+            if log.is_file():
+                shutil.copy2(log, shard_controller / "qualification.log")
+            if not archive_path.is_file():
+                errors.append(f"{shard} evidence archive is missing")
+                failed_shards.append(shard)
+                continue
+            actual_sha = sha256(archive_path)
+            if actual_sha != result["evidence_archive_sha256"]:
+                errors.append(
+                    f"{shard} evidence archive digest mismatch: "
+                    f"expected {result['evidence_archive_sha256']}, got {actual_sha}"
+                )
+                failed_shards.append(shard)
+                continue
+            try:
+                merge_archive(archive_path, staging)
+            except FanoutError as error:
+                errors.append(str(error))
+                failed_shards.append(shard)
+                continue
+            trusted_shards.append(shard)
+            if not passed:
+                errors.append(f"{shard} reported a failed gate shard")
+                failed_shards.append(shard)
+
+        failed_shards = sorted(set(failed_shards))
+        receipt = {
+            "schema": "rvoip-gcp-release-fanout-receipt-v1",
+            "candidate_sha": manifest["candidate_sha"],
+            "github_run_id": manifest["github_run_id"],
+            "github_run_attempt": manifest["github_run_attempt"],
+            "worker_count": manifest["worker_count"],
+            "required_vcpus": manifest["required_vcpus"],
+            "trusted_shards": trusted_shards,
+            "failed_shards": failed_shards,
+            "errors": errors,
+            "status": "FAIL" if errors else "PASS",
+            "publishing_attempted": False,
+        }
+        write_json(controller / "fanout-receipt.json", receipt)
+        staging.rename(output)
+        return receipt
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    prepare = commands.add_parser("prepare")
+    prepare.add_argument("--matrix", type=Path, required=True)
+    prepare.add_argument("--candidate", required=True)
+    prepare.add_argument("--environment-id", required=True)
+    prepare.add_argument("--run-id", required=True)
+    prepare.add_argument("--run-attempt", required=True)
+    prepare.add_argument("--output", type=Path, required=True)
+
+    verify = commands.add_parser("verify")
+    verify.add_argument("--manifest", type=Path, required=True)
+    verify.add_argument("--downloads", type=Path, required=True)
+    verify.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "prepare":
+            manifest = prepare_manifest(
+                matrix=load_json(args.matrix, "GCP matrix"),
+                candidate=args.candidate,
+                environment_id=args.environment_id,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+            )
+            write_json(args.output, manifest)
+        else:
+            receipt = verify_fanout(
+                manifest=load_json(args.manifest, "GCP fanout manifest"),
+                downloads=args.downloads,
+                output=args.output,
+            )
+            print(json.dumps(receipt, sort_keys=True))
+            if receipt["status"] != "PASS":
+                return 1
+    except FanoutError as error:
+        print(f"GCP release fanout error: {error}", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_gcp_fanout.py
+++ b/scripts/test_release_gcp_fanout.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("release") / "gcp_fanout.py"
+SPEC = importlib.util.spec_from_file_location("release_gcp_fanout", SCRIPT)
+assert SPEC and SPEC.loader
+fanout = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fanout)
+
+
+class GcpReleaseFanoutTests(unittest.TestCase):
+    candidate = "c" * 40
+
+    @staticmethod
+    def matrix_entry(
+        shard: str,
+        *,
+        resource: str = "gcp-performance",
+        machine: str = "n2-standard-8",
+        gates: str = "perf.one,perf.two",
+    ) -> dict[str, object]:
+        return {
+            "id": shard,
+            "resource_class": resource,
+            "machine_type": machine,
+            "disk_type": "pd-standard",
+            "disk_size_gb": 200,
+            "gates_csv": gates,
+        }
+
+    def manifest(self) -> dict[str, object]:
+        return fanout.prepare_manifest(
+            matrix={
+                "include": [
+                    self.matrix_entry("gcp-performance-1"),
+                    self.matrix_entry(
+                        "gcp-performance-soak-1",
+                        resource="gcp-performance-soak",
+                        machine="n2-standard-4",
+                        gates="perf.soak",
+                    ),
+                ]
+            },
+            candidate=self.candidate,
+            environment_id="release-environment",
+            run_id="123456789",
+            run_attempt="2",
+        )
+
+    def test_prepare_is_deterministic_and_capacity_aware(self) -> None:
+        manifest = self.manifest()
+        self.assertEqual(manifest["worker_count"], 2)
+        self.assertEqual(manifest["required_vcpus"], 12)
+        workers = manifest["workers"]
+        self.assertEqual(
+            [worker["id"] for worker in workers],
+            ["gcp-performance-1", "gcp-performance-soak-1"],
+        )
+        self.assertEqual(
+            workers[0]["name"], "rvoip-rel-123456789-2-gcp-performance-1"
+        )
+        self.assertEqual(workers[0]["prefix"], "release/123456789-2/gcp-performance-1")
+        self.assertEqual(workers[0]["gates_b64"], "cGVyZi5vbmUscGVyZi50d28=")
+        fanout.validate_manifest(manifest)
+
+    def test_prepare_rejects_duplicate_shards_and_machine_downgrades(self) -> None:
+        duplicate = self.matrix_entry("gcp-performance-1")
+        with self.assertRaisesRegex(fanout.FanoutError, "duplicate GCP shard"):
+            fanout.prepare_manifest(
+                matrix={"include": [duplicate, duplicate]},
+                candidate=self.candidate,
+                environment_id="release-environment",
+                run_id="1",
+                run_attempt="1",
+            )
+        with self.assertRaisesRegex(fanout.FanoutError, "must use n2-standard-8"):
+            fanout.prepare_manifest(
+                matrix={
+                    "include": [
+                        self.matrix_entry(
+                            "gcp-performance-1", machine="n2-standard-4"
+                        )
+                    ]
+                },
+                candidate=self.candidate,
+                environment_id="release-environment",
+                run_id="1",
+                run_attempt="1",
+            )
+
+    @staticmethod
+    def write_archive(path: Path, member_name: str, payload: bytes) -> str:
+        with tarfile.open(path, "w:gz") as bundle:
+            member = tarfile.TarInfo(member_name)
+            member.size = len(payload)
+            bundle.addfile(member, io.BytesIO(payload))
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def populate_downloads(
+        self, root: Path, manifest: dict[str, object], *, unsafe: bool = False
+    ) -> None:
+        expected_run = (
+            f"{manifest['github_run_id']}-{manifest['github_run_attempt']}"
+        )
+        for index, worker in enumerate(manifest["workers"]):
+            shard = worker["id"]
+            directory = root / shard
+            directory.mkdir(parents=True)
+            archive = directory / "release-shard.tar.gz"
+            member = (
+                "release-shard/../escape"
+                if unsafe and index == 0
+                else f"release-shard/{shard}/receipt.json"
+            )
+            archive_sha = self.write_archive(archive, member, b'{"status":"PASS"}\n')
+            result = {
+                "schema": fanout.RESULT_SCHEMA,
+                "candidate_sha": manifest["candidate_sha"],
+                "github_run_id": expected_run,
+                "shard_id": shard,
+                "gates": sorted(worker["gates"]),
+                "exit_code": 0,
+                "status": "PASS",
+                "evidence_archive_sha256": archive_sha,
+                "publishing_attempted": False,
+            }
+            fanout.write_json(directory / "result.json", result)
+            (directory / "qualification.log").write_text("passed\n")
+
+    def test_verify_merges_every_shard_after_binding_all_evidence(self) -> None:
+        manifest = self.manifest()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            downloads = root / "downloads"
+            downloads.mkdir()
+            self.populate_downloads(downloads, manifest)
+            output = root / "release-shard"
+            receipt = fanout.verify_fanout(
+                manifest=manifest, downloads=downloads, output=output
+            )
+            self.assertEqual(receipt["status"], "PASS")
+            self.assertEqual(receipt["worker_count"], 2)
+            for worker in manifest["workers"]:
+                self.assertTrue((output / worker["id"] / "receipt.json").is_file())
+                self.assertTrue(
+                    (
+                        output
+                        / "_gcp-controller"
+                        / worker["id"]
+                        / "result.json"
+                    ).is_file()
+                )
+            fanout_receipt = json.loads(
+                (output / "_gcp-controller" / "fanout-receipt.json").read_text()
+            )
+            self.assertFalse(fanout_receipt["publishing_attempted"])
+
+    def test_verify_rejects_tampering_and_archive_traversal(self) -> None:
+        manifest = self.manifest()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            downloads = root / "downloads"
+            downloads.mkdir()
+            self.populate_downloads(downloads, manifest)
+            worker = manifest["workers"][0]
+            archive = downloads / worker["id"] / "release-shard.tar.gz"
+            archive.write_bytes(archive.read_bytes() + b"tampered")
+            receipt = fanout.verify_fanout(
+                manifest=manifest,
+                downloads=downloads,
+                output=root / "release-shard",
+            )
+            self.assertEqual(receipt["status"], "FAIL")
+            self.assertIn(worker["id"], receipt["failed_shards"])
+            self.assertTrue(any("digest mismatch" in error for error in receipt["errors"]))
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            downloads = root / "downloads"
+            downloads.mkdir()
+            self.populate_downloads(downloads, manifest, unsafe=True)
+            receipt = fanout.verify_fanout(
+                manifest=manifest,
+                downloads=downloads,
+                output=root / "release-shard",
+            )
+            self.assertEqual(receipt["status"], "FAIL")
+            self.assertTrue(
+                any("unsafe evidence archive" in error for error in receipt["errors"])
+            )
+
+    def test_failed_shard_preserves_all_bound_evidence_for_selective_retry(self) -> None:
+        manifest = self.manifest()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            downloads = root / "downloads"
+            downloads.mkdir()
+            self.populate_downloads(downloads, manifest)
+            failed = manifest["workers"][0]
+            result_path = downloads / failed["id"] / "result.json"
+            result = json.loads(result_path.read_text())
+            result["status"] = "FAIL"
+            result["exit_code"] = 1
+            fanout.write_json(result_path, result)
+
+            output = root / "release-shard"
+            receipt = fanout.verify_fanout(
+                manifest=manifest, downloads=downloads, output=output
+            )
+            self.assertEqual(receipt["status"], "FAIL")
+            self.assertEqual(receipt["failed_shards"], [failed["id"]])
+            self.assertEqual(len(receipt["trusted_shards"]), 2)
+            for worker in manifest["workers"]:
+                self.assertTrue((output / worker["id"] / "receipt.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A complete release plans 12 GitHub-hosted shards and 17 real GCP shards. The previous workflow used one GitHub Actions controller job per GCP worker, so GitHub's concurrent-job ceiling queued otherwise available Compute Engine capacity. The latest qualification consequently took 90 minutes and ran GCP shards in waves.

## Change

- Use one GitHub controller job to launch all 17 candidate-bound GCP workers concurrently.
- Preserve all gate assignments, N2 machine types, disks, thresholds, one-hour soaks, immutable GCS evidence, and cleanup behavior.
- Validate the controller manifest, exact candidate/gate binding, worker count, machine sizes, evidence hashes, archive paths, and merged receipts with a dedicated fail-closed helper.
- Let healthy workers finish after another shard fails, and preserve every trustworthy receipt so a corrected candidate can reuse unaffected evidence.
- Keep both in-job deletion and the independent interrupted-run sweep.
- Document the physical one-hour lower bound for fresh soak qualification and exact-input evidence reuse for follow-up candidates.

## Validation

- 87 release and workflow-policy tests pass locally.
- The real 177-gate `remote-release` catalog still plans 29 shards: 12 hosted and 17 GCP.
- The GCP manifest still requires 96 N2 vCPUs: seven `n2-standard-8` performance workers, nine `n2-standard-4` soak workers, and one `n2-standard-4` interoperability worker.
- Failed shards retain candidate-bound evidence while making the aggregate fail.
- Archive tampering, path traversal, duplicate shard IDs, altered manifests, candidate mismatches, missing results, failed shards, and machine downgrades fail closed.

## Risk

Medium: this changes orchestration and evidence collection for protected release qualification. It does not publish, change library APIs, or execute fork code on GCP. A full non-publishing qualification is required before release use.
