### PR TITLE
fix(ci): install release preparation dependencies

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           toolchain: 1.91.0
 
+      - name: Install release validation dependencies
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          libasound2-dev libopus-dev libssl-dev protobuf-compiler pkg-config cmake
+
       - name: Establish local main branch
         run: git checkout -B main origin/main
 

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -119,6 +119,23 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertGreaterEqual(specialty.count("matrix.gate == 'release-tooling'"), 2)
         self.assertIn("max-parallel: 6", specialty)
 
+    def test_release_prepare_installs_native_validation_dependencies(self) -> None:
+        text = (ROOT / ".github/workflows/release-prepare.yml").read_text()
+        dependency_step = text.index("Install release validation dependencies")
+        validation_step = text.index("Prepare all workspace versions")
+
+        self.assertLess(dependency_step, validation_step)
+        for package in (
+            "libasound2-dev",
+            "libopus-dev",
+            "libssl-dev",
+            "protobuf-compiler",
+            "pkg-config",
+            "cmake",
+        ):
+            with self.subTest(package=package):
+                self.assertIn(package, text[dependency_step:validation_step])
+
     def test_parallel_gcp_workspace_is_ephemeral_and_fail_closed(self) -> None:
         workflow = (ROOT / ".github/workflows/gcp-qualification-pilot.yml").read_text()
         startup = (ROOT / "infra/release-runners/gcp-pilot-startup.sh").read_text()


### PR DESCRIPTION
## Problem

The v0.3.6 release preparation workflow failed before opening its candidate PR because cargo check --workspace --all-targets requires ALSA headers that were absent from ubuntu-latest.

## Fix

Install the same native build dependencies already used by release qualification and publication before preparing and validating workspace versions. Add a policy test that keeps the dependency step ahead of release preparation and checks the complete package set.

## Verification

- 19 workflow-policy tests pass
- git diff --check passes
- No package, test threshold, performance workload, or soak duration changes

Closes the automation failure in run 30745284405.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and test changes; no runtime, auth, or release publication logic is modified.
> 
> **Overview**
> Adds an **Install release validation dependencies** step to the **Prepare release PR** workflow so `ubuntu-latest` has native headers/libs (including ALSA via `libasound2-dev`) before `release.py prepare` and workspace validation run—matching the dependency set used elsewhere for release builds (`libopus-dev`, `libssl-dev`, `protobuf-compiler`, `pkg-config`, `cmake`).
> 
> Introduces `test_release_prepare_installs_native_validation_dependencies` in workflow policy tests to require that step appears **before** **Prepare all workspace versions** and lists the full package set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be54f2d7cbfbe671e92bd5f3d37f930f3c2891ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->