### PR TITLE
ci: scope verified lockfile changes

### DIFF
--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -4,11 +4,13 @@
   "target_shard_weight": 12,
   "full_paths": [
     "Cargo.toml",
-    "Cargo.lock",
     "rust-toolchain",
     "rust-toolchain.toml",
     ".cargo/**",
     "deny.toml"
+  ],
+  "scoped_full_paths": [
+    "Cargo.lock"
   ],
   "known_policy_paths": [
     ".config/nextest.toml",

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -107,12 +107,15 @@ def load_metadata(root: Path, metadata_file: Path | None) -> dict[str, Any]:
     )
 
 
-def parse_lockfile(payload: str) -> dict[LockPackage, str]:
+def lockfile_graph(
+    payload: str,
+) -> tuple[dict[LockPackage, dict[str, Any]], dict[LockPackage, frozenset[LockPackage]]]:
     document = tomllib.loads(payload)
     raw_packages = document.get("package", [])
     if not isinstance(raw_packages, list):
         raise PlanError("Cargo.lock package inventory is not a list")
-    packages: dict[LockPackage, str] = {}
+    packages: dict[LockPackage, dict[str, Any]] = {}
+    by_name: dict[str, list[LockPackage]] = {}
     for raw in raw_packages:
         if not isinstance(raw, dict):
             raise PlanError("Cargo.lock contains a non-table package")
@@ -126,29 +129,10 @@ def parse_lockfile(payload: str) -> dict[LockPackage, str]:
             raise PlanError("Cargo.lock package is missing name or version") from error
         if identity in packages:
             raise PlanError(f"Cargo.lock contains duplicate package {identity}")
-        packages[identity] = json.dumps(raw, sort_keys=True, separators=(",", ":"))
+        packages[identity] = raw
+        by_name.setdefault(identity.name, []).append(identity)
     if not packages:
         raise PlanError("Cargo.lock contains no packages")
-    return packages
-
-
-def lockfile_dependency_closure(payload: str, roots: set[str]) -> set[LockPackage]:
-    document = tomllib.loads(payload)
-    raw_packages = document.get("package", [])
-    identities: dict[LockPackage, dict[str, Any]] = {}
-    by_name: dict[str, list[LockPackage]] = {}
-    for raw in raw_packages:
-        if not isinstance(raw, dict) or "name" not in raw or "version" not in raw:
-            raise PlanError("Cargo.lock contains an invalid package entry")
-        identity = LockPackage(
-            name=str(raw["name"]),
-            version=str(raw["version"]),
-            source=str(raw.get("source", "")),
-        )
-        if identity in identities:
-            raise PlanError(f"Cargo.lock contains duplicate package {identity}")
-        identities[identity] = raw
-        by_name.setdefault(identity.name, []).append(identity)
 
     def resolve_dependency(reference: str) -> LockPackage:
         fields = reference.split(" ")
@@ -164,6 +148,38 @@ def lockfile_dependency_closure(payload: str, roots: set[str]) -> set[LockPackag
         if len(candidates) != 1:
             raise PlanError(f"Cargo.lock dependency reference is ambiguous: {reference!r}")
         return candidates[0]
+
+    dependencies: dict[LockPackage, frozenset[LockPackage]] = {}
+    for identity, raw in packages.items():
+        references = raw.get("dependencies", [])
+        if not isinstance(references, list):
+            raise PlanError(f"Cargo.lock dependencies are invalid for {identity.name}")
+        dependencies[identity] = frozenset(
+            resolve_dependency(str(reference)) for reference in references
+        )
+    return packages, dependencies
+
+
+def parse_lockfile(payload: str) -> dict[LockPackage, str]:
+    packages, dependencies = lockfile_graph(payload)
+    fingerprints: dict[LockPackage, str] = {}
+    for identity, raw in packages.items():
+        canonical = dict(raw)
+        canonical["dependencies"] = [
+            [dependency.name, dependency.version, dependency.source]
+            for dependency in sorted(dependencies[identity])
+        ]
+        fingerprints[identity] = json.dumps(
+            canonical, sort_keys=True, separators=(",", ":")
+        )
+    return fingerprints
+
+
+def lockfile_dependency_closure(payload: str, roots: set[str]) -> set[LockPackage]:
+    packages, dependencies = lockfile_graph(payload)
+    by_name: dict[str, list[LockPackage]] = {}
+    for identity in packages:
+        by_name.setdefault(identity.name, []).append(identity)
 
     pending: list[LockPackage] = []
     for name in sorted(roots):
@@ -181,12 +197,7 @@ def lockfile_dependency_closure(payload: str, roots: set[str]) -> set[LockPackag
         if identity in visited:
             continue
         visited.add(identity)
-        raw_dependencies = identities[identity].get("dependencies", [])
-        if not isinstance(raw_dependencies, list):
-            raise PlanError(f"Cargo.lock dependencies are invalid for {identity.name}")
-        pending.extend(
-            resolve_dependency(str(reference)) for reference in raw_dependencies
-        )
+        pending.extend(sorted(dependencies[identity] - visited))
     return visited
 
 

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path, PurePosixPath
 import subprocess
 import sys
+import tomllib
 from typing import Any, Iterable
 
 
@@ -26,6 +27,13 @@ class Package:
     name: str
     root: str
     dependencies: frozenset[str]
+
+
+@dataclass(frozen=True, order=True)
+class LockPackage:
+    name: str
+    version: str
+    source: str
 
 
 def run(argv: list[str], root: Path) -> str:
@@ -97,6 +105,140 @@ def load_metadata(root: Path, metadata_file: Path | None) -> dict[str, Any]:
             root,
         )
     )
+
+
+def parse_lockfile(payload: str) -> dict[LockPackage, str]:
+    document = tomllib.loads(payload)
+    raw_packages = document.get("package", [])
+    if not isinstance(raw_packages, list):
+        raise PlanError("Cargo.lock package inventory is not a list")
+    packages: dict[LockPackage, str] = {}
+    for raw in raw_packages:
+        if not isinstance(raw, dict):
+            raise PlanError("Cargo.lock contains a non-table package")
+        try:
+            identity = LockPackage(
+                name=str(raw["name"]),
+                version=str(raw["version"]),
+                source=str(raw.get("source", "")),
+            )
+        except KeyError as error:
+            raise PlanError("Cargo.lock package is missing name or version") from error
+        if identity in packages:
+            raise PlanError(f"Cargo.lock contains duplicate package {identity}")
+        packages[identity] = json.dumps(raw, sort_keys=True, separators=(",", ":"))
+    if not packages:
+        raise PlanError("Cargo.lock contains no packages")
+    return packages
+
+
+def lockfile_dependency_closure(payload: str, roots: set[str]) -> set[LockPackage]:
+    document = tomllib.loads(payload)
+    raw_packages = document.get("package", [])
+    identities: dict[LockPackage, dict[str, Any]] = {}
+    by_name: dict[str, list[LockPackage]] = {}
+    for raw in raw_packages:
+        if not isinstance(raw, dict) or "name" not in raw or "version" not in raw:
+            raise PlanError("Cargo.lock contains an invalid package entry")
+        identity = LockPackage(
+            name=str(raw["name"]),
+            version=str(raw["version"]),
+            source=str(raw.get("source", "")),
+        )
+        if identity in identities:
+            raise PlanError(f"Cargo.lock contains duplicate package {identity}")
+        identities[identity] = raw
+        by_name.setdefault(identity.name, []).append(identity)
+
+    def resolve_dependency(reference: str) -> LockPackage:
+        fields = reference.split(" ")
+        name = fields[0]
+        version = fields[1] if len(fields) >= 2 and fields[1][:1].isdigit() else None
+        source = " ".join(fields[2:]).removeprefix("(").removesuffix(")")
+        candidates = [
+            identity
+            for identity in by_name.get(name, [])
+            if version is None or identity.version == version
+            if not source or identity.source == source
+        ]
+        if len(candidates) != 1:
+            raise PlanError(f"Cargo.lock dependency reference is ambiguous: {reference!r}")
+        return candidates[0]
+
+    pending: list[LockPackage] = []
+    for name in sorted(roots):
+        candidates = [
+            identity
+            for identity in by_name.get(name, [])
+            if not identity.source
+        ]
+        if len(candidates) != 1:
+            raise PlanError(f"Cargo.lock is missing workspace root {name!r}")
+        pending.append(candidates[0])
+    visited: set[LockPackage] = set()
+    while pending:
+        identity = pending.pop()
+        if identity in visited:
+            continue
+        visited.add(identity)
+        raw_dependencies = identities[identity].get("dependencies", [])
+        if not isinstance(raw_dependencies, list):
+            raise PlanError(f"Cargo.lock dependencies are invalid for {identity.name}")
+        pending.extend(
+            resolve_dependency(str(reference)) for reference in raw_dependencies
+        )
+    return visited
+
+
+def lockfile_delta(
+    base_payload: str, head_payload: str
+) -> tuple[set[LockPackage], set[LockPackage]]:
+    base_packages = parse_lockfile(base_payload)
+    head_packages = parse_lockfile(head_payload)
+    changed_base = {
+        identity
+        for identity, fingerprint in base_packages.items()
+        if head_packages.get(identity) != fingerprint
+    }
+    changed_head = {
+        identity
+        for identity, fingerprint in head_packages.items()
+        if base_packages.get(identity) != fingerprint
+    }
+    return changed_base, changed_head
+
+
+def validate_scoped_lockfile(
+    *,
+    root: Path,
+    packages: dict[str, Package],
+    paths: list[str],
+    base: str,
+    head: str,
+) -> list[str]:
+    manifest_roots = {
+        package.name
+        for package in packages.values()
+        if f"{package.root}/Cargo.toml" in paths
+    }
+    if not manifest_roots:
+        raise PlanError("Cargo.lock changed without a workspace crate manifest")
+    base_payload = run(["git", "show", f"{base}:Cargo.lock"], root)
+    head_payload = run(["git", "show", f"{head}:Cargo.lock"], root)
+    changed_base, changed_head = lockfile_delta(base_payload, head_payload)
+    if not changed_base and not changed_head:
+        raise PlanError("Cargo.lock changed without a package graph delta")
+    base_reachable = lockfile_dependency_closure(base_payload, manifest_roots)
+    head_reachable = lockfile_dependency_closure(head_payload, manifest_roots)
+    unexplained_head = changed_head - head_reachable
+    unexplained_base = changed_base - base_reachable
+    if unexplained_head or unexplained_base:
+        unexplained = sorted(unexplained_head | unexplained_base)
+        detail = ", ".join(
+            f"{identity.name}@{identity.version}" for identity in unexplained
+        )
+        raise PlanError("lockfile delta escapes changed manifest closure: " + detail)
+    return sorted({identity.name for identity in changed_base | changed_head})
 
 
 def workspace_packages(root: Path, metadata: dict[str, Any]) -> dict[str, Package]:
@@ -247,12 +389,28 @@ def make_plan(
     candidate: str | None = None,
     job_mode: str = "split",
     deferred_sip_mode: str = "defer",
+    validated_scoped_paths: set[str] | None = None,
+    lockfile_changed_packages: list[str] | None = None,
 ) -> dict[str, Any]:
     if job_mode not in {"split", "combined"}:
         raise PlanError(f"unsupported shard job mode: {job_mode!r}")
     if deferred_sip_mode not in {"defer", "separate"}:
         raise PlanError(f"unsupported deferred SIP mode: {deferred_sip_mode!r}")
     normalized = sorted({normalize_path(path) for path in paths})
+    validated_scoped = {
+        normalize_path(path) for path in (validated_scoped_paths or set())
+    }
+    declared_scoped = set(policy.get("scoped_full_paths", []))
+    undeclared_scoped = sorted(
+        path
+        for path in validated_scoped
+        if not matches_any(path, declared_scoped)
+    )
+    if undeclared_scoped:
+        raise PlanError(
+            "validated scoped inputs are not declared by policy: "
+            + ", ".join(undeclared_scoped)
+        )
     packages = workspace_packages(root, metadata)
     known_policy_paths = set(policy.get("known_policy_paths", []))
     specialty_set = {
@@ -289,6 +447,11 @@ def make_plan(
     full_reasons = [
         path for path in normalized if matches_any(path, policy.get("full_paths", []))
     ]
+    full_reasons.extend(
+        path
+        for path in normalized
+        if matches_any(path, declared_scoped) and path not in validated_scoped
+    )
     docs_only = bool(normalized) and all(
         documentation_path(path, known_policy_paths) for path in normalized
     )
@@ -299,6 +462,8 @@ def make_plan(
             owner = owning_package(path, packages)
             if owner:
                 direct.add(owner)
+            elif path in validated_scoped:
+                continue
             elif not matches_any(path, known_policy_paths):
                 # Specialty-only trees are mapped even though they are not Cargo members.
                 if not any(
@@ -484,6 +649,8 @@ def make_plan(
         "direct_crates": sorted(direct),
         "selected_crates": sorted(selected),
         "specialty_gates": specialty,
+        "validated_scoped_paths": sorted(validated_scoped),
+        "lockfile_changed_packages": sorted(lockfile_changed_packages or []),
         "sip_jobs": sip_jobs,
         "deferred_sip_targets": deferred_sip_targets,
         "separate_sip_targets": separate_sip_targets,
@@ -554,20 +721,44 @@ def main(argv: list[str] | None = None) -> int:
     root = Path(__file__).resolve().parents[2]
     try:
         policy_path = args.policy if args.policy.is_absolute() else root / args.policy
+        policy = json.loads(policy_path.read_text())
         metadata_file = args.metadata_file
         if metadata_file and not metadata_file.is_absolute():
             metadata_file = root / metadata_file
         paths = args.changed_file or changed_paths(root, args.base, args.head)
+        needs_lockfile_scope = "Cargo.lock" in paths and matches_any(
+            "Cargo.lock", policy.get("scoped_full_paths", [])
+        )
+        metadata = load_metadata(root, metadata_file)
+        validated_scoped_paths: set[str] = set()
+        lockfile_changed_packages: list[str] = []
+        if needs_lockfile_scope:
+            try:
+                lockfile_changed_packages = validate_scoped_lockfile(
+                    root=root,
+                    packages=workspace_packages(root, metadata),
+                    paths=paths,
+                    base=args.base,
+                    head=args.head,
+                )
+                validated_scoped_paths.add("Cargo.lock")
+            except PlanError as error:
+                # An unexplained or unresolvable lockfile edit must not make
+                # the planner fail open. The ordinary full-workspace path
+                # remains selected and records Cargo.lock as its reason.
+                print(f"Scoped lockfile analysis fell back to full: {error}", file=sys.stderr)
         plan = make_plan(
             root=root,
-            metadata=load_metadata(root, metadata_file),
-            policy=json.loads(policy_path.read_text()),
+            metadata=metadata,
+            policy=policy,
             paths=paths,
             base=args.base,
             head=args.head,
             candidate=args.candidate,
             job_mode=args.job_mode,
             deferred_sip_mode=args.deferred_sip_mode,
+            validated_scoped_paths=validated_scoped_paths,
+            lockfile_changed_packages=lockfile_changed_packages,
         )
         for gate in args.specialty_gate:
             if not gate or any(character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-" for character in gate):

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("pr_plan.py")
@@ -37,6 +38,8 @@ class PlannerTests(unittest.TestCase):
                 {
                     "id": f"path+file://{package_root}#{name}@1.0.0",
                     "name": name,
+                    "version": "1.0.0",
+                    "source": None,
                     "manifest_path": str(manifest),
                     "dependencies": [
                         {"name": dependency, "kind": "dev" if name == "gamma" else None}
@@ -51,7 +54,8 @@ class PlannerTests(unittest.TestCase):
         self.policy = {
             "max_shards": 3,
             "target_shard_weight": 3,
-            "full_paths": ["Cargo.toml", "Cargo.lock"],
+            "full_paths": ["Cargo.toml"],
+            "scoped_full_paths": ["Cargo.lock"],
             "known_policy_paths": [
                 "README.md",
                 ".config/nextest.toml",
@@ -105,6 +109,103 @@ class PlannerTests(unittest.TestCase):
                 plan = self.plan(path)
                 self.assertEqual(plan["mode"], "full")
                 self.assertEqual(set(plan["selected_crates"]), {"alpha", "beta", "gamma", "delta"})
+
+    def test_validated_lockfile_delta_uses_changed_manifest_closure(self) -> None:
+        plan = pr_plan.make_plan(
+            root=self.root,
+            metadata=self.metadata,
+            policy=self.policy,
+            paths=["Cargo.lock", "crates/alpha/Cargo.toml"],
+            base="base",
+            head="head",
+            candidate=None,
+            job_mode="combined",
+            validated_scoped_paths={"Cargo.lock"},
+            lockfile_changed_packages=["alpha", "external"],
+        )
+        self.assertEqual(plan["mode"], "targeted")
+        self.assertEqual(plan["direct_crates"], ["alpha"])
+        self.assertEqual(plan["selected_crates"], ["alpha", "beta", "gamma"])
+        self.assertEqual(plan["validated_scoped_paths"], ["Cargo.lock"])
+        self.assertEqual(plan["lockfile_changed_packages"], ["alpha", "external"])
+
+    def test_lockfile_scope_requires_policy_declaration(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["scoped_full_paths"] = []
+        with self.assertRaisesRegex(pr_plan.PlanError, "not declared"):
+            pr_plan.make_plan(
+                root=self.root,
+                metadata=self.metadata,
+                policy=policy,
+                paths=["Cargo.lock", "crates/alpha/Cargo.toml"],
+                base="base",
+                head="head",
+                candidate=None,
+                validated_scoped_paths={"Cargo.lock"},
+            )
+
+    def test_lockfile_validator_accepts_only_reachable_dependency_delta(self) -> None:
+        metadata = copy.deepcopy(self.metadata)
+        base_lock = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+dependencies = ["external 1.0.0"]
+[[package]]
+name = "external"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"""
+        head_lock = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+dependencies = ["external 2.0.0"]
+[[package]]
+name = "external"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"""
+        with mock.patch.object(pr_plan, "run", side_effect=[base_lock, head_lock]):
+            changed = pr_plan.validate_scoped_lockfile(
+                root=self.root,
+                packages=pr_plan.workspace_packages(self.root, metadata),
+                paths=["Cargo.lock", "crates/alpha/Cargo.toml"],
+                base="base",
+                head="head",
+            )
+        self.assertEqual(changed, ["alpha", "external"])
+
+    def test_lockfile_validator_rejects_unrelated_package_delta(self) -> None:
+        base_lock = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+[[package]]
+name = "unrelated"
+version = "1.0.0"
+"""
+        head_lock = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+[[package]]
+name = "unrelated"
+version = "2.0.0"
+"""
+        with mock.patch.object(pr_plan, "run", side_effect=[base_lock, head_lock]):
+            with self.assertRaisesRegex(pr_plan.PlanError, "escapes"):
+                pr_plan.validate_scoped_lockfile(
+                    root=self.root,
+                    packages=pr_plan.workspace_packages(self.root, self.metadata),
+                    paths=["Cargo.lock", "crates/alpha/Cargo.toml"],
+                    base="base",
+                    head="head",
+                )
 
     def test_ci_only_change_runs_policy_without_workspace_crates(self) -> None:
         plan = self.plan("scripts/ci/pr_plan.py", ".github/workflows/pr-gate.yml")

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -144,6 +144,21 @@ class PlannerTests(unittest.TestCase):
                 validated_scoped_paths={"Cargo.lock"},
             )
 
+    def test_lockfile_delta_canonicalizes_dependency_references(self) -> None:
+        explicit = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+dependencies = ["external 2.0.0"]
+[[package]]
+name = "external"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"""
+        implicit = explicit.replace("external 2.0.0", "external", 1)
+        self.assertEqual(pr_plan.lockfile_delta(explicit, implicit), (set(), set()))
+
     def test_lockfile_validator_accepts_only_reachable_dependency_delta(self) -> None:
         metadata = copy.deepcopy(self.metadata)
         base_lock = """\


### PR DESCRIPTION
## Problem

A root `Cargo.lock` edit currently forces all 44 crates and every SIP PR lane, even when the accompanying crate manifest proves the dependency change is isolated. This makes routine dependency and security fixes unnecessarily slow.

## Change

- Treat `Cargo.lock` as conditionally scoped rather than unconditionally full-workspace.
- Compare the exact old and new lockfile package graphs.
- Permit targeted verification only when every changed package is reachable from a workspace crate manifest changed in the same PR.
- Fall back to the full workspace for lockfile-only, malformed, ambiguous, or unexplained changes.
- Record validated scoped paths and changed dependency packages in the machine receipt.

## Verification

- `python3 -m unittest scripts.ci.test_pr_plan` (25 tests)
- `python3 scripts/ci/run_checks.py policy ...` (58 CI policy tests plus formatting)

## Risk

Low and fail-closed. Any analysis error retains the existing full-workspace behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI impact planning in `scripts/ci`; validation errors fall back to the existing full-workspace behavior.
> 
> **Overview**
> **`Cargo.lock` no longer always triggers a full-workspace PR plan.** It moves from unconditional `full_paths` to `scoped_full_paths`, so CI can narrow testing when the lockfile edit is explainable.
> 
> When a PR touches `Cargo.lock`, the planner now diffs base/head lockfiles (canonicalized dependency refs), requires a co-changed workspace `Cargo.toml`, and checks that every changed lock package sits in the dependency closure of those manifests. Success marks `Cargo.lock` as validated and keeps **targeted** crate selection from the manifest change; failure or lockfile-only edits still select **full** workspace (fail-closed, with stderr on analysis errors).
> 
> The plan receipt gains **`validated_scoped_paths`** and **`lockfile_changed_packages`** for downstream CI. Unit tests cover policy declaration, reachable vs escaping deltas, and targeted planning with a validated lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1725d31b76806caf7022453d6708a45f019a7885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->