### PR TITLE
Automate active release metadata updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ---
 
 > [!IMPORTANT]
-> **Unified `0.3.5` release train.** All 44 publishable workspace crates ship on
+> **Unified `0.3.6` release train.** All 44 publishable workspace crates ship on
 > the same version. Publication requires a fresh, strict full-beta run bound to
 > the exact release source: no skipped gates, no carry-forward qualification,
 > and passing workspace, security, four-peer interoperability, performance,
@@ -116,7 +116,7 @@ Add the SIP product:
 
 ```toml
 [dependencies]
-rvoip-sip = "0.3.5"
+rvoip-sip = "0.3.6"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -221,7 +221,7 @@ RTP-over-QUIC has shipped.
 
 ## Extensions
 
-All 14 extension crates ship at `0.3.5`. They are first-class workspace
+All 14 extension crates ship at `0.3.6`. They are first-class workspace
 capabilities, but remain optional so protocol crates depend on provider
 contracts rather than deployment-specific services.
 
@@ -243,22 +243,22 @@ The supporting contracts live in
 The facade exposes the conversation-model extensions together:
 
 ```toml
-rvoip = { version = "0.3.5", features = ["voip-3"] }
+rvoip = { version = "0.3.6", features = ["voip-3"] }
 ```
 
 `voip-3` enables SIP, WebRTC, UCTP, vCon, the identity provider surface, and
 the AI harness. Vapi and STIR/SHAKEN have separate facade features:
 
 ```toml
-rvoip = { version = "0.3.5", features = ["sip", "vapi", "sip-stir-shaken"] }
+rvoip = { version = "0.3.6", features = ["sip", "vapi", "sip-stir-shaken"] }
 ```
 
 Deployment-specific extensions are direct dependencies:
 
 ```toml
-rvoip-keycloak = "0.3.5"
-rvoip-redis = "0.3.5"
-rvoip-audit = "0.3.5"
+rvoip-keycloak = "0.3.6"
+rvoip-redis = "0.3.6"
+rvoip-audit = "0.3.6"
 ```
 
 The facade's `full` feature does **not** enable every workspace extension,
@@ -335,12 +335,12 @@ product's implementation:
   unified release identity, source compatibility notes, and attestation
   provenance.
 
-The `0.3.5` release requires a fresh strict full-beta report bound to one clean,
+The `0.3.6` release requires a fresh strict full-beta report bound to one clean,
 unchanged release source fingerprint. The gate admits no skipped checks and
 includes the workspace, SIP/media, public API, security, PBX, SIPp, strict-UA,
 proxy interoperability, performance, resiliency, and long-soak scopes. The
 historical `0.3.4` carry-forward receipt remains immutable release history; it
-does not qualify `0.3.5`.
+does not qualify `0.3.6`.
 
 ### SIP interoperability attestation
 
@@ -349,7 +349,7 @@ independently managed peers below. The report generator binds every row to the
 tested source tree, exact peer identity and configuration, selected matrix,
 and hashed evidence; it refuses to produce a strict release-candidate report
 if a required peer is missing, skipped, ambiguous, unpinned, or failing. This
-four-peer matrix is mandatory for the `0.3.5` strict release gate.
+four-peer matrix is mandatory for the `0.3.6` strict release gate.
 
 | Peer | Attested boundary | Required release evidence |
 | --- | --- | --- |

--- a/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
+++ b/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
@@ -4,8 +4,8 @@ This document defines the promotion procedure. It does not duplicate a
 candidate's results. The versioned reporting and selection authority is
 `config/beta-release-policy.yaml`; current outcomes are generated from evidence:
 
-Current candidate and runtime crate version: `0.3.5`.
-The `0.3.5` candidate requires the strict full gate; the historical `0.3.2`
+Current candidate and runtime crate version: `0.3.6`.
+The current candidate requires the strict full gate; the historical `0.3.2`
 exception path cannot qualify it.
 
 - [Beta Release Candidate Report](BETA_RELEASE_REPORT.md)

--- a/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
+++ b/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
@@ -1,14 +1,14 @@
-# rvoip 0.3.5 Release Candidate Notes
+# rvoip 0.3.6 Release Candidate Notes
 
 Date: 2026-07-30
 
-These notes describe the coordinated 44-crate `0.3.5` release candidate.
+These notes describe the coordinated 44-crate `0.3.6` release candidate.
 Publication requires a fresh strict full-beta qualification bound to the exact
 clean release source. No `0.3.4` carry-forward evidence qualifies this release.
 
 ## Headline
 
-`0.3.5` is a security, media-correctness, and SIP-lifecycle release. It makes
+`0.3.6` is a security, media-correctness, and SIP-lifecycle release. It makes
 incomplete security features fail closed, repairs RTP/RTCP and SRTP/SRTCP
 state, replaces simulated codec behavior, completes transactional SIP
 renegotiation, closes issues #46 and #50, and makes Tokio the sole WebRTC
@@ -92,11 +92,11 @@ runtime.
 ## Qualification
 
 The release candidate must pass the one-command full beta gate from a clean,
-committed `0.3.5` source tree. Required evidence includes three fresh canonical
+committed `0.3.6` source tree. Required evidence includes three fresh canonical
 2,000-CPS runs; workspace, public-API, security, parser, PBX, SIPp, strict-UA,
 Kamailio, and OpenSIPS gates; full-media performance and resiliency matrices;
 and both one-hour monolithic and split soaks. The generated report package and
 its source fingerprint are verified before crates.io publication.
 
 Historical `0.3.2` exception and `0.3.4` carry-forward attestations remain
-unchanged release history. They are not presented as current `0.3.5` evidence.
+unchanged release history. They are not presented as current `0.3.6` evidence.

--- a/crates/sip/rvoip-sip/scripts/test_beta_attestation.py
+++ b/crates/sip/rvoip-sip/scripts/test_beta_attestation.py
@@ -1395,16 +1395,17 @@ class BetaAttestationTests(unittest.TestCase):
         release_notes = (
             WORKSPACE_ROOT / "crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md"
         ).read_text(encoding="utf-8")
-        self.assertEqual(self.workspace_version, "0.3.5")
         self.assertRegex(
             crate_manifest,
             r"(?m)^version\.workspace\s*=\s*true(?:\s*(?:#.*)?)?$",
         )
         marker = f"Current candidate and runtime crate version: `{self.workspace_version}`"
         self.assertIn(marker, checklist)
-        self.assertIn("0.3.5 Release Candidate Notes", release_notes)
         self.assertIn(
-            "**Unified `0.3.5` release train.**",
+            f"{self.workspace_version} Release Candidate Notes", release_notes
+        )
+        self.assertIn(
+            f"**Unified `{self.workspace_version}` release train.**",
             (WORKSPACE_ROOT / "README.md").read_text(encoding="utf-8"),
         )
 

--- a/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
+++ b/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
@@ -417,7 +417,6 @@ class BetaGateCompatibilitySourceTests(unittest.TestCase):
             (WORKSPACE_ROOT / "Cargo.toml").read_text(encoding="utf-8")
         )
         version = root_manifest["workspace"]["package"]["version"]
-        self.assertEqual(version, "0.3.5")
 
         active_files = [
             WORKSPACE_ROOT / "README.md",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import tomllib
 from typing import Any
 import urllib.error
 import urllib.request
@@ -28,6 +29,11 @@ COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 USER_AGENT = "rvoip-unified-release/1.0"
 DEFAULT_POLL_SECONDS = 15
 DEFAULT_TIMEOUT_SECONDS = 900
+ACTIVE_RELEASE_METADATA_FILES = (
+    Path("README.md"),
+    Path("crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md"),
+    Path("crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md"),
+)
 VERIFICATION_RECEIPT_SCHEMA = "rvoip-unified-release-verification-v4"
 REMOTE_QUALIFICATION_SCHEMA = "rvoip-release-qualification-v1"
 REMOTE_GATE_CATALOG_SCHEMA = "rvoip-release-gate-catalog-v1"
@@ -504,6 +510,25 @@ def planned_version_edits(
     return changes
 
 
+def planned_release_metadata_edits(
+    root: Path, current_version: str, version: str
+) -> dict[Path, bytes]:
+    """Update current-version references in the active release documents."""
+    changes: dict[Path, bytes] = {}
+    for relative_path in ACTIVE_RELEASE_METADATA_FILES:
+        path = root / relative_path
+        text = path.read_text(encoding="utf-8")
+        count = text.count(current_version)
+        if count == 0:
+            raise ReleaseError(
+                f"active release metadata in {relative_path} does not reference "
+                f"workspace version {current_version}"
+            )
+        updated = text.replace(current_version, version)
+        changes[path] = updated.encode()
+    return changes
+
+
 def write_atomic(path: Path, payload: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as temporary:
@@ -647,7 +672,12 @@ def prepare(root: Path, version: str) -> None:
         raise ReleaseError(
             f"cannot prepare an already-published version for: {existing}"
         )
+    root_manifest = root / "Cargo.toml"
+    current_version = tomllib.loads(root_manifest.read_text(encoding="utf-8"))[
+        "workspace"
+    ]["package"]["version"]
     edits = planned_version_edits(root, packages, version)
+    edits.update(planned_release_metadata_edits(root, current_version, version))
     lock_paths = release_lock_paths(root)
     originals = {
         path: path.read_bytes() if path.exists() else None

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -373,6 +373,48 @@ rvoip-rtc = { path = "../rvoip-rtc" }
                 edits[stack_manifest].decode(),
             )
 
+    def test_planned_release_metadata_edits_update_all_active_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            active_files = {
+                Path("README.md"): (
+                    "> **Unified `0.3.5` release train.**\n"
+                    'rvoip-sip = "0.3.5"\n'
+                ),
+                Path("crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md"): (
+                    "Current candidate and runtime crate version: `0.3.5`.\n"
+                ),
+                Path("crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md"): (
+                    "# rvoip 0.3.5 Release Candidate Notes\n"
+                ),
+            }
+            for relative_path, body in active_files.items():
+                path = root / relative_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(body, encoding="utf-8")
+
+            edits = release.planned_release_metadata_edits(
+                root, "0.3.5", "0.3.6"
+            )
+
+            self.assertEqual(set(edits), {root / path for path in active_files})
+            for payload in edits.values():
+                self.assertIn("0.3.6", payload.decode())
+                self.assertNotIn("0.3.5", payload.decode())
+
+    def test_planned_release_metadata_edits_fail_closed_on_missing_marker(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text("no active marker\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                release.ReleaseError, "does not reference workspace version"
+            ):
+                release.planned_release_metadata_edits(
+                    root, "0.3.5", "0.3.6"
+                )
+
     def test_member_dependency_versions_reject_stale_renamed_requirement(
         self,
     ) -> None:


### PR DESCRIPTION
## What changed

- update the active README, SIP beta checklist, and next-release notes to v0.3.6
- make the beta metadata guards derive their expected version from the workspace
- teach release preparation to update all current-version references in the active release documents
- fail release preparation if an expected active document no longer references the current workspace version

## Why

The exact v0.3.6 remote qualification found that two evidence-helper tests were still pinned to v0.3.5. The release preparation workflow updated manifests and lockfiles but left user-facing release metadata and version-bound test assertions behind.

## Impact

This fixes the failing v0.3.6 release gate and prevents the same manual version-sync failure in later releases. It does not change any Rust public API or relax any release requirement.

## Validation

- all 129 evidence-helper tests pass
- all 36 unified release-script tests pass
- diff hygiene passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release scripts, documentation version strings, and test assertions; no Rust runtime or public API behavior is modified.
> 
> **Overview**
> Fixes the **0.3.6** release gate failure where beta evidence tests still expected **0.3.5**, and stops `release prepare` from bumping manifests/lockfiles while leaving user-facing release docs behind.
> 
> **Release preparation** now rewrites every `current_version` occurrence in `README.md`, `BETA_RELEASE_CHECKLIST.md`, and `RELEASE_NOTES_NEXT.md` via `planned_release_metadata_edits`, wired into `prepare()` after reading the workspace version from root `Cargo.toml`. Preparation **fails closed** if any of those files no longer mention the current workspace version.
> 
> **Beta gate tests** derive expected version strings from the workspace instead of pinning `0.3.5` in `test_beta_attestation.py` and `test_beta_gate_source.py`.
> 
> This PR also carries the **0.3.5 → 0.3.6** doc updates and unit tests for successful metadata replacement and the missing-marker error path in `scripts/test_release.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822ad16525e8cbe67cf90b8f0d57aafba72d7c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->