### PR TITLE
Speed up remote release verification

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -45,7 +45,7 @@ concurrency:
   cancel-in-progress: ${{ inputs.profile == 'remote-preflight' || inputs.profile == 'remote-diagnostic' }}
 
 env:
-  RELEASE_ENVIRONMENT_ID: rvoip-release-v1-rust-1.91-nextest-0.9.140
+  RELEASE_ENVIRONMENT_ID: rvoip-release-v2-rust-1.91-nextest-0.9.140-sccache-0.15.0
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
@@ -270,11 +270,13 @@ jobs:
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
       - name: Require all compute and disk quota before creating workers
         env:
+          CACHE_BUCKET: ${{ vars.RVOIP_GCP_CACHE_BUCKET }}
           PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
           REGION: ${{ vars.RVOIP_GCP_REGION }}
           GCP_MATRIX: ${{ needs.plan.outputs.gcp_matrix }}
         run: |
           set -euo pipefail
+          test -n "$CACHE_BUCKET"
           gcloud compute project-info describe --project "$PROJECT" --format=json > global-quotas.json
           gcloud compute regions describe "$REGION" --project "$PROJECT" --format=json > regional-quotas.json
           python3 - <<'PY'
@@ -370,6 +372,7 @@ jobs:
       - name: Create every ephemeral release worker concurrently
         env:
           CANDIDATE: ${{ needs.plan.outputs.candidate_sha }}
+          CACHE_BUCKET: ${{ vars.RVOIP_GCP_CACHE_BUCKET }}
           PROJECT: ${{ vars.RVOIP_GCP_PROJECT_ID }}
           ZONE: ${{ vars.RVOIP_GCP_ZONE }}
           NETWORK: ${{ vars.RVOIP_GCP_NETWORK }}
@@ -408,7 +411,7 @@ jobs:
                 --shielded-vtpm \
                 --shielded-integrity-monitoring \
                 --labels rvoip-role=release-gate,managed-by=github-actions \
-                --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${shard_id},rvoip-resource-class=${resource_class},rvoip-evidence-bucket=${BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
+                --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${shard_id},rvoip-resource-class=${resource_class},rvoip-evidence-bucket=${BUCKET},rvoip-cache-bucket=${CACHE_BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
                 --metadata-from-file startup-script=infra/release-runners/gcp-release-startup.sh
             ) > "target/gcp-controller/create-logs/${shard_id}.log" 2>&1 &
             pids+=("$!")

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -112,6 +112,16 @@ qualification, plus provisioning, build, evidence, and cleanup time. Gates
 whose exact source, dependency, definition, environment, and threshold digests
 remain unchanged may reuse successful prior evidence on a later candidate.
 
+All GCP workers use a verified, pinned `sccache` binary and a private,
+lifecycle-managed GCS compiler-cache bucket. The cache is content-addressed,
+contains no release credentials, and is shared only by trusted protected-main
+workers. Every worker records cache statistics in its evidence archive. A cache
+download or backend failure falls back to direct compilation without changing
+the command, workload, machine class, or acceptance threshold. Hosted release
+checks are balanced across twelve standard shards; together with five nightly
+shards, one evidence shard, and the one GCP controller, the workflow remains
+below the repository's twenty-job concurrency ceiling.
+
 This verification is the version/package delta boundary. It does not claim
 that a prior beta run exercised a later version-only commit.
 

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -15,6 +15,7 @@ RUN_ID="$(metadata rvoip-run-id)"
 SHARD_ID="$(metadata rvoip-shard-id)"
 RESOURCE_CLASS="$(metadata rvoip-resource-class)"
 BUCKET="$(metadata rvoip-evidence-bucket)"
+CACHE_BUCKET="$(metadata rvoip-cache-bucket)"
 PREFIX="$(metadata rvoip-prefix)"
 GATES="$(metadata rvoip-gates-b64 | base64 --decode)"
 ENVIRONMENT_ID="$(metadata rvoip-environment-b64 | base64 --decode)"
@@ -49,6 +50,13 @@ finish() {
   ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   duration="$(( $(date +%s) - START_SECONDS ))"
   archive_sha=""
+  if [[ "${RVOIP_SCCACHE_ACTIVE:-0}" == "1" ]]; then
+    mkdir -p "$EVIDENCE"
+    {
+      sccache --show-stats
+      sccache --stop-server
+    } > "$EVIDENCE/_sccache-stats.txt" 2>&1 || true
+  fi
   if [[ -d "$EVIDENCE" ]]; then
     if [[ -d "$WORKSPACE/target/perf-results" ]]; then
       mkdir -p "$EVIDENCE/_perf-results/$SHARD_ID"
@@ -130,6 +138,57 @@ cd "$WORKSPACE"
 git fetch --depth=1 origin "$CANDIDATE"
 git checkout --detach "$CANDIDATE"
 test "$(git rev-parse HEAD)" = "$CANDIDATE"
+
+# Every ephemeral worker previously spent roughly twenty-one minutes compiling
+# the same release graph. Use a dedicated, lifecycle-managed GCS bucket as a
+# content-addressed compiler cache. Cache availability is an optimization only:
+# a download, authentication, or backend failure falls back to direct rustc so
+# release correctness never depends on cached state.
+SCCACHE_VERSION=0.15.0
+SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+SCCACHE_SHA256=782d2b5dd7ae0a55ebe368ab258114d0928d019ac2d949ab85d5d02f3926709e
+SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+install_sccache() {
+  curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+    "$SCCACHE_URL" -o "/tmp/$SCCACHE_ARCHIVE" || return 1
+  echo "$SCCACHE_SHA256  /tmp/$SCCACHE_ARCHIVE" | sha256sum --check --status \
+    || return 1
+  tar -C /tmp -xzf "/tmp/$SCCACHE_ARCHIVE" || return 1
+  install -m 0755 \
+    "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" \
+    /usr/local/bin/sccache || return 1
+}
+
+mkdir -p "$EVIDENCE" /var/cache/rvoip-sccache
+if install_sccache; then
+  export CARGO_INCREMENTAL=0
+  export RUSTC_WRAPPER=sccache
+  export SCCACHE_BASEDIRS="$WORKSPACE"
+  export SCCACHE_CACHE_SIZE=20G
+  export SCCACHE_DIR=/var/cache/rvoip-sccache
+  export SCCACHE_GCS_BUCKET="$CACHE_BUCKET"
+  export SCCACHE_GCS_KEY_PREFIX=rvoip-release-v1/rust-1.91.0/x86_64-unknown-linux-gnu
+  export SCCACHE_GCS_RW_MODE=READ_WRITE
+  cache_service_account="$(curl --fail --silent --show-error \
+    -H 'Metadata-Flavor: Google' \
+    http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email)" \
+    || cache_service_account=""
+  export SCCACHE_IDLE_TIMEOUT=0
+  export SCCACHE_MULTILEVEL_CHAIN=disk,gcs
+  export SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY=ignore
+  if [[ -n "$cache_service_account" ]]; then
+    export SCCACHE_GCS_SERVICE_ACCOUNT="$cache_service_account"
+  fi
+  if [[ -n "$cache_service_account" ]] && sccache --start-server; then
+    export RVOIP_SCCACHE_ACTIVE=1
+    echo "shared GCS compiler cache enabled"
+  else
+    unset RUSTC_WRAPPER
+    echo "shared compiler cache unavailable; continuing with direct rustc" >&2
+  fi
+else
+  echo "verified sccache install unavailable; continuing with direct rustc" >&2
+fi
 
 # The stock Ubuntu startup service inherits a soft nofile limit of 1024.
 # SIPp and high-density media qualification legitimately require thousands of

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -199,6 +199,27 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("-name '*.jsonl'", startup)
         self.assertNotRegex(startup, r"apt-get install[^\n]*\bsipp\b")
 
+    def test_release_workers_use_a_verified_fail_open_gcs_compiler_cache(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        startup = (ROOT / "infra/release-runners/gcp-release-startup.sh").read_text()
+
+        self.assertIn("RVOIP_GCP_CACHE_BUCKET", workflow)
+        self.assertIn("rvoip-cache-bucket=${CACHE_BUCKET}", workflow)
+        self.assertIn('CACHE_BUCKET="$(metadata rvoip-cache-bucket)"', startup)
+        self.assertIn("SCCACHE_VERSION=0.15.0", startup)
+        self.assertIn(
+            "SCCACHE_SHA256=782d2b5dd7ae0a55ebe368ab258114d0928d019ac2d949ab85d5d02f3926709e",
+            startup,
+        )
+        self.assertIn("--show-error --location", startup)
+        self.assertIn("sha256sum --check --status", startup)
+        self.assertIn("SCCACHE_MULTILEVEL_CHAIN=disk,gcs", startup)
+        self.assertIn("SCCACHE_GCS_RW_MODE=READ_WRITE", startup)
+        self.assertIn("RUSTC_WRAPPER=sccache", startup)
+        self.assertIn("unset RUSTC_WRAPPER", startup)
+        self.assertIn("continuing with direct rustc", startup)
+        self.assertIn("_sccache-stats.txt", startup)
+
     def test_release_infrastructure_preflight_is_full_shape_and_non_publishing(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
         startup = (ROOT / "infra/release-runners/gcp-release-startup.sh").read_text()

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -423,7 +423,12 @@ def matrix_for(plan_gates: list[dict[str, Any]], by_id: dict[str, dict[str, Any]
         groups[gate["resource_class"]].append(gate)
     matrix = []
     limits = {
-        "github-standard": 6,
+        # Keep the complete hosted release fanout below GitHub's 20-job
+        # repository limit while avoiding the two 50+ minute serial shards
+        # observed during the v0.3.6 qualification. Twelve standard shards,
+        # five nightly shards, one evidence shard, and the single GCP
+        # controller peak at nineteen concurrent jobs.
+        "github-standard": 12,
         "github-nightly": 5,
         "github-evidence": 1,
         "gcp-performance": 6,

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -239,6 +239,15 @@ class GateFrameworkTests(unittest.TestCase):
             sum(int(shard["machine_type"].rsplit("-", 1)[1]) for shard in gcp),
             96,
         )
+        hosted = [shard for shard in matrix if shard["hosted"]]
+        standard = [
+            shard for shard in hosted if shard["resource_class"] == "github-standard"
+        ]
+        self.assertEqual(len(standard), 12)
+        # Twelve standard, five nightly, one evidence, and one GCP controller
+        # stay below the twenty-job repository concurrency ceiling.
+        self.assertLessEqual(len(hosted) + 1, 19)
+        self.assertLessEqual(max(shard["estimated_seconds"] for shard in standard), 1260)
 
     def test_remote_diagnostic_runs_only_exact_gcp_gates_and_dependencies(self) -> None:
         requested = ["interop.remote-proxies", "perf.monolithic-soak"]


### PR DESCRIPTION
## What changed

- split hosted release checks across 12 duration-balanced standard shards
- add a private, lifecycle-managed GCS compiler cache to ephemeral GCP release workers
- pin and checksum sccache 0.15.0, record cache statistics in gate evidence, and fall back to direct compilation if caching is unavailable
- require the configured cache bucket during release infrastructure preflight
- document the concurrency and cache behavior

## Why

The v0.3.6 qualification showed two hosted shards taking more than 50 minutes and repeated roughly 21 minutes of identical Rust compilation on GCP workers. This keeps the real machine classes, workloads, soak durations, and acceptance thresholds unchanged while eliminating avoidable serialization and rebuilds.

## Validation

- 56 release planner, workflow policy, and GCP fanout tests pass
- GCP two-pass smoke test proved a cold write followed by a 100% GCS cache hit with zero cache errors
- pinned archive SHA-256 verified
- startup script syntax and diff hygiene pass

## Rollout note

Keep this PR in draft until v0.3.6 qualification/publishing completes. Merging it changes the release environment digest and intentionally invalidates older qualification evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release qualification infrastructure (environment digest, GCP startup, shard fanout) where mistakes could force full re-qualification or slow/fail builds, but workloads and thresholds are unchanged and sccache is explicitly fail-open.
> 
> **Overview**
> Speeds up **remote release qualification** without changing gate commands, machine classes, soak durations, or pass thresholds.
> 
> **Hosted GitHub runners:** `github-standard` shard count rises from **6 to 12** so work is spread more evenly (addressing ~50+ minute serial shards from v0.3.6). Peak concurrency stays under the repo’s **20-job** cap (12 standard + 5 nightly + 1 evidence + 1 GCP controller ≈ 19).
> 
> **GCP ephemeral workers:** The qualify workflow passes **`RVOIP_GCP_CACHE_BUCKET`** through VM metadata, requires the bucket in **preflight**, and bumps **`RELEASE_ENVIRONMENT_ID`** to `rvoip-release-v2-...-sccache-0.15.0` so prior qualification evidence is intentionally invalidated. Startup installs **checksum-pinned sccache 0.15.0**, uses a **disk+GCS** multilevel cache with **fail-open** fallback to direct `rustc`, and archives **`_sccache-stats.txt`** in shard evidence.
> 
> **Docs and tests** describe the cache/concurrency model and lock in the wiring via workflow policy and gate matrix assertions (12 standard shards, max ~21m per standard shard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db1a1b76e9524dd3438bdb8657fc0f17bf6804f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->