### PR TITLE
ci: catch release infrastructure failures in 15 minutes

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -9,11 +9,12 @@ on:
         default: main
         type: string
       profile:
-        description: Core dry run or complete release qualification
+        description: Infrastructure preflight, core dry run, or complete qualification
         required: true
         default: remote-core
         type: choice
         options:
+          - remote-preflight
           - remote-core
           - remote-release
       first_candidate:
@@ -35,8 +36,8 @@ permissions:
   actions: read
 
 concurrency:
-  group: release-qualification-${{ inputs.candidate }}
-  cancel-in-progress: false
+  group: release-qualification-${{ inputs.profile }}-${{ inputs.candidate }}
+  cancel-in-progress: ${{ inputs.profile == 'remote-preflight' }}
 
 env:
   RELEASE_ENVIRONMENT_ID: rvoip-release-v1-rust-1.91-nextest-0.9.140
@@ -72,7 +73,7 @@ jobs:
         with:
           toolchain: 1.91.0
 
-      - name: Require candidate to belong to origin/main
+      - name: Require candidate to belong to protected origin/main
         run: |
           git fetch origin main
           git merge-base --is-ancestor HEAD origin/main || {
@@ -94,7 +95,7 @@ jobs:
           PY
 
       - name: Download prior qualification evidence
-        if: inputs.prior_run_id != ''
+        if: inputs.profile != 'remote-preflight' && inputs.prior_run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PRIOR_RUN_ID: ${{ inputs.prior_run_id }}
@@ -121,13 +122,13 @@ jobs:
             --output target/release-plan/plan.json
             --github-output "$GITHUB_OUTPUT"
           )
-          if test "$FIRST_CANDIDATE" = true; then
+          if test "$FIRST_CANDIDATE" = true || test "$PROFILE" = remote-preflight; then
             args+=(--first-candidate)
           fi
-          if test -n "$PRIOR_RUN_ID"; then
+          if test "$PROFILE" != remote-preflight && test -n "$PRIOR_RUN_ID"; then
             args+=(--prior-evidence target/prior-evidence)
           fi
-          if test -n "$CHANGED_SINCE"; then
+          if test "$PROFILE" != remote-preflight && test -n "$CHANGED_SINCE"; then
             args+=(--changed-since "$CHANGED_SINCE")
           fi
           python3 scripts/release/gates.py plan "${args[@]}"
@@ -236,7 +237,7 @@ jobs:
     steps:
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ vars.RVOIP_GCP_PILOT_PROVIDER }}
+          workload_identity_provider: ${{ vars.RVOIP_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.RVOIP_GCP_PROVISIONER_SERVICE_ACCOUNT }}
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
       - name: Require all compute and disk quota before creating workers
@@ -307,7 +308,7 @@ jobs:
       - name: Authenticate to Google Cloud without a key
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ vars.RVOIP_GCP_PILOT_PROVIDER }}
+          workload_identity_provider: ${{ vars.RVOIP_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.RVOIP_GCP_PROVISIONER_SERVICE_ACCOUNT }}
 
       - name: Install Google Cloud CLI
@@ -550,7 +551,7 @@ jobs:
     steps:
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ vars.RVOIP_GCP_PILOT_PROVIDER }}
+          workload_identity_provider: ${{ vars.RVOIP_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.RVOIP_GCP_PROVISIONER_SERVICE_ACCOUNT }}
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
       - name: Sweep workers left by interrupted controllers

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -25,11 +25,20 @@ the lockfile transactionally.
 ## Verify
 
 After the preparation PR merges, run **Release qualification** for that exact
-`main` commit. Use `remote-core` for a hosted-runner dry run and
-`remote-release` for the complete release profile. The first candidate should
-set `first_candidate=true`; after a fix, provide the prior qualification run
-and the previous candidate SHA so exact matching evidence can be reused while
-failed and affected gates are rerun.
+`main` commit. After release-orchestration changes merge, use
+`remote-preflight` first. It launches the same 17-worker, 96-vCPU GCP shape as a full run, but
+executes short infrastructure probes so credentials, quota, VM startup, OS
+limits, tool installation, repository checkout, GCS evidence transfer,
+controller reconciliation, and cleanup fail within a target of 15 minutes.
+The preflight is deliberately non-publishing and is not release evidence.
+
+Use `remote-core` for a hosted-runner dry run and `remote-release` for the
+complete release profile. Do not start the full profile unless the exact
+release machinery has a recent successful preflight. The first candidate
+should set `first_candidate=true`; after a fix, provide the prior qualification
+run and the previous candidate SHA so exact matching evidence can be reused
+while failed and affected gates are rerun. Diagnose and reproduce a failed gate
+by itself before spending another complete qualification run.
 
 The workflow produces a candidate-bound plan, per-gate receipts, and one
 aggregate qualification receipt. A gate can be reused only when its source,
@@ -74,6 +83,9 @@ The current full profile is balanced across seven `n2-standard-8` performance
 workers, nine `n2-standard-4` soak workers, and one `n2-standard-4`
 interoperability worker. These are real performance machines; the workflow
 does not substitute GitHub-hosted capacity or reduce workloads and thresholds.
+The `remote-preflight` profile recreates that complete capacity shape, including
+all 17 concurrent VM creations, but its short probes never substitute for the
+real performance, interoperability, and soak commands in `remote-release`.
 The one-hour soak establishes a physical lower bound of one hour for a fresh
 qualification, plus provisioning, build, evidence, and cleanup time. Gates
 whose exact source, dependency, definition, environment, and threshold digests

--- a/infra/release-runners/README.md
+++ b/infra/release-runners/README.md
@@ -14,14 +14,23 @@ integration tests, binaries, examples, doctests, and Clippy. `smoke` substitutes
 an all-target WebRTC dependency check for the full workspace suite. Neither
 profile publishes crates, creates a tag, or creates a GitHub release.
 
-This pilot does not claim coverage for the external PBX, long-soak, or
-performance gates that still require structured remote replacements. The
-`remote-release` profile remains fail-closed until those mappings exist.
+This older pilot does not claim coverage for the external PBX, long-soak, or
+performance gates. Those gates now have structured replacements in the
+protected `remote-release` profile; its coverage ledger still fails closed if
+any canonical gate becomes unmapped.
 
 The protected `Release qualification` workflow uses the same ephemeral model
-for the complete gate catalog. A single GitHub controller launches every
-duration-balanced GCP shard concurrently, rather than consuming one GitHub job
-slot per cloud worker. Each worker is bound to one candidate SHA and gate list,
-uploads an immutable result and evidence archive, shuts down, and is deleted
-with its auto-delete disk. Controller and follow-up sweep cleanup both run on
-failure; there is no idle release fleet.
+for the complete gate catalog. Its `remote-preflight` profile launches the full
+release capacity shape—seven `n2-standard-8` performance workers, nine
+`n2-standard-4` soak workers, and one `n2-standard-4` interoperability
+worker—but runs short infrastructure probes. That makes controller, quota,
+startup, OS-limit, dependency, evidence-transfer, and cleanup defects visible
+before a full qualification begins. It is non-publishing and cannot qualify a
+release.
+
+For both preflight and the complete `remote-release` profile, a single GitHub
+controller launches every duration-balanced GCP shard concurrently rather than
+consuming one GitHub job slot per cloud worker. Each worker is bound to one
+candidate SHA and gate list, uploads an immutable result and evidence archive,
+shuts down, and is deleted with its auto-delete disk. Controller and follow-up
+sweep cleanup both run on failure; there is no idle release fleet.

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -111,7 +111,8 @@ if [[ "$RESOURCE_CLASS" == "gcp-interop" ]]; then
   command -v sipp >/dev/null
   command -v tshark >/dev/null
   docker compose version >/dev/null
-elif [[ ",$GATES," == *",perf.sipp-parity,"* ]]; then
+elif [[ ",$GATES," == *",perf.sipp-parity,"* \
+  || ",$GATES," == *",preflight.performance-01,"* ]]; then
   # This performance test otherwise treats a missing external SIPp binary as a
   # local-development skip. Release qualification must execute it, not skip it.
   apt-get install -y --no-install-recommends sip-tester
@@ -136,6 +137,12 @@ test "$(git rev-parse HEAD)" = "$CANDIDATE"
 # future image cannot provide it.
 ulimit -n 262144
 test "$(ulimit -n)" -ge 262144
+
+export RVOIP_RELEASE_CANDIDATE="$CANDIDATE"
+export RVOIP_RELEASE_GATES="$GATES"
+export RVOIP_RELEASE_RESOURCE_CLASS="$RESOURCE_CLASS"
+export RVOIP_RELEASE_RUN_ID="$RUN_ID"
+export RVOIP_RELEASE_SHARD_ID="$SHARD_ID"
 
 python3 scripts/release/gates.py run-shard \
   --candidate "$CANDIDATE" \

--- a/infra/release-runners/release-infrastructure-preflight.sh
+++ b/infra/release-runners/release-infrastructure-preflight.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+EXPECTED_RESOURCE="${1:?expected GCP resource class is required}"
+ARTIFACT_DIR="${2:?artifact directory is required}"
+
+case "$EXPECTED_RESOURCE" in
+  gcp-performance)
+    EXPECTED_VCPUS=8
+    EXPECTED_MEMORY_GIB=28
+    ;;
+  gcp-performance-soak|gcp-interop)
+    EXPECTED_VCPUS=4
+    EXPECTED_MEMORY_GIB=14
+    ;;
+  *)
+    echo "unsupported preflight resource class: $EXPECTED_RESOURCE" >&2
+    exit 2
+    ;;
+esac
+
+test "${RVOIP_RELEASE_RESOURCE_CLASS:-}" = "$EXPECTED_RESOURCE"
+test -n "${RVOIP_RELEASE_CANDIDATE:-}"
+test -n "${RVOIP_RELEASE_SHARD_ID:-}"
+test -n "${RVOIP_RELEASE_GATES:-}"
+test "$(git rev-parse HEAD)" = "$RVOIP_RELEASE_CANDIDATE"
+test -z "${CARGO_REGISTRY_TOKEN:-}"
+test -z "${CRATES_IO_TOKEN:-}"
+
+ACTUAL_VCPUS="$(nproc)"
+NOFILE_LIMIT="$(ulimit -n)"
+MEMORY_KIB="$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)"
+DISK_BYTES="$(df --output=size -B1 / | tail -n 1 | tr -d ' ')"
+
+test "$ACTUAL_VCPUS" -ge "$EXPECTED_VCPUS"
+test "$NOFILE_LIMIT" -ge 262144
+test "$MEMORY_KIB" -ge "$(( EXPECTED_MEMORY_GIB * 1024 * 1024 ))"
+test "$DISK_BYTES" -ge "$(( 180 * 1024 * 1024 * 1024 ))"
+
+for program in cargo cmake git jq pkg-config protoc rustc; do
+  command -v "$program" >/dev/null
+done
+
+if [[ "$EXPECTED_RESOURCE" == gcp-interop ]]; then
+  command -v sipp >/dev/null
+  command -v tshark >/dev/null
+  command -v docker >/dev/null
+  docker compose version >/dev/null
+  systemctl is-active --quiet docker
+elif [[ ",$RVOIP_RELEASE_GATES," == *",preflight.performance-01,"* ]]; then
+  # This worker exercises the conditional SIPp dependency path used by the
+  # real perf.sipp-parity release gate.
+  command -v sipp >/dev/null
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+cargo metadata --locked --no-deps --format-version 1 \
+  > "$ARTIFACT_DIR/cargo-metadata.json"
+
+python3 - "$ARTIFACT_DIR/cargo-metadata.json" <<'PY'
+import json
+import sys
+
+metadata = json.load(open(sys.argv[1], encoding="utf-8"))
+members = set(metadata["workspace_members"])
+publishable = [
+    package
+    for package in metadata["packages"]
+    if package["id"] in members and package.get("publish") != []
+]
+if len(publishable) != 44:
+    raise SystemExit(f"expected 44 publishable workspace packages, found {len(publishable)}")
+PY
+
+# Opening thousands of descriptors catches the stock systemd soft-limit bug
+# in seconds instead of after a high-density performance gate has compiled.
+python3 - <<'PY'
+import socket
+
+sockets = []
+try:
+    for _ in range(4096):
+        item = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        item.bind(("127.0.0.1", 0))
+        sockets.append(item)
+finally:
+    for item in sockets:
+        item.close()
+PY
+
+python3 - \
+  "$ARTIFACT_DIR/system.json" \
+  "$EXPECTED_RESOURCE" \
+  "$ACTUAL_VCPUS" \
+  "$NOFILE_LIMIT" \
+  "$MEMORY_KIB" \
+  "$DISK_BYTES" <<'PY'
+import json
+import os
+import platform
+import sys
+
+path, resource, vcpus, nofile, memory_kib, disk_bytes = sys.argv[1:]
+payload = {
+    "schema": "rvoip-release-infrastructure-preflight-v1",
+    "candidate_sha": os.environ["RVOIP_RELEASE_CANDIDATE"],
+    "gate_ids": sorted(filter(None, os.environ["RVOIP_RELEASE_GATES"].split(","))),
+    "kernel": platform.release(),
+    "memory_kib": int(memory_kib),
+    "nofile_limit": int(nofile),
+    "publishing_credentials_present": False,
+    "resource_class": resource,
+    "root_disk_bytes": int(disk_bytes),
+    "shard_id": os.environ["RVOIP_RELEASE_SHARD_ID"],
+    "vcpus": int(vcpus),
+}
+with open(path, "w", encoding="utf-8") as output:
+    json.dump(payload, output, indent=2, sort_keys=True)
+    output.write("\n")
+PY
+

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -132,7 +132,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("sip-tester", startup)
         self.assertIn("tshark", startup)
         self.assertIn("docker-compose-v2", startup)
-        self.assertIn('elif [[ ",$GATES," == *",perf.sipp-parity,"* ]]', startup)
+        self.assertIn('",$GATES," == *",perf.sipp-parity,"*', startup)
+        self.assertIn('",$GATES," == *",preflight.performance-01,"*', startup)
         self.assertGreaterEqual(startup.count("command -v sipp >/dev/null"), 2)
         self.assertIn("command -v tshark >/dev/null", startup)
         self.assertIn("docker compose version >/dev/null", startup)
@@ -140,6 +141,31 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('test "$(ulimit -n)" -ge 262144', startup)
         self.assertIn("-name '*.jsonl'", startup)
         self.assertNotRegex(startup, r"apt-get install[^\n]*\bsipp\b")
+
+    def test_release_infrastructure_preflight_is_full_shape_and_non_publishing(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        startup = (ROOT / "infra/release-runners/gcp-release-startup.sh").read_text()
+        probe = (
+            ROOT / "infra/release-runners/release-infrastructure-preflight.sh"
+        ).read_text()
+
+        self.assertIn("remote-preflight", workflow)
+        self.assertIn(
+            'test "$FIRST_CANDIDATE" = true || test "$PROFILE" = remote-preflight',
+            workflow,
+        )
+        self.assertIn("Require candidate to belong to protected origin/main", workflow)
+        self.assertIn("RVOIP_GCP_WORKLOAD_IDENTITY_PROVIDER", workflow)
+        self.assertNotIn("RVOIP_GCP_PILOT_PROVIDER", workflow)
+        self.assertIn('export RVOIP_RELEASE_RESOURCE_CLASS="$RESOURCE_CLASS"', startup)
+        self.assertIn('export RVOIP_RELEASE_CANDIDATE="$CANDIDATE"', startup)
+        self.assertIn('export RVOIP_RELEASE_GATES="$GATES"', startup)
+        self.assertIn("expected 44 publishable workspace packages", probe)
+        self.assertIn("for _ in range(4096)", probe)
+        self.assertIn('test "$NOFILE_LIMIT" -ge 262144', probe)
+        self.assertIn('test -z "${CARGO_REGISTRY_TOKEN:-}"', probe)
+        self.assertIn('test -z "${CRATES_IO_TOKEN:-}"', probe)
+        self.assertIn('"publishing_credentials_present": False', probe)
 
     def test_release_gcp_workers_do_not_consume_one_github_job_each(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()

--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -439,6 +439,50 @@ def synthetic_gate(
     }
 
 
+def infrastructure_preflight_gates() -> list[dict[str, Any]]:
+    """Build the full-shape, short-running GCP orchestration acceptance profile.
+
+    The release profile currently uses seven performance workers, nine soak
+    workers, and one interoperability worker.  Keep the same fanout here so a
+    controller, quota, startup, evidence, or cleanup defect is found before a
+    real hour-long qualification begins.
+    """
+    paths = [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py",
+    ]
+    result = []
+    for resource, count in (
+        ("gcp-performance", 7),
+        ("gcp-performance-soak", 9),
+        ("gcp-interop", 1),
+    ):
+        suffix = resource.removeprefix("gcp-")
+        for index in range(1, count + 1):
+            result.append(
+                synthetic_gate(
+                    f"preflight.{suffix}-{index:02d}",
+                    f"{resource} worker {index:02d} infrastructure acceptance",
+                    executor="argv",
+                    command=[
+                        "bash",
+                        "infra/release-runners/release-infrastructure-preflight.sh",
+                        resource,
+                        "{artifact_dir}",
+                    ],
+                    resource=resource,
+                    paths=paths,
+                    always_fresh=True,
+                )
+            )
+    return result
+
+
 def security_gates() -> list[dict[str, Any]]:
     result = [
         synthetic_gate(
@@ -605,6 +649,7 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
         ),
     ]
     synthetic.extend(burst_scenario_gates())
+    preflight = infrastructure_preflight_gates()
     core = [core_gate(package, root, weights) for package in package_rows]
     security = security_gates()
     remote_without_final = [gate["id"] for gate in synthetic + core + security]
@@ -624,7 +669,7 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
             always_fresh=True,
         ),
     ]
-    gates = legacy + synthetic + core + security + final
+    gates = legacy + synthetic + preflight + core + security + final
 
     direct_legacy = [gate["id"] for gate in legacy if gate["executor"] == "argv"]
     structured_legacy = [
@@ -683,6 +728,7 @@ def build_catalog(root: Path, source: Path) -> dict[str, Any]:
                     + [f"perf.media-burst.{scenario}" for scenario in BURST_SCENARIOS]
                 )
             ),
+            "remote-preflight": sorted(gate["id"] for gate in preflight),
             "remote-core": remote_core,
             "remote-release": remote_release,
         },

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -5801,6 +5801,669 @@
       "working_directory": "."
     },
     {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-01",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance worker 01 infrastructure acceptance",
+      "resource_class": "gcp-performance",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-02",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance worker 02 infrastructure acceptance",
+      "resource_class": "gcp-performance",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-03",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance worker 03 infrastructure acceptance",
+      "resource_class": "gcp-performance",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-04",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance worker 04 infrastructure acceptance",
+      "resource_class": "gcp-performance",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-05",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance worker 05 infrastructure acceptance",
+      "resource_class": "gcp-performance",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-06",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance worker 06 infrastructure acceptance",
+      "resource_class": "gcp-performance",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-07",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance worker 07 infrastructure acceptance",
+      "resource_class": "gcp-performance",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-01",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 01 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-02",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 02 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-03",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 03 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-04",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 04 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-05",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 05 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-06",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 06 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-07",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 07 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-08",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 08 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-performance-soak",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-performance-soak {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.performance-soak-09",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-performance-soak worker 09 infrastructure acceptance",
+      "resource_class": "gcp-performance-soak",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
+      "affected_crates": [],
+      "affected_paths": [
+        ".github/workflows/release-qualify.yml",
+        "infra/release-runners/gcp-release-startup.sh",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "scripts/release/build_gate_catalog.py",
+        "scripts/release/gates.py",
+        "scripts/release/gates.json",
+        "scripts/release/gcp_fanout.py"
+      ],
+      "always_fresh": true,
+      "category": "Remote release framework",
+      "command": [
+        "bash",
+        "infra/release-runners/release-infrastructure-preflight.sh",
+        "gcp-interop",
+        "{artifact_dir}"
+      ],
+      "dependencies": [],
+      "display_command": "bash infra/release-runners/release-infrastructure-preflight.sh gcp-interop {artifact_dir}",
+      "estimated_seconds": 1,
+      "executor": "argv",
+      "expected_outputs": [
+        "receipt.json",
+        "command.log"
+      ],
+      "id": "preflight.interop-01",
+      "kind": "remote",
+      "legacy": null,
+      "max_infrastructure_retries": 1,
+      "name": "gcp-interop worker 01 infrastructure acceptance",
+      "resource_class": "gcp-interop",
+      "retry_on_exit_codes": [
+        75
+      ],
+      "timeout_minutes": 60,
+      "working_directory": "."
+    },
+    {
       "affected_crates": [
         "rvoip"
       ],
@@ -8529,6 +9192,25 @@
       "test.workspace-doctest",
       "test.workspace-integration",
       "test.workspace-unit"
+    ],
+    "remote-preflight": [
+      "preflight.interop-01",
+      "preflight.performance-01",
+      "preflight.performance-02",
+      "preflight.performance-03",
+      "preflight.performance-04",
+      "preflight.performance-05",
+      "preflight.performance-06",
+      "preflight.performance-07",
+      "preflight.performance-soak-01",
+      "preflight.performance-soak-02",
+      "preflight.performance-soak-03",
+      "preflight.performance-soak-04",
+      "preflight.performance-soak-05",
+      "preflight.performance-soak-06",
+      "preflight.performance-soak-07",
+      "preflight.performance-soak-08",
+      "preflight.performance-soak-09"
     ],
     "remote-release": [
       "build.claimed-lower-crates",

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -1089,7 +1089,11 @@ def parser() -> argparse.ArgumentParser:
     commands = result.add_subparsers(dest="command", required=True)
     commands.add_parser("validate")
     plan = commands.add_parser("plan")
-    plan.add_argument("--profile", choices=("remote-core", "remote-release", "legacy-full"), required=True)
+    plan.add_argument(
+        "--profile",
+        choices=("remote-preflight", "remote-core", "remote-release", "legacy-full"),
+        required=True,
+    )
     plan.add_argument("--candidate", required=True)
     plan.add_argument("--environment-id", required=True)
     plan.add_argument("--prior-evidence", type=Path)

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -154,6 +154,46 @@ class GateFrameworkTests(unittest.TestCase):
         self.assertEqual(aggregate["executor"], "aggregate")
         self.assertEqual(set(aggregate["dependencies"]), scenario_ids)
 
+    def test_remote_preflight_recreates_the_complete_gcp_worker_shape(self) -> None:
+        selected = self.catalog["profiles"]["remote-preflight"]
+        self.assertEqual(len(selected), 17)
+        by_id = {gate["id"]: gate for gate in self.catalog["gates"]}
+        matrix = gates.matrix_for(
+            [{"id": gate_id, "decision": "RUN"} for gate_id in selected],
+            by_id,
+        )
+        counts = {
+            resource: sum(shard["resource_class"] == resource for shard in matrix)
+            for resource in (
+                "gcp-performance",
+                "gcp-performance-soak",
+                "gcp-interop",
+            )
+        }
+        self.assertEqual(
+            counts,
+            {
+                "gcp-performance": 7,
+                "gcp-performance-soak": 9,
+                "gcp-interop": 1,
+            },
+        )
+        self.assertEqual(len(matrix), 17)
+        self.assertEqual(
+            sum(int(shard["machine_type"].rsplit("-", 1)[1]) for shard in matrix),
+            96,
+        )
+        self.assertTrue(all(not shard["hosted"] for shard in matrix))
+        self.assertTrue(all(len(shard["gates"]) == 1 for shard in matrix))
+        for gate_id in selected:
+            with self.subTest(gate=gate_id):
+                gate = by_id[gate_id]
+                self.assertTrue(gate["always_fresh"])
+                self.assertIn(
+                    "infra/release-runners/release-infrastructure-preflight.sh",
+                    gate["command"],
+                )
+
     def test_remote_release_requires_bridgefu_chromium_dtmf_regression(self) -> None:
         gate_id = "interop.browser-dtmf"
         self.assertIn(gate_id, self.catalog["profiles"]["remote-release"])


### PR DESCRIPTION
## Problem
Release orchestration defects were being discovered only after 90–120 minute qualification attempts. Seven consecutive runs consumed a day without producing a qualifying receipt.

## Fix
- Add a non-publishing remote-preflight profile.
- Launch the exact full GCP release shape: 17 concurrent workers and 96 N2 vCPUs.
- Exercise the same protected identity, controller, startup script, OS limits, dependency installation, candidate checkout, GCS evidence path, reconciliation, shutdown, and cleanup.
- Open 4,096 sockets per worker so the prior nofile defect fails immediately.
- Keep all real performance, interoperability, soak workloads, and thresholds unchanged.
- Force every preflight probe to run fresh; its aggregate cannot be accepted for publication.

## Affected areas
Release qualification automation and documentation only. No Rust public API changes.

## Verification
- 89 release and workflow-policy tests pass.
- Gate catalog regenerates deterministically and validates all 108 legacy mappings and 44 crate gates.
- Planned preflight matrix is exactly 7 n2-standard-8 performance, 9 n2-standard-4 soak, and 1 n2-standard-4 interoperability worker (96 vCPUs).
- Shell syntax and diff hygiene pass.

## Risk
The preflight consumes short-lived billable GCP capacity when manually dispatched on protected main. All instances and auto-delete disks are swept on success, failure, or interruption. Target completion is under 15 minutes; it is an infrastructure acceptance test, not release qualification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protected release qualification workflows, GCP workload identity configuration, and gate catalog; misconfiguration could block qualifications or briefly spin billable GCP capacity, but probes do not publish and do not alter real release gate commands.
> 
> **Overview**
> Adds a **`remote-preflight`** dispatch option to **Release qualification** so release orchestration can be exercised on the **same 17-worker / 96 vCPU GCP fanout** as `remote-release`, but with **short infrastructure probes** instead of real perf/soak/interop workloads. Probes are **non-publishing**, **always run fresh** (no prior-run reuse), and are **not** valid release evidence.
> 
> The gate catalog gains **17 `preflight.*` gates** (mirroring 7 performance, 9 soak, 1 interop workers) that run `release-infrastructure-preflight.sh`: candidate checkout binding, vCPU/memory/disk/nofile checks, toolchain presence, optional SIPp/docker on the right classes, **4096-socket** stress, locked `cargo metadata` (44 packages), and asserts **no crates.io tokens**. Workers receive **`RVOIP_RELEASE_*` exports** from `gcp-release-startup.sh`; SIPp install also triggers for `preflight.performance-01`.
> 
> Workflow behavior updates: **concurrency** keyed by profile+candidate with **cancel-in-progress** for preflight; planning **forces `--first-candidate`** and **skips** prior evidence / `changed_since` for preflight; GCP auth uses **`RVOIP_GCP_WORKLOAD_IDENTITY_PROVIDER`** (replacing the pilot var). Docs and workflow-policy tests encode running preflight after orchestration changes before full qualification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a328120ccb7d7b64c7f91da1532d174619f263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->