### PR TITLE
ci: rerun exact failed release gates

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -4,26 +4,31 @@ on:
   workflow_dispatch:
     inputs:
       candidate:
-        description: Commit or main ref to qualify
+        description: Protected main commit or ref to diagnose or qualify
         required: true
         default: main
         type: string
       profile:
-        description: Infrastructure preflight, core dry run, or complete qualification
+        description: Preflight, exact-gate diagnosis, core dry run, or qualification
         required: true
         default: remote-core
         type: choice
         options:
           - remote-preflight
+          - remote-diagnostic
           - remote-core
           - remote-release
+      diagnostic_gates:
+        description: Comma-separated exact GCP gate IDs for remote-diagnostic
+        required: false
+        type: string
       first_candidate:
         description: Force every selected gate to run fresh
         required: true
         default: true
         type: boolean
       prior_run_id:
-        description: Optional successful/failed qualification run to reuse exactly matching evidence
+        description: Optional comma-separated run IDs whose exact matching evidence may be reused
         required: false
         type: string
       changed_since:
@@ -37,7 +42,7 @@ permissions:
 
 concurrency:
   group: release-qualification-${{ inputs.profile }}-${{ inputs.candidate }}
-  cancel-in-progress: ${{ inputs.profile == 'remote-preflight' }}
+  cancel-in-progress: ${{ inputs.profile == 'remote-preflight' || inputs.profile == 'remote-diagnostic' }}
 
 env:
   RELEASE_ENVIRONMENT_ID: rvoip-release-v1-rust-1.91-nextest-0.9.140
@@ -95,16 +100,29 @@ jobs:
           PY
 
       - name: Download prior qualification evidence
-        if: inputs.profile != 'remote-preflight' && inputs.prior_run_id != ''
+        if: inputs.profile != 'remote-preflight' && inputs.profile != 'remote-diagnostic' && inputs.prior_run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          PRIOR_RUN_ID: ${{ inputs.prior_run_id }}
+          PRIOR_RUN_IDS: ${{ inputs.prior_run_id }}
           REPOSITORY: ${{ github.repository }}
-        run: >-
-          gh run download "$PRIOR_RUN_ID"
-          --repo "$REPOSITORY"
-          --name release-gate-evidence
-          --dir target/prior-evidence
+        run: |
+          set -euo pipefail
+          IFS=, read -r -a run_ids <<< "$PRIOR_RUN_IDS"
+          if (( ${#run_ids[@]} > 5 )); then
+            echo "at most five prior evidence runs may be combined" >&2
+            exit 1
+          fi
+          for value in "${run_ids[@]}"; do
+            run_id="${value//[[:space:]]/}"
+            [[ "$run_id" =~ ^[1-9][0-9]*$ ]] || {
+              echo "invalid prior run ID: $value" >&2
+              exit 1
+            }
+            gh run download "$run_id" \
+              --repo "$REPOSITORY" \
+              --name release-gate-evidence \
+              --dir "target/prior-evidence/$run_id"
+          done
 
       - name: Plan fresh and reusable gates
         id: plan
@@ -113,6 +131,7 @@ jobs:
           FIRST_CANDIDATE: ${{ inputs.first_candidate }}
           PRIOR_RUN_ID: ${{ inputs.prior_run_id }}
           CHANGED_SINCE: ${{ inputs.changed_since }}
+          DIAGNOSTIC_GATES: ${{ inputs.diagnostic_gates }}
           PROFILE: ${{ inputs.profile }}
         run: |
           args=(
@@ -122,13 +141,22 @@ jobs:
             --output target/release-plan/plan.json
             --github-output "$GITHUB_OUTPUT"
           )
-          if test "$FIRST_CANDIDATE" = true || test "$PROFILE" = remote-preflight; then
+          if test "$PROFILE" = remote-diagnostic; then
+            args+=(--only-gates "$DIAGNOSTIC_GATES")
+          fi
+          if test "$FIRST_CANDIDATE" = true \
+            || test "$PROFILE" = remote-preflight \
+            || test "$PROFILE" = remote-diagnostic; then
             args+=(--first-candidate)
           fi
-          if test "$PROFILE" != remote-preflight && test -n "$PRIOR_RUN_ID"; then
+          if test "$PROFILE" != remote-preflight \
+            && test "$PROFILE" != remote-diagnostic \
+            && test -n "$PRIOR_RUN_ID"; then
             args+=(--prior-evidence target/prior-evidence)
           fi
-          if test "$PROFILE" != remote-preflight && test -n "$CHANGED_SINCE"; then
+          if test "$PROFILE" != remote-preflight \
+            && test "$PROFILE" != remote-diagnostic \
+            && test -n "$CHANGED_SINCE"; then
             args+=(--changed-since "$CHANGED_SINCE")
           fi
           python3 scripts/release/gates.py plan "${args[@]}"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,9 +36,26 @@ Use `remote-core` for a hosted-runner dry run and `remote-release` for the
 complete release profile. Do not start the full profile unless the exact
 release machinery has a recent successful preflight. The first candidate
 should set `first_candidate=true`; after a fix, provide the prior qualification
-run and the previous candidate SHA so exact matching evidence can be reused
-while failed and affected gates are rerun. Diagnose and reproduce a failed gate
-by itself before spending another complete qualification run.
+run and the previous candidate SHA, and set `first_candidate=false`, so exact
+matching evidence can be reused while failed and affected gates are rerun.
+Diagnose and reproduce a failed gate by itself before spending another complete
+qualification run.
+
+For a real GCP performance, soak, or interoperability failure, dispatch
+`remote-diagnostic` on protected `main` and enter one or more exact catalog gate
+IDs in `diagnostic_gates`, separated by commas. The planner accepts only
+executable GCP gates from `remote-release`, adds their declared dependencies,
+and forces them to run fresh with their release commands, machines, workloads,
+and thresholds. At most 20 gates may be requested. The resulting profile is
+non-publishing and cannot qualify a release.
+
+The next complete qualification may combine up to five evidence runs by
+entering their comma-separated IDs in `prior_run_id`. This lets it consume the
+successful receipts from a failed full run plus corrected diagnostic runs,
+while still rerunning anything failed, changed, stale, missing, or
+digest-mismatched. Candidate inventory and final aggregate receipts are always
+regenerated. Use `changed_since` for the previous candidate SHA after a code
+fix; unknown mappings still invalidate the full profile.
 
 The workflow produces a candidate-bound plan, per-gate receipts, and one
 aggregate qualification receipt. A gate can be reused only when its source,

--- a/infra/release-runners/README.md
+++ b/infra/release-runners/README.md
@@ -28,6 +28,13 @@ startup, OS-limit, dependency, evidence-transfer, and cleanup defects visible
 before a full qualification begins. It is non-publishing and cannot qualify a
 release.
 
+Its `remote-diagnostic` profile accepts only named executable GCP gates already
+present in `remote-release`. It expands their dependency closure and uses the
+same machines, startup path, commands, workloads, thresholds, immutable
+evidence, and cleanup. It cannot publish or qualify a release. A later complete
+qualification can combine exact receipts from up to five prior runs, avoiding
+a full rerun after a corrected or transient isolated failure.
+
 For both preflight and the complete `remote-release` profile, a single GitHub
 controller launches every duration-balanced GCP shard concurrently rather than
 consuming one GitHub job slot per cloud worker. Each worker is bound to one

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -150,10 +150,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         ).read_text()
 
         self.assertIn("remote-preflight", workflow)
-        self.assertIn(
-            'test "$FIRST_CANDIDATE" = true || test "$PROFILE" = remote-preflight',
-            workflow,
-        )
+        self.assertIn('test "$PROFILE" = remote-preflight', workflow)
         self.assertIn("Require candidate to belong to protected origin/main", workflow)
         self.assertIn("RVOIP_GCP_WORKLOAD_IDENTITY_PROVIDER", workflow)
         self.assertNotIn("RVOIP_GCP_PILOT_PROVIDER", workflow)
@@ -166,6 +163,22 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('test -z "${CARGO_REGISTRY_TOKEN:-}"', probe)
         self.assertIn('test -z "${CRATES_IO_TOKEN:-}"', probe)
         self.assertIn('"publishing_credentials_present": False', probe)
+
+    def test_remote_diagnostics_are_exact_gate_fresh_and_non_publishing(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        publication = (ROOT / ".github/workflows/release-publish.yml").read_text()
+
+        self.assertIn("remote-diagnostic", workflow)
+        self.assertIn("diagnostic_gates:", workflow)
+        self.assertIn('args+=(--only-gates "$DIAGNOSTIC_GATES")', workflow)
+        self.assertIn('test "$PROFILE" = remote-diagnostic', workflow)
+        self.assertIn("inputs.profile != 'remote-diagnostic'", workflow)
+        self.assertIn("at most five prior evidence runs may be combined", workflow)
+        self.assertIn('--dir "target/prior-evidence/$run_id"', workflow)
+        self.assertIn(
+            'test "$(jq -r .profile "$aggregate")" = remote-release',
+            publication,
+        )
 
     def test_release_gcp_workers_do_not_consume_one_github_job_each(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -25,6 +25,7 @@ PLAN_SCHEMA = "rvoip-release-gate-plan-v1"
 RECEIPT_SCHEMA = "rvoip-release-gate-receipt-v1"
 AGGREGATE_SCHEMA = "rvoip-release-qualification-v1"
 DEFAULT_CATALOG = Path("scripts/release/gates.json")
+MAX_DIAGNOSTIC_GATES = 20
 COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 
 
@@ -473,6 +474,60 @@ def matrix_for(plan_gates: list[dict[str, Any]], by_id: dict[str, dict[str, Any]
     return matrix
 
 
+def profile_selection(
+    catalog: dict[str, Any], profile: str, only_gates: list[str] | None = None
+) -> list[str]:
+    profiles = catalog["profiles"]
+    if profile != "remote-diagnostic":
+        if profile not in profiles:
+            raise GateError(f"unknown release profile {profile!r}")
+        if only_gates:
+            raise GateError("--only-gates is allowed only with remote-diagnostic")
+        return profiles[profile]
+
+    requested = sorted(set(only_gates or []))
+    if not requested:
+        raise GateError("remote-diagnostic requires at least one --only-gates ID")
+    if len(requested) > MAX_DIAGNOSTIC_GATES:
+        raise GateError(
+            f"remote-diagnostic accepts at most {MAX_DIAGNOSTIC_GATES} requested gates"
+        )
+
+    release_ids = set(profiles["remote-release"])
+    by_id = gate_map(catalog)
+    unknown = sorted(set(requested) - release_ids)
+    if unknown:
+        raise GateError(
+            "remote-diagnostic gate IDs must belong to remote-release: "
+            + ", ".join(unknown)
+        )
+    invalid = sorted(
+        gate_id
+        for gate_id in requested
+        if not by_id[gate_id]["resource_class"].startswith("gcp-")
+        or by_id[gate_id]["executor"] != "argv"
+    )
+    if invalid:
+        raise GateError(
+            "remote-diagnostic accepts executable GCP gates only: "
+            + ", ".join(invalid)
+        )
+
+    selected = set(requested)
+    pending = list(requested)
+    while pending:
+        gate_id = pending.pop()
+        for dependency in by_id[gate_id].get("dependencies", []):
+            if dependency not in release_ids:
+                raise GateError(
+                    f"remote-diagnostic dependency {dependency!r} is outside remote-release"
+                )
+            if dependency not in selected:
+                selected.add(dependency)
+                pending.append(dependency)
+    return sorted(selected)
+
+
 def create_plan(
     *,
     root: Path,
@@ -483,10 +538,9 @@ def create_plan(
     prior_path: Path | None,
     first_candidate: bool,
     changed_since: str | None,
+    only_gates: list[str] | None = None,
 ) -> dict[str, Any]:
-    profiles = catalog["profiles"]
-    if profile not in profiles:
-        raise GateError(f"unknown release profile {profile!r}")
+    selected = profile_selection(catalog, profile, only_gates)
     if profile == "remote-release":
         missing = catalog.get("remote_release_legacy_coverage", {}).get(
             "unautomated_legacy_ids", []
@@ -500,7 +554,6 @@ def create_plan(
     resolved_candidate = git(root, "rev-parse", f"{candidate}^{{commit}}")
     if head != resolved_candidate:
         raise GateError(f"checkout HEAD {head} does not match candidate {resolved_candidate}")
-    selected = profiles[profile]
     by_id = gate_map(catalog)
     inputs = all_input_records(root, catalog, selected, environment_id)
     prior = load_prior_receipts(prior_path)
@@ -1091,8 +1144,18 @@ def parser() -> argparse.ArgumentParser:
     plan = commands.add_parser("plan")
     plan.add_argument(
         "--profile",
-        choices=("remote-preflight", "remote-core", "remote-release", "legacy-full"),
+        choices=(
+            "remote-preflight",
+            "remote-diagnostic",
+            "remote-core",
+            "remote-release",
+            "legacy-full",
+        ),
         required=True,
+    )
+    plan.add_argument(
+        "--only-gates",
+        help="comma-separated exact GCP gate IDs for remote-diagnostic",
     )
     plan.add_argument("--candidate", required=True)
     plan.add_argument("--environment-id", required=True)
@@ -1138,6 +1201,13 @@ def main(argv: list[str] | None = None) -> int:
                 prior_path=prior,
                 first_candidate=args.first_candidate,
                 changed_since=args.changed_since,
+                only_gates=sorted(
+                    {
+                        value.strip()
+                        for value in (args.only_gates or "").split(",")
+                        if value.strip()
+                    }
+                ),
             )
             output = args.output if args.output.is_absolute() else root / args.output
             output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -194,6 +194,56 @@ class GateFrameworkTests(unittest.TestCase):
                     gate["command"],
                 )
 
+    def test_remote_diagnostic_runs_only_exact_gcp_gates_and_dependencies(self) -> None:
+        requested = ["interop.remote-proxies", "perf.monolithic-soak"]
+        selected = gates.profile_selection(
+            self.catalog, "remote-diagnostic", requested
+        )
+        self.assertEqual(
+            set(selected),
+            {
+                "interop.remote-proxies",
+                "perf.monolithic-soak",
+                "source.clean-start",
+                "source.remote-clean",
+            },
+        )
+        by_id = {gate["id"]: gate for gate in self.catalog["gates"]}
+        matrix = gates.matrix_for(
+            [{"id": gate_id, "decision": "RUN"} for gate_id in selected], by_id
+        )
+        self.assertEqual(
+            {shard["resource_class"] for shard in matrix},
+            {"gcp-interop", "gcp-performance-soak", "github-evidence"},
+        )
+        self.assertEqual(
+            {
+                gate_id
+                for shard in matrix
+                for gate_id in shard["gates"]
+                if shard["resource_class"].startswith("gcp-")
+            },
+            set(requested),
+        )
+
+        invalid_cases = (
+            ([], "requires at least one"),
+            (["core.rvoip"], "executable GCP gates only"),
+            (["perf.media-burst-matrix"], "executable GCP gates only"),
+            (["not.a.gate"], "must belong to remote-release"),
+            ([f"gate-{index}" for index in range(21)], "at most 20"),
+        )
+        for gate_ids, message in invalid_cases:
+            with self.subTest(gates=gate_ids):
+                with self.assertRaisesRegex(gates.GateError, message):
+                    gates.profile_selection(
+                        self.catalog, "remote-diagnostic", gate_ids
+                    )
+        with self.assertRaisesRegex(gates.GateError, "allowed only"):
+            gates.profile_selection(
+                self.catalog, "remote-release", ["perf.monolithic-soak"]
+            )
+
     def test_remote_release_requires_bridgefu_chromium_dtmf_regression(self) -> None:
         gate_id = "interop.browser-dtmf"
         self.assertIn(gate_id, self.catalog["profiles"]["remote-release"])
@@ -387,6 +437,35 @@ class GateFrameworkTests(unittest.TestCase):
                 [receipt], {"always_fresh": True}, inputs, "environment"
             )
         )
+
+    def test_prior_receipts_combine_failed_full_and_passing_diagnostic_runs(self) -> None:
+        inputs = {
+            "gate_definition_sha256": "d" * 64,
+            "input_sha256": "i" * 64,
+            "environment_sha256": "e" * 64,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for run_id, status in (("100", "FAIL"), ("101", "PASS")):
+                gate_dir = root / run_id / "release-evidence" / "perf.example"
+                gate_dir.mkdir(parents=True)
+                receipt = {
+                    "schema": gates.RECEIPT_SCHEMA,
+                    "gate_id": "perf.example",
+                    "candidate_sha": ("a" if status == "FAIL" else "b") * 40,
+                    "status": status,
+                    **inputs,
+                }
+                (gate_dir / "receipt.json").write_text(json.dumps(receipt))
+
+            combined = gates.load_prior_receipts(root)["perf.example"]
+            self.assertEqual([item["status"] for item in combined], ["FAIL", "PASS"])
+            self.assertEqual(
+                gates.exact_reusable(
+                    combined, {"always_fresh": False}, inputs, "environment"
+                )["status"],
+                "PASS",
+            )
 
     def test_failed_gate_invalidates_reverse_dependency_closure(self) -> None:
         by_id = {


### PR DESCRIPTION
## Problem
A genuine performance or interoperability failure still needed a broad release workflow to reproduce it. A corrected diagnostic receipt also could not be combined with successful evidence from a prior failed full run.

## Fix
- Add a non-publishing remote-diagnostic profile.
- Accept only named executable GCP gates already present in remote-release.
- Expand each requested gate through its declared dependency closure.
- Force diagnostics fresh on protected main with the unchanged release machine, command, workload, threshold, evidence, and cleanup path.
- Cap one request at 20 gates.
- Allow a complete qualification to combine exact receipts from up to five prior run IDs.
- Keep publication restricted to complete remote-release aggregates.

## Affected areas
Release qualification automation and documentation only. No Rust public API changes.

## Verification
- 92 release and workflow-policy tests pass.
- Deterministic 194-gate catalog regeneration passes.
- A plan requesting perf.monolithic-soak and interop.remote-proxies contains exactly those two GCP gates plus their two source prerequisites: three shards instead of 177 gates.
- Invalid, hosted, aggregate, unknown, and oversized diagnostic selections fail closed.
- Combined failed-full and passing-diagnostic receipt selection is covered.
- Shell syntax and diff hygiene pass.

## Risk
Diagnostics consume short-lived billable GCP capacity, but only on protected main and only for catalogued release commands. Their aggregate profile is remote-diagnostic, which protected publication rejects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release qualification orchestration and evidence reuse rules; mistakes could allow wrong gate reuse or extra GCP spend, but diagnostics are non-publishing and publication remains gated on `remote-release` aggregates.
> 
> **Overview**
> Introduces **`remote-diagnostic`** on the Release qualification workflow: dispatch with comma-separated catalog gate IDs, run only those executable GCP gates (plus their `remote-release` dependencies) fresh on protected `main`, capped at 20 gates. Diagnostics skip prior-evidence download and reuse planning like preflight, and publication still requires a complete **`remote-release`** aggregate.
> 
> **`gates.py`** gains `profile_selection` / `--only-gates` with fail-closed validation (release catalog membership, GCP+argv only, dependency closure). **`prior_run_id`** is now comma-separated: the workflow downloads up to five runs into per-run directories under `target/prior-evidence`, and the planner can combine receipts across them (later PASS can win for exact reuse).
> 
> Docs and workflow-policy tests describe the diagnostic path and the multi-run evidence merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be151c59e7dc69bf8b4c4426c1ae26efb283651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->