### PR TITLE
ci: parallelize example smoke demos

### DIFF
--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -48,6 +48,13 @@
     "06-attended-transfer",
     "11-ai-harness-demo"
   ],
+  "pr_example_smoke_projects": [
+    "01-quickstart-p2p",
+    "02-softphone-audio",
+    "06-attended-transfer",
+    "07-secure-call-srtp",
+    "10-call-center-b2bua"
+  ],
   "pr_sip_partitions": 3,
   "pr_deferred_sip_targets": [
     "audio_roundtrip_integration"

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -449,9 +449,21 @@ def make_plan(
             for rule in policy.get("specialty_rules", [])
             if any(matches_any(path, rule.get("patterns", [])) for path in normalized)
         }
+    projects = policy.get("example_projects", [])
+    if "examples-smoke" in specialty_set:
+        specialty_set.remove("examples-smoke")
+        smoke_projects = policy.get("pr_example_smoke_projects", [])
+        unknown_smoke_projects = sorted(set(smoke_projects) - set(projects))
+        if not smoke_projects or unknown_smoke_projects:
+            raise PlanError(
+                "PR example smoke set is empty or unknown: "
+                + ", ".join(unknown_smoke_projects)
+            )
+        specialty_set.update(
+            f"example-smoke--{project}" for project in smoke_projects
+        )
     if "examples" in specialty_set:
         specialty_set.remove("examples")
-        projects = policy.get("example_projects", [])
         directly_changed = {
             project
             for project in projects

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -235,14 +235,23 @@ def specialty_commands(
         return [
             (["cargo", "build", "--manifest-path", str(manifest), "--locked"], None, None)
         ]
+    smoke_examples = (
+        "01-quickstart-p2p",
+        "02-softphone-audio",
+        "06-attended-transfer",
+        "07-secure-call-srtp",
+        "10-call-center-b2bua",
+    )
+    if gate.startswith("example-smoke--"):
+        example = gate.removeprefix("example-smoke--")
+        if example not in smoke_examples:
+            raise CheckError(f"unknown example smoke project: {example}")
+        directory = root / "examples" / example
+        return [
+            (["cargo", "build", "--release", "--locked"], directory, None),
+            (["timeout", "120", "./run_demo.sh"], directory, None),
+        ]
     if gate == "examples-smoke":
-        smoke_examples = (
-            "01-quickstart-p2p",
-            "02-softphone-audio",
-            "06-attended-transfer",
-            "07-secure-call-srtp",
-            "10-call-center-b2bua",
-        )
         commands: list[tuple[list[str], Path | None, dict[str, str] | None]] = []
         for example in smoke_examples:
             directory = root / "examples" / example

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -377,6 +377,44 @@ version = "2.0.0"
         plan = self.plan("examples/two/src/main.rs")
         self.assertEqual(plan["specialty_gates"], ["example--two"])
 
+    def test_example_smoke_matrix_is_split_into_independent_gates(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["specialty_rules"].append(
+            {"gate": "examples-smoke", "patterns": ["examples/**"]}
+        )
+        policy["pr_example_smoke_projects"] = ["one", "two"]
+        plan = pr_plan.make_plan(
+            root=self.root,
+            metadata=self.metadata,
+            policy=policy,
+            paths=["examples/two/src/main.rs"],
+            base="base",
+            head="head",
+            candidate=None,
+            job_mode="combined",
+        )
+        self.assertEqual(
+            plan["specialty_gates"],
+            ["example--two", "example-smoke--one", "example-smoke--two"],
+        )
+
+    def test_invalid_example_smoke_matrix_fails_closed(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["specialty_rules"].append(
+            {"gate": "examples-smoke", "patterns": ["examples/**"]}
+        )
+        policy["pr_example_smoke_projects"] = ["missing"]
+        with self.assertRaisesRegex(pr_plan.PlanError, "smoke set"):
+            pr_plan.make_plan(
+                root=self.root,
+                metadata=self.metadata,
+                policy=policy,
+                paths=["examples/two/src/main.rs"],
+                base="base",
+                head="head",
+                candidate=None,
+            )
+
     def test_invalid_pr_example_contract_set_fails_closed(self) -> None:
         self.policy["pr_example_projects"] = ["missing"]
         with self.assertRaises(pr_plan.PlanError):

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -89,6 +89,17 @@ class RunChecksTests(unittest.TestCase):
             5,
         )
 
+    def test_example_smoke_partition_runs_one_release_demo(self) -> None:
+        commands = run_checks.specialty_commands(
+            "example-smoke--07-secure-call-srtp", Path("/workspace")
+        )
+        self.assertEqual(len(commands), 2)
+        self.assertEqual(commands[0][0], ["cargo", "build", "--release", "--locked"])
+        self.assertEqual(commands[1][0], ["timeout", "120", "./run_demo.sh"])
+        self.assertEqual(
+            commands[0][1], Path("/workspace/examples/07-secure-call-srtp")
+        )
+
     def test_vcon_gate_contains_live_store_and_boundary_checks(self) -> None:
         commands = run_checks.specialty_commands("vcon-postgres", Path("/workspace"))
         argv = [item[0] for item in commands]


### PR DESCRIPTION
## Problem

The `examples-smoke` specialty gate runs five release builds and five demo executions sequentially. In a targeted dependency PR it remained the only active job after every affected crate and compatibility check had passed.

## Change

- Expand the smoke set into five independent specialty matrix jobs.
- Keep the same release build and bounded 120-second demo command for every project.
- Retain the aggregate `examples-smoke` command as a compatibility entry point.
- Fail closed if the configured smoke inventory is empty or references an unknown example.

## Verification

- 40 focused planner/runner tests
- 65 CI policy tests plus formatting
- Dry replay of PR #131 selects all five independent smoke gates

## Expected impact

Critical-path time becomes the slowest smoke project instead of the sum of all five; no test requirement is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI orchestration only; smoke commands and project set are unchanged, with added validation and unit tests.
> 
> **Overview**
> **Parallelizes PR example smoke work** so CI runs five independent specialty jobs (`example-smoke--*`) instead of one gate that built and ran all demos back-to-back.
> 
> When `examples-smoke` matches a change, `pr_plan.py` now replaces that single gate with one gate per project listed in new policy key `pr_example_smoke_projects` (same five examples as before). `run_checks.py` runs release build plus `timeout 120 ./run_demo.sh` for each `example-smoke--{project}` gate; the aggregate `examples-smoke` gate remains for callers that still invoke it (e.g. main CI).
> 
> Planning **fails closed** if the smoke list is empty or names unknown examples. Tests cover matrix expansion, invalid smoke config, and per-partition commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b871539c0c9cf6fb26d51a2c0ffe3a4ff9964a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->