### PR TITLE
ci: scope lockfile graph transitions

### DIFF
--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -109,7 +109,11 @@ def load_metadata(root: Path, metadata_file: Path | None) -> dict[str, Any]:
 
 def lockfile_graph(
     payload: str,
-) -> tuple[dict[LockPackage, dict[str, Any]], dict[LockPackage, frozenset[LockPackage]]]:
+) -> tuple[
+    dict[LockPackage, dict[str, Any]],
+    dict[LockPackage, frozenset[LockPackage]],
+    dict[LockPackage, frozenset[str]],
+]:
     document = tomllib.loads(payload)
     raw_packages = document.get("package", [])
     if not isinstance(raw_packages, list):
@@ -134,7 +138,7 @@ def lockfile_graph(
     if not packages:
         raise PlanError("Cargo.lock contains no packages")
 
-    def resolve_dependency(reference: str) -> LockPackage:
+    def resolve_dependency(reference: str) -> LockPackage | None:
         fields = reference.split(" ")
         name = fields[0]
         version = fields[1] if len(fields) >= 2 and fields[1][:1].isdigit() else None
@@ -145,30 +149,38 @@ def lockfile_graph(
             if version is None or identity.version == version
             if not source or identity.source == source
         ]
-        if len(candidates) != 1:
-            raise PlanError(f"Cargo.lock dependency reference is ambiguous: {reference!r}")
-        return candidates[0]
+        return candidates[0] if len(candidates) == 1 else None
 
     dependencies: dict[LockPackage, frozenset[LockPackage]] = {}
+    unresolved: dict[LockPackage, frozenset[str]] = {}
     for identity, raw in packages.items():
         references = raw.get("dependencies", [])
         if not isinstance(references, list):
             raise PlanError(f"Cargo.lock dependencies are invalid for {identity.name}")
+        resolved = [
+            (str(reference), resolve_dependency(str(reference)))
+            for reference in references
+        ]
         dependencies[identity] = frozenset(
-            resolve_dependency(str(reference)) for reference in references
+            dependency
+            for _, dependency in resolved
+            if dependency is not None
         )
-    return packages, dependencies
+        unresolved[identity] = frozenset(
+            reference for reference, dependency in resolved if dependency is None
+        )
+    return packages, dependencies, unresolved
 
 
 def parse_lockfile(payload: str) -> dict[LockPackage, str]:
-    packages, dependencies = lockfile_graph(payload)
+    packages, dependencies, unresolved = lockfile_graph(payload)
     fingerprints: dict[LockPackage, str] = {}
     for identity, raw in packages.items():
         canonical = dict(raw)
         canonical["dependencies"] = [
-            [dependency.name, dependency.version, dependency.source]
+            ["package", dependency.name, dependency.version, dependency.source]
             for dependency in sorted(dependencies[identity])
-        ]
+        ] + [["unresolved", reference] for reference in sorted(unresolved[identity])]
         fingerprints[identity] = json.dumps(
             canonical, sort_keys=True, separators=(",", ":")
         )
@@ -176,7 +188,7 @@ def parse_lockfile(payload: str) -> dict[LockPackage, str]:
 
 
 def lockfile_dependency_closure(payload: str, roots: set[str]) -> set[LockPackage]:
-    packages, dependencies = lockfile_graph(payload)
+    packages, dependencies, _unresolved = lockfile_graph(payload)
     by_name: dict[str, list[LockPackage]] = {}
     for identity in packages:
         by_name.setdefault(identity.name, []).append(identity)
@@ -196,6 +208,10 @@ def lockfile_dependency_closure(payload: str, roots: set[str]) -> set[LockPackag
         identity = pending.pop()
         if identity in visited:
             continue
+        # Cargo may retain a target-specific dependency reference without
+        # materializing that package for the current resolver target. Keep the
+        # exact reference in the package fingerprint, but there is no package
+        # identity to traverse or attribute to another workspace crate.
         visited.add(identity)
         pending.extend(sorted(dependencies[identity] - visited))
     return visited
@@ -241,10 +257,14 @@ def validate_scoped_lockfile(
         raise PlanError("Cargo.lock changed without a package graph delta")
     base_reachable = lockfile_dependency_closure(base_payload, manifest_roots)
     head_reachable = lockfile_dependency_closure(head_payload, manifest_roots)
-    unexplained_head = changed_head - head_reachable
-    unexplained_base = changed_base - base_reachable
-    if unexplained_head or unexplained_base:
-        unexplained = sorted(unexplained_head | unexplained_base)
+    changed_in_place = changed_base & changed_head
+    unexplained_common = changed_in_place - (base_reachable | head_reachable)
+    unexplained_head = (changed_head - changed_in_place) - head_reachable
+    unexplained_base = (changed_base - changed_in_place) - base_reachable
+    if unexplained_common or unexplained_head or unexplained_base:
+        unexplained = sorted(
+            unexplained_common | unexplained_head | unexplained_base
+        )
         detail = ", ".join(
             f"{identity.name}@{identity.version}" for identity in unexplained
         )

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -159,6 +159,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         implicit = explicit.replace("external 2.0.0", "external", 1)
         self.assertEqual(pr_plan.lockfile_delta(explicit, implicit), (set(), set()))
 
+    def test_lockfile_delta_tolerates_unreachable_stale_record(self) -> None:
+        payload = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+[[package]]
+name = "stale"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = ["missing 9.9.9"]
+"""
+        self.assertEqual(pr_plan.lockfile_delta(payload, payload), (set(), set()))
+        self.assertEqual(
+            pr_plan.lockfile_dependency_closure(payload, {"alpha"}),
+            {pr_plan.LockPackage("alpha", "1.0.0", "")},
+        )
+
+    def test_lockfile_closure_tolerates_unmaterialized_target_dependency(self) -> None:
+        payload = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+dependencies = ["target-only 9.9.9"]
+"""
+        self.assertEqual(
+            pr_plan.lockfile_dependency_closure(payload, {"alpha"}),
+            {pr_plan.LockPackage("alpha", "1.0.0", "")},
+        )
+
+    def test_lockfile_validator_accepts_dependency_that_becomes_reachable(self) -> None:
+        base_lock = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+[[package]]
+name = "external"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "old"
+"""
+        head_lock = """\
+version = 4
+[[package]]
+name = "alpha"
+version = "1.0.0"
+dependencies = ["external"]
+[[package]]
+name = "external"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "new"
+"""
+        with mock.patch.object(pr_plan, "run", side_effect=[base_lock, head_lock]):
+            changed = pr_plan.validate_scoped_lockfile(
+                root=self.root,
+                packages=pr_plan.workspace_packages(self.root, self.metadata),
+                paths=["Cargo.lock", "crates/alpha/Cargo.toml"],
+                base="base",
+                head="head",
+            )
+        self.assertEqual(changed, ["alpha", "external"])
+
     def test_lockfile_validator_accepts_only_reachable_dependency_delta(self) -> None:
         metadata = copy.deepcopy(self.metadata)
         base_lock = """\


### PR DESCRIPTION
## Problem

The fail-closed lockfile planner correctly scopes ordinary version changes, but two valid Cargo lock graph forms still fall back to all 44 crates:

- an existing package becomes newly reachable and its dependency record changes in the same update;
- Cargo retains an unresolved target-specific reference that is not materialized for the current resolver target.

## Change

- Attribute in-place package changes to the union of their old and new dependency closures.
- Preserve unresolved target references in canonical fingerprints without inventing a package identity or traversing them.
- Continue rejecting every changed package that is outside both affected closures.

## Verification

- 29 focused planner tests
- 62 CI policy tests plus formatting
- Dry replay of the OpenTelemetry lock delta now scopes successfully

## Risk

Low and fail-closed. Added/removed package identities still require exact reachability in the corresponding old/new graph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI planning logic only; fail-closed rules for unrelated lockfile deltas remain, with added regression tests.
> 
> **Overview**
> Fixes scoped PR lockfile planning so valid `Cargo.lock` graph shapes no longer force a full-workspace CI run.
> 
> **Lockfile graph parsing** no longer errors on dependency references that do not resolve to a single package. Unresolved references are kept in each package’s canonical fingerprint and are not traversed during closure walks, which matches Cargo keeping target-specific or stale edges without materializing those packages.
> 
> **Scoped lockfile validation** treats packages that change in place (present on both sides with different fingerprints) as explainable if they lie in the **union** of the old and new manifest-root closures. Additions and removals still must be reachable only on the corresponding side. That covers cases such as a dependency becoming newly reachable while its record changes in the same update.
> 
> New planner tests cover stale unreachable records, unmaterialized target-only dependencies, and a dependency that becomes reachable when a manifest adds it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bdd04ff6fd8f2fa6acf74c8a20fb84088d2f97c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->