### PR TITLE
fix(security): upgrade jsonwebtoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2061,6 +2061,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2385,6 +2386,30 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3805,17 +3830,26 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac 0.12.1",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.7",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -8550,7 +8584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -9970,7 +10004,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,6 @@ chromiumoxide = { version = "0.7", default-features = false, features = ["tokio-
 sha2 = "0.10"
 zeroize = "1.9"
 hmac = "0.12"
-jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 aes = "0.8"
 md-5 = "0.10"
 ring = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,6 +312,7 @@ chromiumoxide = { version = "0.7", default-features = false, features = ["tokio-
 sha2 = "0.10"
 zeroize = "1.9"
 hmac = "0.12"
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 aes = "0.8"
 md-5 = "0.10"
 ring = "0.17"

--- a/crates/extensions/rvoip-stir-shaken/Cargo.toml
+++ b/crates/extensions/rvoip-stir-shaken/Cargo.toml
@@ -32,7 +32,7 @@ rvoip-sip-core.workspace = true
 rvoip-sip-dialog.workspace = true
 
 # JWS / JWT for PASSporT (RFC 8225)
-jsonwebtoken = "9.3"
+jsonwebtoken.workspace = true
 
 # Certificate parsing for SHAKEN profile checks (TNAuthList, JWT Claim Constraints)
 x509-parser = "0.18"

--- a/crates/extensions/rvoip-stir-shaken/Cargo.toml
+++ b/crates/extensions/rvoip-stir-shaken/Cargo.toml
@@ -32,7 +32,7 @@ rvoip-sip-core.workspace = true
 rvoip-sip-dialog.workspace = true
 
 # JWS / JWT for PASSporT (RFC 8225)
-jsonwebtoken.workspace = true
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 
 # Certificate parsing for SHAKEN profile checks (TNAuthList, JWT Claim Constraints)
 x509-parser = "0.18"

--- a/crates/extensions/rvoip-vcon/Cargo.toml
+++ b/crates/extensions/rvoip-vcon/Cargo.toml
@@ -31,7 +31,7 @@ x509-parser.workspace = true
 mime = "0.3"
 
 # JWS cryptographic primitives; wire framing is General JSON, not JWT.
-jsonwebtoken = "9.3"
+jsonwebtoken.workspace = true
 
 thiserror = "1.0"
 

--- a/crates/extensions/rvoip-vcon/Cargo.toml
+++ b/crates/extensions/rvoip-vcon/Cargo.toml
@@ -31,7 +31,7 @@ x509-parser.workspace = true
 mime = "0.3"
 
 # JWS cryptographic primitives; wire framing is General JSON, not JWT.
-jsonwebtoken.workspace = true
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 
 thiserror = "1.0"
 

--- a/crates/identity/auth-core/Cargo.toml
+++ b/crates/identity/auth-core/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2", "charset"] }
 
 # JWT handling
-jsonwebtoken.workspace = true
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/identity/auth-core/Cargo.toml
+++ b/crates/identity/auth-core/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2", "charset"] }
 
 # JWT handling
-jsonwebtoken = "9.3"
+jsonwebtoken.workspace = true
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/identity/auth-core/tests/jwt.rs
+++ b/crates/identity/auth-core/tests/jwt.rs
@@ -84,6 +84,15 @@ fn mint(claims: &TestClaims) -> String {
     .expect("encode test JWT")
 }
 
+fn mint_json(claims: &serde_json::Value) -> String {
+    encode(
+        &Header::default(),
+        claims,
+        &EncodingKey::from_secret(HMAC_SECRET),
+    )
+    .expect("encode test JWT")
+}
+
 #[tokio::test]
 async fn valid_hmac_token_yields_user_authorized() {
     let validator = JwtValidator::from_hmac_secret(HMAC_SECRET);
@@ -294,6 +303,20 @@ async fn expired_token_rejects() {
         matches!(result, Err(BearerAuthError::Invalid(_))),
         "expired token must be rejected"
     );
+}
+
+#[tokio::test]
+async fn non_numeric_expiration_claim_fails_closed() {
+    let validator = JwtValidator::from_hmac_secret(HMAC_SECRET);
+    let token = mint_json(&serde_json::json!({
+        "sub": "id_alice",
+        "exp": "not-a-numeric-date"
+    }));
+
+    assert!(matches!(
+        validator.validate(&token).await,
+        Err(BearerAuthError::Invalid(_))
+    ));
 }
 
 #[tokio::test]

--- a/crates/identity/users-core/Cargo.toml
+++ b/crates/identity/users-core/Cargo.toml
@@ -39,7 +39,7 @@ argon2 = "0.5"
 password-hash = "0.5"
 
 # JWT
-jsonwebtoken = "9.3"
+jsonwebtoken.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/crates/identity/users-core/Cargo.toml
+++ b/crates/identity/users-core/Cargo.toml
@@ -39,7 +39,7 @@ argon2 = "0.5"
 password-hash = "0.5"
 
 # JWT
-jsonwebtoken.workspace = true
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/crates/moq/rvoip-moq/Cargo.toml
+++ b/crates/moq/rvoip-moq/Cargo.toml
@@ -44,7 +44,7 @@ sha2.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-jsonwebtoken = "9.3"
+jsonwebtoken.workspace = true
 rand.workspace = true
 rcgen.workspace = true
 tempfile = "3.14"

--- a/crates/moq/rvoip-moq/Cargo.toml
+++ b/crates/moq/rvoip-moq/Cargo.toml
@@ -44,7 +44,7 @@ sha2.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-jsonwebtoken.workspace = true
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 rand.workspace = true
 rcgen.workspace = true
 tempfile = "3.14"

--- a/crates/uctp/rvoip-uctp/Cargo.toml
+++ b/crates/uctp/rvoip-uctp/Cargo.toml
@@ -67,7 +67,7 @@ rvoip-media-core.workspace = true
 url = "2"
 
 # JWT validator integration test (plan C4 prelude).
-jsonwebtoken.workspace = true
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 
 # Gap plan §5.2 v1 punch list — sig9421_gate.rs test signs envelopes
 # directly with Ed25519 + base64 to drive the coordinator's verify

--- a/crates/uctp/rvoip-uctp/Cargo.toml
+++ b/crates/uctp/rvoip-uctp/Cargo.toml
@@ -67,7 +67,7 @@ rvoip-media-core.workspace = true
 url = "2"
 
 # JWT validator integration test (plan C4 prelude).
-jsonwebtoken = "9.3"
+jsonwebtoken.workspace = true
 
 # Gap plan §5.2 v1 punch list — sig9421_gate.rs test signs envelopes
 # directly with Ed25519 + base64 to drive the coordinator's verify

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1320,6 +1321,30 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2195,17 +2220,26 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.7",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2213,6 +2247,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -2463,6 +2500,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm 0.2.16",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,12 +2540,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm 0.2.16",
 ]
 
 [[package]]
@@ -2734,6 +2798,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -3314,6 +3389,26 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rtc-datachannel"
@@ -4770,6 +4865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4910,7 +5011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches JWT signing/verification across identity, STIR/SHAKEN, vCon, and MOQ paths via a major jsonwebtoken release and a different crypto backend; behavior is mostly covered by existing tests plus one new malformed-`exp` case.
> 
> **Overview**
> Bumps **`jsonwebtoken`** from **9.3** to **10.4** everywhere it is declared (`rvoip-auth-core`, `rvoip-users-core`, `rvoip-stir-shaken`, `rvoip-vcon`, `rvoip-moq`, `rvoip-uctp` dev-deps), enabling the **`rust_crypto`** feature so JWT crypto no longer goes through **`ring`** inside that crate.
> 
> **`Cargo.lock`** / **`examples/Cargo.lock`** pick up the new transitive graph (`ed25519-dalek`, `rsa`, `p256`/`p384`, etc.) plus minor unrelated lock churn (e.g. **`windows-sys`** / **`getrandom`** on some packages).
> 
> **`auth-core`** adds **`non_numeric_expiration_claim_fails_closed`**, minting a JWT with a string **`exp`** via **`mint_json`** and asserting **`JwtValidator`** rejects it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20efd4290ad5702fd55323d5745c98eb7366e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->