### PR TITLE
fix(core): preserve cross-crate event semantics

### DIFF
--- a/crates/foundation/infra-common/src/events/cross_crate.rs
+++ b/crates/foundation/infra-common/src/events/cross_crate.rs
@@ -2717,6 +2717,16 @@ pub enum RvoipCoreCrossCrateEvent {
     ConnectionConnected {
         connection_id: String,
     },
+    /// Authentication completed. Identity, tenant, scope, and principal
+    /// details are deliberately omitted from the process-wide event bus.
+    ConnectionAuthenticated {
+        connection_id: String,
+    },
+    /// Principal authentication completed. The principal itself is retained
+    /// only on rvoip-core's tenant-authorized in-process event.
+    ConnectionPrincipalAuthenticated {
+        connection_id: String,
+    },
     ConnectionProgress {
         connection_id: String,
         kind: String,
@@ -2744,6 +2754,10 @@ pub enum RvoipCoreCrossCrateEvent {
     ConnectionTransferred {
         connection_id: String,
         target: String,
+    },
+    ConnectionTransferStatus {
+        connection_id: String,
+        status: String,
     },
 
     // --- Participant lifecycle ---
@@ -2836,6 +2850,16 @@ pub enum RvoipCoreCrossCrateEvent {
         connection_id: String,
         identity_id: Option<String>,
     },
+    IdentityStepUpRequested {
+        connection_id: String,
+        required: String,
+    },
+    /// A step-up response arrived. The credential is never copied onto the
+    /// process-wide event bus.
+    IdentityStepUpResponseReceived {
+        connection_id: String,
+        method: String,
+    },
 
     // --- Registration ---
     RegistrationChanged {
@@ -2868,6 +2892,15 @@ pub enum RvoipCoreCrossCrateEvent {
         packet_loss_pct: f32,
         mos: Option<f32>,
     },
+    BargeInDetected {
+        connection_id: String,
+        ai_attachment_id: String,
+    },
+    ActiveSpeakerChanged {
+        session_id: String,
+        connection_id: String,
+        audio_level_dbov: i8,
+    },
 }
 
 impl fmt::Debug for RvoipCoreCrossCrateEvent {
@@ -2892,12 +2925,17 @@ impl RvoipCoreCrossCrateEvent {
             Self::ConnectionInbound { .. } => "rvoip_core.connection_inbound",
             Self::ConnectionOutbound { .. } => "rvoip_core.connection_outbound",
             Self::ConnectionConnected { .. } => "rvoip_core.connection_connected",
+            Self::ConnectionAuthenticated { .. } => "rvoip_core.connection_authenticated",
+            Self::ConnectionPrincipalAuthenticated { .. } => {
+                "rvoip_core.connection_principal_authenticated"
+            }
             Self::ConnectionProgress { .. } => "rvoip_core.connection_progress",
             Self::ConnectionEnded { .. } => "rvoip_core.connection_ended",
             Self::ConnectionFailed { .. } => "rvoip_core.connection_failed",
             Self::ConnectionsBridged { .. } => "rvoip_core.connections_bridged",
             Self::ConnectionsUnbridged { .. } => "rvoip_core.connections_unbridged",
             Self::ConnectionTransferred { .. } => "rvoip_core.connection_transferred",
+            Self::ConnectionTransferStatus { .. } => "rvoip_core.connection_transfer_status",
             Self::ParticipantJoined { .. } => "rvoip_core.participant_joined",
             Self::ParticipantLeft { .. } => "rvoip_core.participant_left",
             Self::AiAttached { .. } => "rvoip_core.ai_attached",
@@ -2917,12 +2955,18 @@ impl RvoipCoreCrossCrateEvent {
             Self::VconReady { .. } => "rvoip_core.vcon_ready",
             Self::VconRedacted { .. } => "rvoip_core.vcon_redacted",
             Self::IdentityAssuranceChanged { .. } => "rvoip_core.identity_assurance_changed",
+            Self::IdentityStepUpRequested { .. } => "rvoip_core.identity_step_up_requested",
+            Self::IdentityStepUpResponseReceived { .. } => {
+                "rvoip_core.identity_step_up_response_received"
+            }
             Self::RegistrationChanged { .. } => "rvoip_core.registration_changed",
             Self::RegistrationHeartbeat { .. } => "rvoip_core.registration_heartbeat",
             Self::CapacityReport { .. } => "rvoip_core.capacity_report",
             Self::UsageRecord { .. } => "rvoip_core.usage_record",
             Self::Anomaly { .. } => "rvoip_core.anomaly",
             Self::MediaQuality { .. } => "rvoip_core.media_quality",
+            Self::BargeInDetected { .. } => "rvoip_core.barge_in_detected",
+            Self::ActiveSpeakerChanged { .. } => "rvoip_core.active_speaker_changed",
         }
     }
 
@@ -2937,12 +2981,15 @@ impl RvoipCoreCrossCrateEvent {
         "rvoip_core.connection_inbound",
         "rvoip_core.connection_outbound",
         "rvoip_core.connection_connected",
+        "rvoip_core.connection_authenticated",
+        "rvoip_core.connection_principal_authenticated",
         "rvoip_core.connection_progress",
         "rvoip_core.connection_ended",
         "rvoip_core.connection_failed",
         "rvoip_core.connections_bridged",
         "rvoip_core.connections_unbridged",
         "rvoip_core.connection_transferred",
+        "rvoip_core.connection_transfer_status",
         "rvoip_core.participant_joined",
         "rvoip_core.participant_left",
         "rvoip_core.ai_attached",
@@ -2962,12 +3009,16 @@ impl RvoipCoreCrossCrateEvent {
         "rvoip_core.vcon_ready",
         "rvoip_core.vcon_redacted",
         "rvoip_core.identity_assurance_changed",
+        "rvoip_core.identity_step_up_requested",
+        "rvoip_core.identity_step_up_response_received",
         "rvoip_core.registration_changed",
         "rvoip_core.registration_heartbeat",
         "rvoip_core.capacity_report",
         "rvoip_core.usage_record",
         "rvoip_core.anomaly",
         "rvoip_core.media_quality",
+        "rvoip_core.barge_in_detected",
+        "rvoip_core.active_speaker_changed",
     ];
 }
 
@@ -3006,6 +3057,66 @@ mod tests {
             CrossCrateEvent::event_type(&deserialized),
             CrossCrateEvent::event_type(&event)
         );
+    }
+
+    #[test]
+    fn core_projection_variants_round_trip_with_distinct_registered_types() {
+        let events = [
+            RvoipCoreCrossCrateEvent::ConnectionAuthenticated {
+                connection_id: "conn-auth".into(),
+            },
+            RvoipCoreCrossCrateEvent::ConnectionPrincipalAuthenticated {
+                connection_id: "conn-principal".into(),
+            },
+            RvoipCoreCrossCrateEvent::ConnectionTransferStatus {
+                connection_id: "conn-transfer".into(),
+                status: "Accepted".into(),
+            },
+            RvoipCoreCrossCrateEvent::IdentityStepUpRequested {
+                connection_id: "conn-request".into(),
+                required: "UserAuthorized".into(),
+            },
+            RvoipCoreCrossCrateEvent::IdentityStepUpResponseReceived {
+                connection_id: "conn-response".into(),
+                method: "bearer".into(),
+            },
+            RvoipCoreCrossCrateEvent::BargeInDetected {
+                connection_id: "conn-barge".into(),
+                ai_attachment_id: "ai-1".into(),
+            },
+            RvoipCoreCrossCrateEvent::ActiveSpeakerChanged {
+                session_id: "session-1".into(),
+                connection_id: "conn-speaker".into(),
+                audio_level_dbov: -24,
+            },
+        ];
+
+        for inner in events {
+            let expected_type = inner.event_type();
+            assert!(RvoipCoreCrossCrateEvent::ALL_EVENT_TYPES.contains(&expected_type));
+            let encoded = serde_json::to_string(&RvoipCrossCrateEvent::Core(inner))
+                .expect("serialize core projection");
+            let decoded: RvoipCrossCrateEvent =
+                serde_json::from_str(&encoded).expect("deserialize core projection");
+            assert_eq!(CrossCrateEvent::event_type(&decoded), expected_type);
+        }
+
+        let unique: std::collections::HashSet<_> = RvoipCoreCrossCrateEvent::ALL_EVENT_TYPES
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(
+            unique.len(),
+            RvoipCoreCrossCrateEvent::ALL_EVENT_TYPES.len()
+        );
+    }
+
+    #[test]
+    fn unknown_future_core_variant_fails_closed_instead_of_being_retyped() {
+        let encoded = r#"{"Core":{"FutureSecurityDecision":{"allowed":true}}}"#;
+        let error = serde_json::from_str::<RvoipCrossCrateEvent>(encoded)
+            .expect_err("an unknown semantic event must not fall back to a known variant");
+        assert!(error.to_string().contains("unknown variant"));
     }
 
     #[test]

--- a/crates/foundation/rvoip-core/src/events.rs
+++ b/crates/foundation/rvoip-core/src/events.rs
@@ -549,7 +549,9 @@ impl Event {
     /// Translate the rich in-process event to the primitive-payload wire form
     /// published through `infra-common::GlobalEventCoordinator`. The
     /// `RvoipCrossCrateEvent::Core` variant lives in infra-common per the
-    /// CARVE_PLAN events.rs commitment.
+    /// CARVE_PLAN events.rs commitment. The match below intentionally has no
+    /// wildcard: adding a core event is a compile-time request to review and
+    /// declare its cross-crate export and redaction policy.
     pub fn to_cross_crate(&self) -> RvoipCrossCrateEvent {
         use Event::*;
         let inner = match self {
@@ -597,18 +599,15 @@ impl Event {
             }
             ConnectionAuthenticated { connection_id, .. } => {
                 // Authentication context is tenant-sensitive. The global
-                // cross-crate bus is not tenant-authorized, so it receives
-                // only a lifecycle marker; rich identity stays on the typed
-                // in-process event and connection route.
-                RvoipCoreCrossCrateEvent::IdentityAssuranceChanged {
+                // cross-crate bus receives only the correctly typed lifecycle
+                // marker; rich identity stays on the in-process event.
+                RvoipCoreCrossCrateEvent::ConnectionAuthenticated {
                     connection_id: connection_id.to_string(),
-                    identity_id: None,
                 }
             }
             ConnectionPrincipalAuthenticated { connection_id, .. } => {
-                RvoipCoreCrossCrateEvent::IdentityAssuranceChanged {
+                RvoipCoreCrossCrateEvent::ConnectionPrincipalAuthenticated {
                     connection_id: connection_id.to_string(),
-                    identity_id: None,
                 }
             }
             ConnectionProgress {
@@ -659,9 +658,9 @@ impl Event {
                 connection_id,
                 status,
                 ..
-            } => RvoipCoreCrossCrateEvent::ConnectionProgress {
+            } => RvoipCoreCrossCrateEvent::ConnectionTransferStatus {
                 connection_id: connection_id.to_string(),
-                kind: format!("transfer:{status:?}"),
+                status: format!("{status:?}"),
             },
             ParticipantJoined {
                 session_id,
@@ -841,37 +840,43 @@ impl Event {
                 packet_loss_pct: snapshot.packet_loss_pct,
                 mos: snapshot.mos,
             },
-            BargeInDetected { connection_id, .. } => {
-                // No dedicated cross-crate variant yet; surface as
-                // IdentityAssuranceChanged with None identity so
-                // downstream services notice an event on the bus.
-                RvoipCoreCrossCrateEvent::IdentityAssuranceChanged {
+            BargeInDetected {
+                connection_id,
+                ai_attachment_id,
+                ..
+            } => RvoipCoreCrossCrateEvent::BargeInDetected {
+                connection_id: connection_id.to_string(),
+                ai_attachment_id: ai_attachment_id.to_string(),
+            },
+            ActiveSpeakerChanged {
+                session_id,
+                connection_id,
+                audio_level_dbov,
+                ..
+            } => RvoipCoreCrossCrateEvent::ActiveSpeakerChanged {
+                session_id: session_id.to_string(),
+                connection_id: connection_id.to_string(),
+                audio_level_dbov: *audio_level_dbov,
+            },
+            IdentityStepUpRequested {
+                connection_id,
+                required,
+                ..
+            } => RvoipCoreCrossCrateEvent::IdentityStepUpRequested {
+                connection_id: connection_id.to_string(),
+                required: format!("{required:?}"),
+            },
+            IdentityStepUpResponseReceived {
+                connection_id,
+                method,
+                credential: _,
+                ..
+            } => {
+                // The credential is intentionally absent from both the wire
+                // payload and its Debug representation.
+                RvoipCoreCrossCrateEvent::IdentityStepUpResponseReceived {
                     connection_id: connection_id.to_string(),
-                    identity_id: None,
-                }
-            }
-            ActiveSpeakerChanged { connection_id, .. } => {
-                // No dedicated wire variant yet — surface as MediaQuality
-                // with zero loss so downstream crates that don't know
-                // about ActiveSpeaker still see *something* on the bus.
-                RvoipCoreCrossCrateEvent::MediaQuality {
-                    connection_id: connection_id.to_string(),
-                    jitter_ms: 0.0,
-                    packet_loss_pct: 0.0,
-                    mos: None,
-                }
-            }
-            IdentityStepUpRequested { connection_id, .. }
-            | IdentityStepUpResponseReceived { connection_id, .. } => {
-                // P12.6 — no dedicated cross-crate variant yet; surface
-                // as IdentityAssuranceChanged with None identity_id so
-                // downstream services see the round-trip on the bus.
-                // The actual assurance change still emits a separate
-                // IdentityAssuranceChanged event when the consumer calls
-                // `complete_step_up`.
-                RvoipCoreCrossCrateEvent::IdentityAssuranceChanged {
-                    connection_id: connection_id.to_string(),
-                    identity_id: None,
+                    method: method.clone(),
                 }
             }
         };
@@ -882,6 +887,69 @@ impl Event {
 #[cfg(test)]
 mod credential_diagnostic_tests {
     use super::*;
+
+    fn projected_core(event: Event) -> RvoipCoreCrossCrateEvent {
+        let RvoipCrossCrateEvent::Core(inner) = event.to_cross_crate() else {
+            panic!("core event projected outside the core namespace");
+        };
+        inner
+    }
+
+    #[test]
+    fn unsupported_aliases_have_dedicated_semantic_projections() {
+        let connection_id = ConnectionId::new();
+        let session_id = SessionId::new();
+        let ai_attachment_id = AiAttachmentId::new();
+
+        let barge = projected_core(Event::BargeInDetected {
+            connection_id: connection_id.clone(),
+            ai_attachment_id: ai_attachment_id.clone(),
+            at: Utc::now(),
+        });
+        assert!(matches!(
+            barge,
+            RvoipCoreCrossCrateEvent::BargeInDetected { .. }
+        ));
+
+        let speaker = projected_core(Event::ActiveSpeakerChanged {
+            session_id,
+            connection_id: connection_id.clone(),
+            audio_level_dbov: -17,
+            at: Utc::now(),
+        });
+        assert!(matches!(
+            speaker,
+            RvoipCoreCrossCrateEvent::ActiveSpeakerChanged {
+                audio_level_dbov: -17,
+                ..
+            }
+        ));
+
+        let requested = projected_core(Event::IdentityStepUpRequested {
+            connection_id: connection_id.clone(),
+            required: crate::capability::IdentityAssuranceRequirement::UserAuthorized,
+            at: Utc::now(),
+        });
+        assert!(matches!(
+            requested,
+            RvoipCoreCrossCrateEvent::IdentityStepUpRequested { .. }
+        ));
+
+        const CREDENTIAL: &str = "step-up-secret-canary";
+        let response = projected_core(Event::IdentityStepUpResponseReceived {
+            connection_id,
+            method: "bearer".into(),
+            credential: CREDENTIAL.into(),
+            at: Utc::now(),
+        });
+        assert!(matches!(
+            &response,
+            RvoipCoreCrossCrateEvent::IdentityStepUpResponseReceived { .. }
+        ));
+        assert!(!serde_json::to_string(&response)
+            .expect("serialize redacted response")
+            .contains(CREDENTIAL));
+    }
 
     #[test]
     fn enclosing_step_up_event_redacts_credential_and_keeps_live_value() {

--- a/crates/foundation/rvoip-core/tests/principal_cross_crate.rs
+++ b/crates/foundation/rvoip-core/tests/principal_cross_crate.rs
@@ -25,16 +25,14 @@ fn principal_cross_crate_event_redacts_tenant_authorization_context() {
 
     let wire = event.to_cross_crate();
     let encoded = serde_json::to_string(&wire).expect("serialize cross-crate event");
-    let RvoipCrossCrateEvent::Core(RvoipCoreCrossCrateEvent::IdentityAssuranceChanged {
+    let RvoipCrossCrateEvent::Core(RvoipCoreCrossCrateEvent::ConnectionPrincipalAuthenticated {
         connection_id: wire_connection_id,
-        identity_id,
     }) = wire
     else {
         panic!("expected redacted authentication lifecycle event");
     };
 
     assert_eq!(wire_connection_id, connection_id.to_string());
-    assert_eq!(identity_id, None);
     for sensitive in [
         "user-42",
         "tenant-a",


### PR DESCRIPTION
## Problem

Several `rvoip-core` events were projected onto unrelated cross-crate event types merely because no dedicated wire variant existed. Barge-in appeared as an identity change, active-speaker changes appeared as zero-loss media quality, and authentication/step-up/transfer lifecycle events were similarly retyped. Downstream consumers could therefore act on events that never happened.

Closes #115.

## Fix

- Add distinct, additive, non-exhaustive cross-crate variants for each supported semantic event.
- Keep authentication principals and step-up credentials off the process-wide bus.
- Make the core projection match exhaustive so new core events require an explicit export/redaction decision.
- Register every new event type on its own broadcast channel.
- Fail closed when deserializing an unknown future semantic variant rather than silently retyping it.

## Affected areas

- `rvoip-infra-common` cross-crate event wire model
- `rvoip-core` event projection and redaction policy

## Tests

- `cargo fmt --all -- --check`
- dedicated variant serialization/round-trip test
- unknown-future-variant fail-closed test
- fabricated-alias regression test for barge-in, active-speaker, step-up request, and step-up response
- principal authentication redaction integration test

All focused tests executed with non-zero test counts and passed. The remote PR Gate will validate affected crates and reverse dependents.

## Risk

Low-to-moderate and additive at the wire enum level. Consumers matching the existing `#[non_exhaustive]` enum continue to compile; event subscribers now receive the correct event type instead of a misleading legacy alias.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wire event-type strings change for several formerly aliased signals, so subscribers keyed on the old misleading types need to follow the new channels; auth and credential redaction behavior is security-sensitive but tightened rather than loosened.
> 
> **Overview**
> **Stops mis-typed rvoip-core events on the process-wide bus** by replacing temporary aliases with dedicated `RvoipCoreCrossCrateEvent` variants and wiring `Event::to_cross_crate()` to project each in-process event to the matching wire shape (e.g. barge-in and active-speaker no longer appear as identity or fake media-quality events; auth, transfer status, and step-up use their own types).
> 
> New wire variants are registered with distinct `rvoip_core.*` event types, and sensitive fields stay off the bus (connection IDs only for auth lifecycle; step-up credentials omitted). The core projection match is exhaustive so new `Event` variants force an explicit export/redaction choice, and deserialization rejects unknown future core variants instead of silently mapping them.
> 
> Tests cover round-trip serialization, fail-closed unknown variants, regression against the old aliases, and principal-auth redaction on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30820c5eb81dbb8227d8d9980259844b6fa79503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->