### PR TITLE
fix(security): upgrade OpenTelemetry SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1582,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
 dependencies = [
  "futures-core",
- "prost",
+ "prost 0.13.5",
  "prost-types",
  "tonic",
  "tracing-core",
@@ -1601,7 +1601,7 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost",
+ "prost 0.13.5",
  "prost-types",
  "serde",
  "serde_json",
@@ -4833,78 +4833,71 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
- "tracing",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.2",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "async-trait",
- "futures-core",
  "http 1.4.2",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
- "reqwest",
- "thiserror 1.0.69",
+ "prost 0.14.4",
+ "reqwest 0.13.4",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.14.4",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.7",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5403,7 +5396,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -5419,7 +5422,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.13.5",
  "prost-types",
  "regex",
  "syn 2.0.119",
@@ -5440,12 +5443,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -5937,9 +5953,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.1.0",
@@ -5972,6 +5986,37 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6602,7 +6647,7 @@ dependencies = [
  "dashmap",
  "futures",
  "parking_lot",
- "prost",
+ "prost 0.13.5",
  "prost-build",
  "rustls",
  "rvoip-core",
@@ -6637,7 +6682,7 @@ name = "rvoip-audit"
 version = "0.3.5"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.12.28",
  "rvoip-auth-core",
  "serde",
  "serde_json",
@@ -6660,7 +6705,7 @@ dependencies = [
  "mockito",
  "moka",
  "rand 0.8.7",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rvoip-core-traits",
  "rvoip-infra-common",
@@ -6788,7 +6833,7 @@ dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
  "md-5",
- "reqwest",
+ "reqwest 0.12.28",
  "rvoip-sip",
  "serde",
  "serde_json",
@@ -6831,7 +6876,7 @@ name = "rvoip-keycloak"
 version = "0.3.5"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.12.28",
  "rvoip-auth-core",
  "rvoip-core-traits",
  "serde",
@@ -6995,7 +7040,7 @@ name = "rvoip-oidc"
 version = "0.3.5"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.12.28",
  "rvoip-auth-core",
  "rvoip-core-traits",
  "serde",
@@ -7347,7 +7392,7 @@ dependencies = [
  "bytes",
  "jsonwebtoken",
  "rcgen 0.14.8",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls-pki-types",
  "rustls-webpki",
  "rvoip-sip-core",
@@ -7423,7 +7468,7 @@ dependencies = [
  "password-hash",
  "rand 0.8.7",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rsa",
  "rvoip-auth-core",
  "rvoip-core-traits",
@@ -7456,7 +7501,7 @@ dependencies = [
  "futures",
  "metrics 0.23.1",
  "parking_lot",
- "reqwest",
+ "reqwest 0.12.28",
  "rvoip-core",
  "serde",
  "serde_json",
@@ -7548,7 +7593,7 @@ dependencies = [
  "quinn",
  "rand 0.8.7",
  "rcgen 0.14.8",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "rustls-pemfile",
  "rvoip-auth-core",
@@ -8946,7 +8991,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
  "tokio-stream",
@@ -9069,14 +9114,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "tracing",
  "tracing-core",
  "tracing-subscriber",

--- a/crates/foundation/infra-common/Cargo.toml
+++ b/crates/foundation/infra-common/Cargo.toml
@@ -44,12 +44,12 @@ bytes = { workspace = true }
 
 # P12.7 — OpenTelemetry span hierarchy. Optional, gated on the
 # `otel` feature so consumers that don't want the OTLP exporter
-# don't pay the dep cost. Pinned to the 0.27 line which matches
-# the current `tracing-opentelemetry` API surface.
-opentelemetry = { version = "0.27", default-features = false, features = ["trace"], optional = true }
-opentelemetry_sdk = { version = "0.27", default-features = false, features = ["trace", "rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.27", default-features = false, features = ["http-proto", "trace", "reqwest-blocking-client"], optional = true }
-tracing-opentelemetry = { version = "0.28", default-features = false, optional = true }
+# don't pay the dep cost. Keep the API, SDK, OTLP exporter, and tracing bridge
+# on their mutually compatible 0.32/0.33 lines.
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"], optional = true }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace"], optional = true }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "trace", "reqwest-blocking-client"], optional = true }
+tracing-opentelemetry = { version = "0.33", default-features = false, optional = true }
 
 [features]
 # Disable the mimalloc `#[global_allocator]` in `lib.rs`. Required by

--- a/crates/foundation/infra-common/src/logging/setup.rs
+++ b/crates/foundation/infra-common/src/logging/setup.rs
@@ -135,8 +135,8 @@ fn setup_logging_with_otel(
         .build()
         .map_err(|e| Error::Config(format!("OTLP exporter init failed: {}", e)))?;
 
-    let provider = opentelemetry_sdk::trace::TracerProvider::builder()
-        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
         .build();
     let tracer = provider.tracer(config.app_name.clone());
 

--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -127,6 +127,14 @@
       ]
     },
     {
+      "gate": "infra-otel",
+      "patterns": [
+        "Cargo.lock",
+        "crates/foundation/infra-common/Cargo.toml",
+        "crates/foundation/infra-common/src/logging/**"
+      ]
+    },
+    {
       "gate": "examples",
       "patterns": [
         "examples/**",

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -339,6 +339,23 @@ def specialty_commands(
                 None,
             ),
         ]
+    if gate == "infra-otel":
+        return [
+            (
+                [
+                    "cargo",
+                    "check",
+                    "--locked",
+                    "-p",
+                    "rvoip-infra-common",
+                    "--features",
+                    "otel",
+                    "--all-targets",
+                ],
+                None,
+                None,
+            )
+        ]
     if gate == "webrtc-runtime":
         commands = []
         for feature_args in ([], ["--no-default-features"], ["--all-features"]):

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -120,6 +120,13 @@ class RunChecksTests(unittest.TestCase):
             commands[1][0],
         )
 
+    def test_otel_gate_compiles_the_optional_exporter(self) -> None:
+        commands = run_checks.specialty_commands("infra-otel", Path("/workspace"))
+        self.assertEqual(len(commands), 1)
+        self.assertIn("rvoip-infra-common", commands[0][0])
+        self.assertIn("otel", commands[0][0])
+        self.assertIn("--all-targets", commands[0][0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -48,6 +48,15 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("Cargo.lock", rules["amazon-connect-aws-control"])
         self.assertIn("examples/Cargo.lock", rules["amazon-connect-aws-control"])
 
+    def test_lockfile_changes_compile_the_optional_otel_exporter(self) -> None:
+        policy = json.loads((ROOT / "scripts/ci/policy.json").read_text())
+        rules = {
+            rule["gate"]: set(rule["patterns"])
+            for rule in policy["specialty_rules"]
+        }
+        self.assertIn("infra-otel", rules)
+        self.assertIn("Cargo.lock", rules["infra-otel"])
+
     def test_every_sip_process_fixture_is_prebuilt_by_the_dedicated_lane(self) -> None:
         policy = json.loads((ROOT / "scripts/ci/policy.json").read_text())
         mapping = policy["pr_sip_fixture_examples"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches optional telemetry export and dependency upgrades that can change OTLP behavior at runtime; impact is limited because the `otel` feature is off by default and CI now compiles that path on relevant changes.
> 
> **Overview**
> **Bumps the optional OpenTelemetry stack** in `rvoip-infra-common` from the 0.27/0.28 line to aligned **0.32 / 0.32.1 / 0.33** (`opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`, `tracing-opentelemetry`), with `Cargo.lock` updated for the new transitive graph (e.g. `prost` 0.14 and `reqwest` 0.13 on the OTLP path).
> 
> **Adapts OTLP logging setup** in `setup.rs` to the 0.32 SDK: batch tracing uses `SdkTracerProvider::builder().with_batch_exporter(exporter)` instead of the old `TracerProvider` + `opentelemetry_sdk::runtime::Tokio` wiring.
> 
> **Adds an `infra-otel` CI specialty gate** so changes to the lockfile, `infra-common` OTel deps, or logging code run `cargo check -p rvoip-infra-common --features otel --all-targets`, with policy and unit tests mirroring the existing Amazon Connect gate pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd43d23cd6edb1bc2f20b6ff1f8621bff30343e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->