### PR TITLE
Prepare v0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6787,7 +6787,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -6816,7 +6816,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-amazon-connect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-audio-device"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "cpal",
@@ -6860,7 +6860,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-audit"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -6874,7 +6874,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-auth-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-codec-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "opus",
@@ -6939,7 +6939,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6972,7 +6972,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core-traits"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6988,7 +6988,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-harness"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-identity"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "rvoip-core",
@@ -7007,7 +7007,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-ims-aka"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes",
  "async-trait",
@@ -7026,7 +7026,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-infra-common"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7054,7 +7054,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-keycloak"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-ldap"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "ldap3",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-media-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "apodize",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-native"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-relay"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7200,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-transport"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "futures",
@@ -7218,7 +7218,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-oidc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-quic"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7257,7 +7257,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-redis"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7312,7 +7312,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtp-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7349,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-saml"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7364,7 +7364,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-scim"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7469,7 +7469,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-dialog"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-proxy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -7513,7 +7513,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-registrar"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7534,7 +7534,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-transport"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7566,7 +7566,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-stir-shaken"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7591,7 +7591,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-uctp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7630,7 +7630,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-users-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7672,7 +7672,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vapi"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -7697,7 +7697,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7718,7 +7718,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon-postgres"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7735,7 +7735,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webauthn"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -7806,7 +7806,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc-stack"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7827,7 +7827,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-websocket"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7856,7 +7856,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webtransport"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ default-members = [
 [workspace.package]
 # Every publishable workspace crate ships at this one version. Feature-level
 # maturity and non-claims remain documented independently of package SemVer.
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/eisenzopf/rvoip"
@@ -213,55 +213,55 @@ collapsible_else_if = "allow"
 # the in-repo directory changed. See the grouped [workspace] members above.
 # All publishable workspace crates and internal registry requirements move
 # together in one dependency-ordered release.
-rvoip-sip-core      = { path = "crates/sip/sip-core", version = "0.3.5" }
-rvoip-sip-transport = { path = "crates/sip/sip-transport", version = "0.3.5" }
-rvoip-sip-dialog    = { path = "crates/sip/sip-dialog", version = "0.3.5" }
-rvoip-sip-proxy     = { path = "crates/sip/sip-proxy", version = "0.3.5" }
-rvoip-sip-registrar = { path = "crates/sip/sip-registrar", version = "0.3.5" }
-rvoip-rtp-core      = { path = "crates/media/rtp-core", version = "0.3.5" }
-rvoip-media-core    = { path = "crates/media/media-core", version = "0.3.5" }
-rvoip-sip           = { path = "crates/sip/rvoip-sip", version = "0.3.5" }
-rvoip-core          = { path = "crates/foundation/rvoip-core", version = "0.3.5" }
-rvoip-codec-core    = { path = "crates/media/codec-core", version = "0.3.5" }
-rvoip-infra-common  = { path = "crates/foundation/infra-common", version = "0.3.5" }
-rvoip-auth-core     = { path = "crates/identity/auth-core", version = "0.3.5" }
-rvoip-core-traits   = { path = "crates/foundation/rvoip-core-traits", version = "0.3.5" }
-rvoip-users-core    = { path = "crates/identity/users-core", version = "0.3.5" }
+rvoip-sip-core      = { path = "crates/sip/sip-core", version = "0.3.6" }
+rvoip-sip-transport = { path = "crates/sip/sip-transport", version = "0.3.6" }
+rvoip-sip-dialog    = { path = "crates/sip/sip-dialog", version = "0.3.6" }
+rvoip-sip-proxy     = { path = "crates/sip/sip-proxy", version = "0.3.6" }
+rvoip-sip-registrar = { path = "crates/sip/sip-registrar", version = "0.3.6" }
+rvoip-rtp-core      = { path = "crates/media/rtp-core", version = "0.3.6" }
+rvoip-media-core    = { path = "crates/media/media-core", version = "0.3.6" }
+rvoip-sip           = { path = "crates/sip/rvoip-sip", version = "0.3.6" }
+rvoip-core          = { path = "crates/foundation/rvoip-core", version = "0.3.6" }
+rvoip-codec-core    = { path = "crates/media/codec-core", version = "0.3.6" }
+rvoip-infra-common  = { path = "crates/foundation/infra-common", version = "0.3.6" }
+rvoip-auth-core     = { path = "crates/identity/auth-core", version = "0.3.6" }
+rvoip-core-traits   = { path = "crates/foundation/rvoip-core-traits", version = "0.3.6" }
+rvoip-users-core    = { path = "crates/identity/users-core", version = "0.3.6" }
 
 # Optional and top-of-stack crates are part of the same release. Facade and
 # core packages list extension crates such as rvoip-vcon, rvoip-harness, and
 # rvoip-vapi as optional runtime dependencies, so their versions must resolve
 # on crates.io regardless of feature activation.
-rvoip-vcon          = { path = "crates/extensions/rvoip-vcon", version = "0.3.5" }
-rvoip-vcon-postgres = { path = "crates/extensions/rvoip-vcon-postgres", version = "0.3.5" }
-rvoip-harness       = { path = "crates/extensions/rvoip-harness", version = "0.3.5" }
-rvoip-vapi          = { path = "crates/extensions/rvoip-vapi", version = "0.3.5" }
-rvoip               = { path = "crates/rvoip", version = "0.3.5" }
-rvoip-uctp          = { path = "crates/uctp/rvoip-uctp", version = "0.3.5" }
-rvoip-quic          = { path = "crates/uctp/rvoip-quic", version = "0.3.5" }
-rvoip-webtransport  = { path = "crates/uctp/rvoip-webtransport", version = "0.3.5" }
-rvoip-websocket     = { path = "crates/uctp/rvoip-websocket", version = "0.3.5" }
-rvoip-moq-transport = { path = "crates/moq/rvoip-moq-transport", version = "0.3.5" }
-rvoip-moq-native    = { path = "crates/moq/rvoip-moq-native", version = "0.3.5" }
-rvoip-moq-relay     = { path = "crates/moq/rvoip-moq-relay", version = "0.3.5", default-features = false }
-rvoip-moq           = { path = "crates/moq/rvoip-moq", version = "0.3.5" }
-rvoip-rtc           = { path = "crates/webrtc/rvoip-rtc", version = "0.3.5" }
-rvoip-webrtc-stack  = { path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.5" }
-rvoip-webrtc        = { path = "crates/webrtc/rvoip-webrtc", version = "0.3.5" }
-rvoip-identity      = { path = "crates/identity/rvoip-identity", version = "0.3.5" }
-rvoip-client        = { path = "crates/rvoip-client", version = "0.3.5" }
-rvoip-audio-device  = { path = "crates/media/rvoip-audio-device", version = "0.3.5" }
-rvoip-stir-shaken   = { path = "crates/extensions/rvoip-stir-shaken", version = "0.3.5" }
-rvoip-keycloak      = { path = "crates/extensions/rvoip-keycloak", version = "0.3.5" }
-rvoip-redis         = { path = "crates/extensions/rvoip-redis", version = "0.3.5" }
-rvoip-audit         = { path = "crates/extensions/rvoip-audit", version = "0.3.5" }
-rvoip-oidc          = { path = "crates/extensions/rvoip-oidc", version = "0.3.5" }
-rvoip-ldap          = { path = "crates/extensions/rvoip-ldap", version = "0.3.5" }
-rvoip-scim          = { path = "crates/extensions/rvoip-scim", version = "0.3.5" }
-rvoip-saml          = { path = "crates/extensions/rvoip-saml", version = "0.3.5" }
-rvoip-webauthn      = { path = "crates/extensions/rvoip-webauthn", version = "0.3.5" }
-rvoip-ims-aka       = { path = "crates/extensions/rvoip-ims-aka", version = "0.3.5" }
-rtc = { package = "rvoip-rtc", path = "crates/webrtc/rvoip-rtc", version = "0.3.5" }
+rvoip-vcon          = { path = "crates/extensions/rvoip-vcon", version = "0.3.6" }
+rvoip-vcon-postgres = { path = "crates/extensions/rvoip-vcon-postgres", version = "0.3.6" }
+rvoip-harness       = { path = "crates/extensions/rvoip-harness", version = "0.3.6" }
+rvoip-vapi          = { path = "crates/extensions/rvoip-vapi", version = "0.3.6" }
+rvoip               = { path = "crates/rvoip", version = "0.3.6" }
+rvoip-uctp          = { path = "crates/uctp/rvoip-uctp", version = "0.3.6" }
+rvoip-quic          = { path = "crates/uctp/rvoip-quic", version = "0.3.6" }
+rvoip-webtransport  = { path = "crates/uctp/rvoip-webtransport", version = "0.3.6" }
+rvoip-websocket     = { path = "crates/uctp/rvoip-websocket", version = "0.3.6" }
+rvoip-moq-transport = { path = "crates/moq/rvoip-moq-transport", version = "0.3.6" }
+rvoip-moq-native    = { path = "crates/moq/rvoip-moq-native", version = "0.3.6" }
+rvoip-moq-relay     = { path = "crates/moq/rvoip-moq-relay", version = "0.3.6", default-features = false }
+rvoip-moq           = { path = "crates/moq/rvoip-moq", version = "0.3.6" }
+rvoip-rtc           = { path = "crates/webrtc/rvoip-rtc", version = "0.3.6" }
+rvoip-webrtc-stack  = { path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.6" }
+rvoip-webrtc        = { path = "crates/webrtc/rvoip-webrtc", version = "0.3.6" }
+rvoip-identity      = { path = "crates/identity/rvoip-identity", version = "0.3.6" }
+rvoip-client        = { path = "crates/rvoip-client", version = "0.3.6" }
+rvoip-audio-device  = { path = "crates/media/rvoip-audio-device", version = "0.3.6" }
+rvoip-stir-shaken   = { path = "crates/extensions/rvoip-stir-shaken", version = "0.3.6" }
+rvoip-keycloak      = { path = "crates/extensions/rvoip-keycloak", version = "0.3.6" }
+rvoip-redis         = { path = "crates/extensions/rvoip-redis", version = "0.3.6" }
+rvoip-audit         = { path = "crates/extensions/rvoip-audit", version = "0.3.6" }
+rvoip-oidc          = { path = "crates/extensions/rvoip-oidc", version = "0.3.6" }
+rvoip-ldap          = { path = "crates/extensions/rvoip-ldap", version = "0.3.6" }
+rvoip-scim          = { path = "crates/extensions/rvoip-scim", version = "0.3.6" }
+rvoip-saml          = { path = "crates/extensions/rvoip-saml", version = "0.3.6" }
+rvoip-webauthn      = { path = "crates/extensions/rvoip-webauthn", version = "0.3.6" }
+rvoip-ims-aka       = { path = "crates/extensions/rvoip-ims-aka", version = "0.3.6" }
+rtc = { package = "rvoip-rtc", path = "crates/webrtc/rvoip-rtc", version = "0.3.6" }
 
 # External dependencies
 tokio = { version = "1.36", features = ["full"] }
@@ -334,15 +334,15 @@ tokio-util = { version = "0.7", features = ["codec", "compat"] }
 metrics = "0.23"
 # Qualified, attributed MOQT draft-19 forks. Package aliases retain the
 # upstream Rust crate names while the registry identities remain rvoip-owned.
-moq-transport = { package = "rvoip-moq-transport", path = "crates/moq/rvoip-moq-transport", version = "0.3.5" }
-moq-native-ietf = { package = "rvoip-moq-native", path = "crates/moq/rvoip-moq-native", version = "0.3.5" }
-moq-relay-ietf = { package = "rvoip-moq-relay", path = "crates/moq/rvoip-moq-relay", version = "0.3.5", default-features = false }
+moq-transport = { package = "rvoip-moq-transport", path = "crates/moq/rvoip-moq-transport", version = "0.3.6" }
+moq-native-ietf = { package = "rvoip-moq-native", path = "crates/moq/rvoip-moq-native", version = "0.3.6" }
+moq-relay-ietf = { package = "rvoip-moq-relay", path = "crates/moq/rvoip-moq-relay", version = "0.3.6", default-features = false }
 # rvoip-websocket signaling + media. tokio-tungstenite for the WebSocket
 # transport, webrtc for the co-located PeerConnection media plane.
 # webrtc is pre-1.0 and API-volatile — pinned strictly. Bumping requires
 # verifying the WebRtcMediaBridge still compiles.
 tokio-tungstenite = "0.29"
-webrtc = { package = "rvoip-webrtc-stack", path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.5" }
+webrtc = { package = "rvoip-webrtc-stack", path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.6" }
 hickory-resolver = { version = "0.26.1", default-features = false, features = ["tokio", "system-config"] }
 tracing-appender = "0.2"
 env_logger = "0.11"

--- a/crates/webrtc/rvoip-webrtc-stack/Cargo.toml
+++ b/crates/webrtc/rvoip-webrtc-stack/Cargo.toml
@@ -203,7 +203,7 @@ version = "0.3.31"
 version = "0.4.29"
 
 [dependencies.rtc]
-version = "0.3.5"
+version = "0.3.6"
 path = "../rvoip-rtc"
 package = "rvoip-rtc"
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3807,7 +3807,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rvoip"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "axum",
  "bytes",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-amazon-connect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-auth-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-codec-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "opus",
  "thiserror 1.0.69",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core-traits"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-harness"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-infra-common"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-media-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "apodize",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-quic"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "hex",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtp-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-dialog"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-proxy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-registrar"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-transport"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-uctp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vapi"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc-stack"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-websocket"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webtransport"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -22,6 +22,7 @@ import urllib.request
 
 
 EXPECTED_PACKAGE_COUNT = 44
+RELEASE_LOCK_MANIFESTS = (Path("Cargo.toml"), Path("examples/Cargo.toml"))
 SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 USER_AGENT = "rvoip-unified-release/1.0"
@@ -240,6 +241,44 @@ def cargo_metadata(root: Path, *, locked: bool) -> dict[str, Any]:
     if locked:
         argv.append("--locked")
     return json.loads(run(argv, cwd=root).stdout)
+
+
+def release_lock_paths(root: Path) -> tuple[Path, ...]:
+    return tuple(root / manifest.parent / "Cargo.lock" for manifest in RELEASE_LOCK_MANIFESTS)
+
+
+def refresh_release_lockfiles(root: Path) -> None:
+    for manifest in RELEASE_LOCK_MANIFESTS:
+        manifest_path = root / manifest
+        if not manifest_path.is_file():
+            raise ReleaseError(f"release lock manifest is missing: {manifest}")
+        run(
+            [
+                "cargo",
+                "metadata",
+                "--manifest-path",
+                str(manifest),
+                "--format-version",
+                "1",
+            ],
+            cwd=root,
+        )
+
+
+def validate_release_lockfiles(root: Path) -> None:
+    for manifest in RELEASE_LOCK_MANIFESTS:
+        run(
+            [
+                "cargo",
+                "metadata",
+                "--manifest-path",
+                str(manifest),
+                "--format-version",
+                "1",
+                "--locked",
+            ],
+            cwd=root,
+        )
 
 
 def publishable_packages(metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -609,15 +648,16 @@ def prepare(root: Path, version: str) -> None:
             f"cannot prepare an already-published version for: {existing}"
         )
     edits = planned_version_edits(root, packages, version)
-    lock_path = root / "Cargo.lock"
+    lock_paths = release_lock_paths(root)
     originals = {
         path: path.read_bytes() if path.exists() else None
-        for path in [*edits, lock_path]
+        for path in [*edits, *lock_paths]
     }
     try:
         for path, payload in edits.items():
             write_atomic(path, payload)
-        run(["cargo", "metadata", "--format-version", "1"], cwd=root)
+        refresh_release_lockfiles(root)
+        validate_release_lockfiles(root)
         validate_workspace(root, version, locked=True)
         run(
             ["cargo", "check", "--workspace", "--all-targets", "--locked"],
@@ -632,7 +672,7 @@ def prepare(root: Path, version: str) -> None:
                 write_atomic(path, payload)
         raise
     print(f"prepared all {len(packages)} workspace packages at {version}")
-    print("review and commit the manifest and Cargo.lock changes before verification")
+    print("review and commit the manifest and lockfile changes before verification")
 
 
 class ReleaseLog:

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -8,6 +8,7 @@ import importlib.util
 import io
 import json
 from pathlib import Path
+import subprocess
 import tempfile
 import tomllib
 import unittest
@@ -134,6 +135,72 @@ class ReleaseTests(unittest.TestCase):
         for value in ("0.3", "v0.3.0", "0.3.0-beta.1", "next"):
             with self.subTest(value=value), self.assertRaises(release.ReleaseError):
                 release.require_version(value)
+
+    def test_release_lockfiles_cover_root_and_standalone_examples(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "examples").mkdir()
+            (root / "Cargo.toml").write_text("[workspace]\n")
+            (root / "examples/Cargo.toml").write_text("[workspace]\n")
+            commands: list[list[str]] = []
+
+            def fake_run(
+                argv: list[str],
+                *,
+                cwd: Path,
+                **_: object,
+            ) -> subprocess.CompletedProcess[str]:
+                self.assertEqual(cwd, root)
+                commands.append(argv)
+                return subprocess.CompletedProcess(argv, 0, "{}", "")
+
+            with mock.patch.object(release, "run", side_effect=fake_run):
+                release.refresh_release_lockfiles(root)
+                release.validate_release_lockfiles(root)
+
+            self.assertEqual(
+                release.release_lock_paths(root),
+                (root / "Cargo.lock", root / "examples/Cargo.lock"),
+            )
+            self.assertEqual(
+                commands,
+                [
+                    [
+                        "cargo",
+                        "metadata",
+                        "--manifest-path",
+                        "Cargo.toml",
+                        "--format-version",
+                        "1",
+                    ],
+                    [
+                        "cargo",
+                        "metadata",
+                        "--manifest-path",
+                        "examples/Cargo.toml",
+                        "--format-version",
+                        "1",
+                    ],
+                    [
+                        "cargo",
+                        "metadata",
+                        "--manifest-path",
+                        "Cargo.toml",
+                        "--format-version",
+                        "1",
+                        "--locked",
+                    ],
+                    [
+                        "cargo",
+                        "metadata",
+                        "--manifest-path",
+                        "examples/Cargo.toml",
+                        "--format-version",
+                        "1",
+                        "--locked",
+                    ],
+                ],
+            )
 
     def test_topological_order_includes_0_3_and_ignores_dev_cycle(self) -> None:
         packages = {


### PR DESCRIPTION
Automated preparation of all 44 workspace crates for v0.3.6.

The required PR Gate remains authoritative. After merge, run the protected release qualification workflow for this exact commit; publication will reject any other commit or incomplete aggregate.

Preparation evidence: all 44 packages were updated and cargo check --workspace --all-targets --locked passed on GitHub in run 30745520682. The run concluded as failed only because the repository had not yet allowed Actions to create pull requests; that setting is now enabled for future releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Coordinated SemVer bump across 44 crates affects downstream version resolution on publish; changes are mechanical with no runtime logic edits beyond release automation.
> 
> **Overview**
> **Prepares a unified v0.3.6 release** for all 44 publishable workspace crates by bumping `[workspace.package]` and every internal `[workspace.dependencies]` entry from `0.3.5` to `0.3.6`, with matching updates in `Cargo.lock`, `examples/Cargo.lock`, and the pinned `rtc` version in `rvoip-webrtc-stack`.
> 
> **Release tooling** now treats both the root workspace and the standalone `examples` workspace as first-class lock targets: `prepare` refreshes and validates `Cargo.lock` and `examples/Cargo.lock` via per-manifest `cargo metadata` (including `--locked`), rolls back both on failure, and documents committing “manifest and lockfile” changes. A unit test asserts that refresh/validate invoke the expected command sequence for both manifests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d11f34d75fde8686bcefdc4e435ad311f973f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->