### PR TITLE
fix(core): make filtered message pagination deterministic

### DIFF
--- a/crates/foundation/rvoip-core/src/store/message_store.rs
+++ b/crates/foundation/rvoip-core/src/store/message_store.rs
@@ -4,7 +4,7 @@
 //! against (Postgres, Redis, etc.). The in-memory `MemoryMessageStore`
 //! is the v1 default for dev/tests.
 
-use crate::error::Result;
+use crate::error::{Result, RvoipError};
 use crate::ids::{ConversationId, MessageId, ParticipantId};
 use crate::message::{ContentType, Message};
 use chrono::{DateTime, Utc};
@@ -24,9 +24,13 @@ pub struct MessageFilter {
     pub page_size: Option<usize>,
 }
 
-/// Opaque cursor. Today: byte offset into the per-Conversation log.
-/// Wire form is a JSON-encoded number so clients can round-trip it
-/// without parsing.
+/// Cursor into the sequence produced after applying [`MessageFilter`].
+///
+/// A cursor must be reused with the same Conversation and materially identical
+/// filter. The memory store preserves insertion order and does not support
+/// removals. Matching messages appended after a page was read may therefore
+/// appear on a later page. The public `offset` field is retained for wire and
+/// source compatibility; callers should treat it as opaque.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct PageCursor {
     pub offset: usize,
@@ -129,10 +133,17 @@ impl MessageStore for MemoryMessageStore {
             .unwrap_or_default();
         let start = cursor.map(|c| c.offset).unwrap_or(0);
         let limit = filter.page_size.unwrap_or(50);
+        if limit == 0 {
+            return Err(RvoipError::InvalidState(
+                "message page size must be greater than zero",
+            ));
+        }
 
-        let filtered: Vec<Message> = log
+        // The cursor and its successor are both expressed in filtered-result
+        // coordinates. Taking one look-ahead item makes `next` exact, including
+        // when the match count is an exact multiple of the page size.
+        let mut filtered: Vec<Message> = log
             .into_iter()
-            .skip(start)
             .filter(|m| {
                 filter
                     .from_participant
@@ -145,10 +156,15 @@ impl MessageStore for MemoryMessageStore {
                     && filter.since.map_or(true, |t| m.timestamp >= t)
                     && filter.until.map_or(true, |t| m.timestamp <= t)
             })
-            .take(limit)
+            .skip(start)
+            .take(limit.saturating_add(1))
             .collect();
 
-        let next = if filtered.len() == limit {
+        let has_more = filtered.len() > limit;
+        if has_more {
+            filtered.truncate(limit);
+        }
+        let next = if has_more {
             Some(PageCursor {
                 offset: start + limit,
             })

--- a/crates/foundation/rvoip-core/tests/message_store_pagination.rs
+++ b/crates/foundation/rvoip-core/tests/message_store_pagination.rs
@@ -1,0 +1,10 @@
+#[path = "support/message_store_conformance.rs"]
+mod message_store_conformance;
+
+use rvoip_core::store::MemoryMessageStore;
+
+#[tokio::test]
+async fn memory_message_store_satisfies_pagination_contract() {
+    let store = MemoryMessageStore::new();
+    message_store_conformance::assert_message_store_pagination(&store).await;
+}

--- a/crates/foundation/rvoip-core/tests/support/message_store_conformance.rs
+++ b/crates/foundation/rvoip-core/tests/support/message_store_conformance.rs
@@ -1,0 +1,219 @@
+use bytes::Bytes;
+use chrono::{Duration, TimeZone, Utc};
+use rvoip_core::connection::Direction;
+use rvoip_core::error::RvoipError;
+use rvoip_core::ids::{ConversationId, MessageId, ParticipantId};
+use rvoip_core::message::{ContentType, Message, MessageOrigin, MessageRecipients};
+use rvoip_core::store::{MessageFilter, MessageStore, PageCursor};
+use std::collections::HashSet;
+
+fn message(
+    conversation_id: ConversationId,
+    id: &str,
+    from: ParticipantId,
+    content_type: ContentType,
+    second: i64,
+) -> Message {
+    Message {
+        id: MessageId::from_string(id),
+        conversation_id,
+        origin: MessageOrigin::System,
+        from_participant: from,
+        to: MessageRecipients::All,
+        direction: Direction::Inbound,
+        content_type,
+        body: Bytes::from_static(b"pagination-conformance"),
+        attachments: Vec::new(),
+        in_reply_to: None,
+        timestamp: Utc
+            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .single()
+            .expect("valid fixture timestamp")
+            + Duration::seconds(second),
+    }
+}
+
+async fn traverse<S: MessageStore + ?Sized>(
+    store: &S,
+    conversation_id: &ConversationId,
+    filter: MessageFilter,
+) -> Vec<String> {
+    let mut cursor: Option<PageCursor> = None;
+    let mut ids = Vec::new();
+    loop {
+        let page = store
+            .list(conversation_id, filter.clone(), cursor)
+            .await
+            .expect("conforming store lists a valid page");
+        ids.extend(page.messages.into_iter().map(|item| item.id.to_string()));
+        match page.next {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+    ids
+}
+
+/// Shared pagination contract for memory and future durable MessageStore
+/// implementations. A backend test can call this function with its own store.
+pub async fn assert_message_store_pagination<S: MessageStore + ?Sized>(store: &S) {
+    let wanted = ParticipantId::from_string("participant-wanted");
+    let other = ParticipantId::from_string("participant-other");
+
+    // Exercise zero, one, and many leading raw-log entries that do not match.
+    for prefix_misses in 0..=3 {
+        let conversation_id =
+            ConversationId::from_string(format!("pagination-prefix-{prefix_misses}"));
+        for index in 0..prefix_misses {
+            store
+                .put(message(
+                    conversation_id.clone(),
+                    &format!("prefix-{prefix_misses}-miss-{index}"),
+                    other.clone(),
+                    ContentType::Binary,
+                    index as i64,
+                ))
+                .await
+                .expect("insert prefix miss");
+        }
+        for index in 0..5 {
+            store
+                .put(message(
+                    conversation_id.clone(),
+                    &format!("prefix-{prefix_misses}-match-{index}"),
+                    wanted.clone(),
+                    ContentType::Text,
+                    (prefix_misses + index) as i64,
+                ))
+                .await
+                .expect("insert match");
+        }
+        let filter = MessageFilter {
+            from_participant: Some(wanted.clone()),
+            page_size: Some(2),
+            ..MessageFilter::default()
+        };
+        let first = traverse(store, &conversation_id, filter.clone()).await;
+        let second = traverse(store, &conversation_id, filter).await;
+        assert_eq!(first, second, "immutable traversal must be deterministic");
+        assert_eq!(first.len(), 5);
+        assert_eq!(first.iter().collect::<HashSet<_>>().len(), first.len());
+    }
+
+    // Sparse matches exercise page sizes one, exact multiple, below the match
+    // count, and above it without duplicates, omissions, or an empty tail page.
+    let sparse_id = ConversationId::from_string("pagination-sparse");
+    for index in 0..12 {
+        let is_match = matches!(index, 1 | 4 | 7 | 10);
+        store
+            .put(message(
+                sparse_id.clone(),
+                &format!("sparse-{index}"),
+                if is_match {
+                    wanted.clone()
+                } else {
+                    other.clone()
+                },
+                if is_match {
+                    ContentType::Json
+                } else {
+                    ContentType::Binary
+                },
+                index,
+            ))
+            .await
+            .expect("insert sparse fixture");
+    }
+    let expected = vec!["sparse-1", "sparse-4", "sparse-7", "sparse-10"];
+    for page_size in [1, 2, 3, 4, 10] {
+        let filter = MessageFilter {
+            from_participant: Some(wanted.clone()),
+            content_types: Some(vec![ContentType::Json]),
+            page_size: Some(page_size),
+            ..MessageFilter::default()
+        };
+        assert_eq!(traverse(store, &sparse_id, filter).await, expected);
+    }
+
+    let exact_filter = MessageFilter {
+        from_participant: Some(wanted.clone()),
+        page_size: Some(2),
+        ..MessageFilter::default()
+    };
+    let first = store
+        .list(&sparse_id, exact_filter.clone(), None)
+        .await
+        .expect("first exact page");
+    let second = store
+        .list(&sparse_id, exact_filter, first.next)
+        .await
+        .expect("second exact page");
+    assert_eq!(second.messages.len(), 2);
+    assert!(
+        second.next.is_none(),
+        "exact final page must not advertise an empty tail"
+    );
+
+    let zero_result = store
+        .list(
+            &sparse_id,
+            MessageFilter {
+                page_size: Some(0),
+                ..MessageFilter::default()
+            },
+            None,
+        )
+        .await;
+    let zero_error = match zero_result {
+        Err(error) => error,
+        Ok(_) => panic!("zero page size must be invalid"),
+    };
+    assert!(matches!(zero_error, RvoipError::InvalidState(_)));
+
+    // Appends are visible after the cursor because the memory model has no
+    // removals and preserves insertion order.
+    let append_id = ConversationId::from_string("pagination-append");
+    for index in 0..3 {
+        store
+            .put(message(
+                append_id.clone(),
+                &format!("append-{index}"),
+                wanted.clone(),
+                ContentType::Text,
+                index,
+            ))
+            .await
+            .expect("insert append fixture");
+    }
+    let append_filter = MessageFilter {
+        page_size: Some(2),
+        ..MessageFilter::default()
+    };
+    let first = store
+        .list(&append_id, append_filter.clone(), None)
+        .await
+        .expect("first append page");
+    store
+        .put(message(
+            append_id.clone(),
+            "append-3",
+            wanted,
+            ContentType::Text,
+            3,
+        ))
+        .await
+        .expect("append after first page");
+    let second = store
+        .list(&append_id, append_filter, first.next)
+        .await
+        .expect("second append page");
+    assert_eq!(
+        second
+            .messages
+            .iter()
+            .map(|item| item.id.to_string())
+            .collect::<Vec<_>>(),
+        ["append-2", "append-3"]
+    );
+    assert!(second.next.is_none());
+}


### PR DESCRIPTION
## Problem

`MemoryMessageStore::list` mixed raw-log and filtered-result offsets, so sparse filters could duplicate or skip messages across pages and could advertise an unnecessary trailing empty page.

Closes #119.

## Fix

- Apply the complete filter before interpreting the pagination offset.
- Use one look-ahead result so `next` is present exactly when another matching result exists.
- Reject a zero page size explicitly.
- Document deterministic insertion-order and append semantics.
- Add a reusable `MessageStore` pagination conformance suite for future durable backends.

## Affected areas

- `rvoip-core` in-memory message store
- `MessageStore` pagination behavior and test contract

No public type or function signatures change.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p rvoip-core --test message_store_pagination`

The always-present remote PR Gate will select `rvoip-core` and its reverse workspace dependents.

## Risk

Low and contained to pagination semantics. Existing callers that accidentally depended on mixed-coordinate cursors will now receive the deterministic documented result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contained pagination semantics fix in rvoip-core’s in-memory store; callers using old mixed-coordinate cursors may see different (correct) pages, with no API signature changes.
> 
> **Overview**
> Fixes **filtered message pagination** in `MemoryMessageStore::list` so cursors count positions in the **filtered** result set, not the raw conversation log. That removes duplicates, skips, and spurious “next page” cursors when filters are sparse.
> 
> Pagination now **filters first**, then applies `skip`/`take` on matches, uses a **one-item look-ahead** so `next` is set only when another match exists (including when the match count is an exact multiple of page size), and returns **`InvalidState`** for `page_size == 0`. **`PageCursor`** docs now describe filter-stable, opaque cursors and append-only memory semantics.
> 
> Adds a reusable **`assert_message_store_pagination`** conformance suite (wired for `MemoryMessageStore`) so future durable `MessageStore` backends can share the same contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3bbd4d352cedb5a2ea455795ae16a5cf99da8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->