### PR TITLE
ci: keep release and main verification from blocking PR feedback

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -113,6 +113,8 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      # Keep hosted capacity available for PR feedback and release controllers.
+      max-parallel: 3
       matrix: ${{ fromJSON(needs.plan.outputs.shards) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -181,6 +183,8 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      # Full-main coverage is background work; do not starve pull requests.
+      max-parallel: 4
       matrix: ${{ fromJSON(needs.plan.outputs.sip_jobs) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -248,7 +252,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix: ${{ fromJSON(needs.plan.outputs.specialty) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -43,7 +43,7 @@ permissions:
 concurrency:
   # Supersede the same qualification request, but allow disjoint diagnostic
   # gate sets for one candidate to use independent GCP workers concurrently.
-  group: release-qualification-${{ inputs.profile }}-${{ inputs.candidate }}-${{ inputs.gates || 'all' }}
+  group: release-qualification-${{ inputs.profile }}-${{ inputs.candidate }}-${{ inputs.diagnostic_gates || 'all' }}
   cancel-in-progress: ${{ inputs.profile == 'remote-preflight' || inputs.profile == 'remote-diagnostic' }}
 
 env:

--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -41,7 +41,9 @@ permissions:
   actions: read
 
 concurrency:
-  group: release-qualification-${{ inputs.profile }}-${{ inputs.candidate }}
+  # Supersede the same qualification request, but allow disjoint diagnostic
+  # gate sets for one candidate to use independent GCP workers concurrently.
+  group: release-qualification-${{ inputs.profile }}-${{ inputs.candidate }}-${{ inputs.gates || 'all' }}
   cancel-in-progress: ${{ inputs.profile == 'remote-preflight' || inputs.profile == 'remote-diagnostic' }}
 
 env:

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -231,6 +231,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('args+=(--only-gates "$DIAGNOSTIC_GATES")', workflow)
         self.assertIn('test "$PROFILE" = remote-diagnostic', workflow)
         self.assertIn("inputs.profile != 'remote-diagnostic'", workflow)
+        self.assertIn("inputs.gates || 'all'", workflow)
         self.assertIn("at most five prior evidence runs may be combined", workflow)
         self.assertIn('--dir "target/prior-evidence/$run_id"', workflow)
         self.assertIn(

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -117,7 +117,23 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("Install nightly for release fuzz validation", specialty)
         self.assertIn("cargo-fuzz@0.13.2", specialty)
         self.assertGreaterEqual(specialty.count("matrix.gate == 'release-tooling'"), 2)
-        self.assertIn("max-parallel: 6", specialty)
+        self.assertIn("max-parallel: 3", specialty)
+
+    def test_main_preserves_capacity_for_pr_and_release_feedback(self) -> None:
+        text = (ROOT / ".github/workflows/main-ci.yml").read_text()
+        crate_tests = text.split("\n  crate-tests:\n", maxsplit=1)[1].split(
+            "\n  doctests:\n", maxsplit=1
+        )[0]
+        sip_tests = text.split("\n  sip-tests:\n", maxsplit=1)[1].split(
+            "\n  specialty:\n", maxsplit=1
+        )[0]
+        specialty = text.split("\n  specialty:\n", maxsplit=1)[1].split(
+            "\n  main-gate:\n", maxsplit=1
+        )[0]
+
+        self.assertIn("max-parallel: 3", crate_tests)
+        self.assertIn("max-parallel: 4", sip_tests)
+        self.assertIn("max-parallel: 3", specialty)
 
     def test_release_prepare_installs_native_validation_dependencies(self) -> None:
         text = (ROOT / ".github/workflows/release-prepare.yml").read_text()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -231,7 +231,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('args+=(--only-gates "$DIAGNOSTIC_GATES")', workflow)
         self.assertIn('test "$PROFILE" = remote-diagnostic', workflow)
         self.assertIn("inputs.profile != 'remote-diagnostic'", workflow)
-        self.assertIn("inputs.gates || 'all'", workflow)
+        self.assertIn("inputs.diagnostic_gates || 'all'", workflow)
         self.assertIn("at most five prior evidence runs may be combined", workflow)
         self.assertIn('--dir "target/prior-evidence/$run_id"', workflow)
         self.assertIn(


### PR DESCRIPTION
## Problem

Two scheduling failures made verification slower than the tests themselves:

1. Targeted release diagnostics for the same candidate canceled one another even when they selected disjoint gates. A 35-minute GCP performance run was discarded when an independent interop/soak run started.
2. A full-main run could occupy essentially all 20 hosted-runner slots, leaving new PR gates and release controllers queued behind background coverage.

## Fix

- Include the exact diagnostic gate selection in the release-qualification concurrency key. A retry of the same gate set still supersedes its predecessor; disjoint gate sets run concurrently.
- Cap background full-main work at 3 crate shards, 4 SIP shards, and 3 specialty jobs at once. All checks still run; up to eight hosted slots remain available for PR and release feedback.

## Verification

- All 20 workflow-policy tests pass.
- Diff hygiene passes.
- No test command, threshold, GCP machine class, or evidence digest changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only GitHub Actions scheduling and policy tests; no application code, gates, or evidence semantics.
> 
> **Overview**
> **Limits how many full-main jobs run at once** so PR gates and release controllers are less likely to sit behind background verification. `crate-tests` and `specialty` now use `max-parallel: 3`; `sip-tests` uses `max-parallel: 4` (specialty was reduced from 6). Coverage is unchanged—jobs still run, just with a lower concurrent ceiling on hosted runners.
> 
> **Release qualification concurrency** now keys on `diagnostic_gates` (default `all`) in addition to profile and candidate. Retries with the same gate selection still supersede each other; different diagnostic gate sets for one candidate can run in parallel instead of canceling unrelated long GCP runs.
> 
> Workflow policy tests were updated to lock in the new `max-parallel` values and the concurrency group shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c17c82ecaff475feb4c5b19d46c20f0eb7657157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->