### PR TITLE
Fix release memory gate measurement isolation

### DIFF
--- a/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh
+++ b/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh
@@ -17,10 +17,10 @@ export CARGO_MANIFEST_DIR="${CRATE_DIR}"
 # horizon beyond that protocol deadline so it never manufactures a timeout
 # while the transaction layer is still behaving correctly.
 : "${RVOIP_PERF_CALL_TIMEOUT_SECS:=40}"
-# Burst acceptance first waits through the 90-second SIP-retention horizon,
-# captures exact structural diagnostics, then leaves a 5-second settle and a
-# quiet 60-second RSS tail. The Rust harness clamps shorter overrides to this
-# same 160-second minimum.
+# Burst acceptance first waits through the 90-second SIP-retention horizon and
+# an allocator-settle margin. It then measures a separate quiet RSS window and
+# captures exact structural diagnostics only after that measurement. The Rust
+# harness clamps shorter drain overrides to this same 160-second minimum.
 : "${RVOIP_PERF_RETENTION_DRAIN_WAIT_SECS:=160}"
 : "${RVOIP_PERF_MEMORY_DIAGNOSTICS:=0}"
 : "${RVOIP_PERF_ALLOCATOR_DIAGNOSTICS:=0}"

--- a/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
@@ -399,12 +399,10 @@ async fn perf_burst_caller() {
 
     let mut retention_series = retention_sampler.stop_periodic().await;
     // Structural snapshots walk every owned runtime index and perturb the
-    // allocator. Keep the complete drain/RSS window quiet, then capture the
-    // exact final retention evidence after process sampling has stopped.
+    // allocator. Keep the complete drain/RSS window quiet.
     tokio::time::sleep(retention_drain_wait).await;
-    // End process sampling at the declared drain boundary. Retention capture
-    // and report construction allocate diagnostic data and are not part of
-    // the runtime-under-test RSS window.
+    // End active-process sampling at the declared drain boundary. The separate
+    // settled sampler below is the authoritative memory-growth window.
     let mut resources = match sampler {
         Some(sampler) => sampler.stop().await,
         None => ResourceSummary::empty(),
@@ -414,12 +412,6 @@ async fn perf_burst_caller() {
         Some(sampler) => Some(sampler.stop().await),
         None => None,
     };
-    let final_sample =
-        capture_endpoint_retention_sample("burst_caller", "after_drain", started, &clients[0].peer)
-            .await;
-    retention_series.record_sample("burst_caller", final_sample);
-    let final_retention_all = capture_all_caller_retention(clients.as_slice()).await;
-    let retained_after_drain = final_retention_all.retained_total;
     let (mut settled_resources, settled_observation) = if in_process_resource_sampling {
         sample_settled_rss_window("burst_caller", scenario.acceptance.min_rss_gate_window_secs)
             .await
@@ -440,6 +432,14 @@ async fn perf_burst_caller() {
     } else {
         "reported_only_short_settled_window"
     };
+    // Capture exact structural proof only after authoritative RSS sampling has
+    // stopped so the proof cannot manufacture the growth it is meant to find.
+    let final_sample =
+        capture_endpoint_retention_sample("burst_caller", "after_drain", started, &clients[0].peer)
+            .await;
+    retention_series.record_sample("burst_caller", final_sample);
+    let final_retention_all = capture_all_caller_retention(clients.as_slice()).await;
+    let retained_after_drain = final_retention_all.retained_total;
     resources.samples.clear();
     settled_resources.samples.clear();
     let dhat_diagnostics = dhat_profile.finish();

--- a/crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs
@@ -26,13 +26,14 @@ use support::burst::{
     BURST_ALICE_MEDIA_START, BURST_BOB_MEDIA_END, BURST_BOB_MEDIA_START,
 };
 use support::soak::{
-    admission_diagnostics, burst_retention_drain_wait, capture_endpoint_retention_sample,
-    diagnostic_artifact_path, diagnostic_sample_path, endpoint_metric, endpoint_retention_summary,
-    in_process_resource_sampler_enabled, media_receive_diagnostics, media_setup_raw_diagnostics,
-    media_setup_timing_diagnostics, memory_diagnostic_interval, memory_diagnostic_summary,
-    read_required_u16_env, resource_sampling_diagnostics, round2, sample_settled_rss_window,
-    sip_dialog_raw_diagnostics, sip_dialog_timing_diagnostics, sip_udp_diagnostics, DhatProfile,
-    EndpointRetentionSampler, MemoryDiagnosticSampler, RssGrowthGate,
+    admission_diagnostics, burst_retention_drain_wait, burst_retention_periodic_limit,
+    capture_endpoint_retention_sample, diagnostic_artifact_path, diagnostic_sample_path,
+    endpoint_metric, endpoint_retention_summary, in_process_resource_sampler_enabled,
+    media_receive_diagnostics, media_setup_raw_diagnostics, media_setup_timing_diagnostics,
+    memory_diagnostic_interval, memory_diagnostic_summary, read_required_u16_env,
+    resource_sampling_diagnostics, round2, sample_settled_rss_window, sip_dialog_raw_diagnostics,
+    sip_dialog_timing_diagnostics, sip_udp_diagnostics, DhatProfile, EndpointRetentionSampler,
+    MemoryDiagnosticSampler, RssGrowthGate,
 };
 use support::{
     CallSetupDiagnostics, LoadProfile, ResourceSampler, ResourceSummary, ScenarioReport,
@@ -159,10 +160,15 @@ async fn perf_burst_receiver() {
     } else {
         None
     };
-    let retention_sampler = EndpointRetentionSampler::start(
+    let maximum_hold = max_hold(&scenario);
+    let retention_sampler = EndpointRetentionSampler::start_with_periodic_limit(
         "burst_receiver",
         receiver.coordinator.clone(),
         support::soak::RETENTION_DIAGNOSTIC_SAMPLE_INTERVAL,
+        Some(burst_retention_periodic_limit(
+            scenario.duration_secs(),
+            maximum_hold,
+        )),
     );
     let memory_sampler = MemoryDiagnosticSampler::start(
         "burst_receiver",
@@ -173,7 +179,7 @@ async fn perf_burst_receiver() {
 
     let started = std::time::Instant::now();
     let max_wait = Duration::from_secs(scenario.duration_secs())
-        + max_hold(&scenario)
+        + maximum_hold
         + retention_drain_wait
         + Duration::from_secs(300);
     let mut stop_seen = false;
@@ -191,12 +197,10 @@ async fn perf_burst_receiver() {
 
     let mut retention_series = retention_sampler.stop_periodic().await;
     // Structural snapshots walk every owned runtime index and perturb the
-    // allocator. Keep the complete drain/RSS window quiet, then capture the
-    // exact final retention evidence after process sampling has stopped.
+    // allocator. Keep the complete drain/RSS window quiet.
     tokio::time::sleep(retention_drain_wait).await;
-    // End process sampling at the declared drain boundary. Retention capture
-    // and report construction allocate diagnostic data and are not part of
-    // the runtime-under-test RSS window.
+    // End active-process sampling at the declared drain boundary. The separate
+    // settled sampler below is the authoritative memory-growth window.
     let mut resources = match sampler {
         Some(sampler) => sampler.stop().await,
         None => ResourceSummary::empty(),
@@ -205,23 +209,6 @@ async fn perf_burst_receiver() {
         Some(sampler) => Some(sampler.stop().await),
         None => None,
     };
-    let final_sample = capture_endpoint_retention_sample(
-        "burst_receiver",
-        "after_drain",
-        started,
-        &receiver.coordinator,
-    )
-    .await;
-    retention_series.record_sample("burst_receiver", final_sample);
-    let final_retention = retention_series
-        .final_sample
-        .clone()
-        .unwrap_or_else(|| json!({}));
-    let retained_after_drain = retention_series.final_retained_objects;
-    let active_audio_receivers_after_drain = active_audio_receivers.load(Ordering::Relaxed);
-    let completed_audio_receivers = completed_audio_receivers.load(Ordering::Relaxed);
-    let received_frames = received_frames.load(Ordering::Relaxed);
-    let incoming_calls = incoming_calls.load(Ordering::Relaxed);
     let (mut settled_resources, settled_observation) = if in_process_resource_sampling {
         sample_settled_rss_window(
             "burst_receiver",
@@ -245,6 +232,25 @@ async fn perf_burst_receiver() {
     } else {
         "reported_only_short_settled_window"
     };
+    // Capture exact structural proof only after authoritative RSS sampling has
+    // stopped so the proof cannot manufacture the growth it is meant to find.
+    let final_sample = capture_endpoint_retention_sample(
+        "burst_receiver",
+        "after_drain",
+        started,
+        &receiver.coordinator,
+    )
+    .await;
+    retention_series.record_sample("burst_receiver", final_sample);
+    let final_retention = retention_series
+        .final_sample
+        .clone()
+        .unwrap_or_else(|| json!({}));
+    let retained_after_drain = retention_series.final_retained_objects;
+    let active_audio_receivers_after_drain = active_audio_receivers.load(Ordering::Relaxed);
+    let completed_audio_receivers = completed_audio_receivers.load(Ordering::Relaxed);
+    let received_frames = received_frames.load(Ordering::Relaxed);
+    let incoming_calls = incoming_calls.load(Ordering::Relaxed);
     resources.samples.clear();
     settled_resources.samples.clear();
     let dhat_diagnostics = dhat_profile.finish();

--- a/crates/sip/rvoip-sip/tests/perf/perf_soak_30min.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_soak_30min.rs
@@ -9,7 +9,7 @@
 //!
 //! - `latency_drift_pct` — `(setup p99 in last minute) / (setup p99 in
 //!   first minute) - 1`. Should stay well under 50 % on a healthy run.
-//! - `rss_gate_growth_mb_per_hr` — projection of the final 600 seconds under
+//! - `rss_gate_growth_mb_per_hr` — projection of the final 1,200 seconds under
 //!   active load for a long soak. Short diagnostic runs fall back to the
 //!   post-drain or final tail slope. Qualifying the active window prevents a
 //!   per-call leak from being hidden by the plateau after load stops.
@@ -393,7 +393,7 @@ async fn perf_soak_30min() {
         Arc::clone(&alice),
         Arc::clone(&bob.coordinator),
         support::soak::RETENTION_DIAGNOSTIC_SAMPLE_INTERVAL,
-        (duration_secs >= 600).then(|| Duration::from_secs(duration_secs - 600)),
+        support::soak::long_soak_retention_periodic_limit(duration_secs),
     );
 
     // Cycling active media pool. Replenishment stops early enough to avoid
@@ -2326,6 +2326,24 @@ mod tests {
         let diagnostic = series.diagnostic_summary(0);
         assert_eq!(diagnostic["storage"], "streamed_lossless");
         assert!(diagnostic.get("samples").is_none());
+    }
+
+    #[test]
+    fn structural_diagnostic_limits_leave_authoritative_rss_windows_quiet() {
+        assert_eq!(support::soak::long_soak_retention_periodic_limit(599), None);
+        assert_eq!(support::soak::long_soak_retention_periodic_limit(600), None);
+        assert_eq!(
+            support::soak::long_soak_retention_periodic_limit(1_200),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(
+            support::soak::long_soak_retention_periodic_limit(3_600),
+            Some(Duration::from_secs(2_400))
+        );
+        assert_eq!(
+            support::soak::burst_retention_periodic_limit(130, Duration::from_secs(360)),
+            Duration::from_secs(490)
+        );
     }
 
     #[test]

--- a/crates/sip/rvoip-sip/tests/perf/perf_soak_caller.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_soak_caller.rs
@@ -146,7 +146,7 @@ async fn perf_soak_caller() {
         None
     };
     let retention_periodic_limit =
-        (settings.duration_secs >= 600).then(|| Duration::from_secs(settings.duration_secs - 600));
+        support::soak::long_soak_retention_periodic_limit(settings.duration_secs);
     let retention_sampler = support::soak::EndpointRetentionSampler::start_with_periodic_limit(
         "caller",
         Arc::clone(&caller),
@@ -183,7 +183,7 @@ async fn perf_soak_caller() {
         Some(sampler) => sampler.stop().await,
         None => ResourceSummary::empty(),
     };
-    let rss_gate_policy = if settings.duration_secs >= 600 {
+    let rss_gate_policy = if settings.duration_secs >= support::soak::LONG_SOAK_ACTIVE_WINDOW_SECS {
         RssGatePolicy::ActiveTail1200
     } else {
         RssGatePolicy::PostDrainOrTail
@@ -384,10 +384,14 @@ async fn perf_soak_caller() {
     drop(caller);
 
     let mut gate_failures = Vec::new();
-    if settings.duration_secs >= 600 && !rss.active_tail_window_complete {
+    if settings.duration_secs >= support::soak::LONG_SOAK_ACTIVE_WINDOW_SECS
+        && !rss.active_tail_window_complete
+    {
         gate_failures.push(format!(
-            "caller active RSS gate window incomplete: measured {:.2}s with {} samples; required 600s",
-            rss.active_tail_window_secs, rss.active_tail_sample_count
+            "caller active RSS gate window incomplete: measured {:.2}s with {} samples; required {}s",
+            rss.active_tail_window_secs,
+            rss.active_tail_sample_count,
+            support::soak::LONG_SOAK_ACTIVE_WINDOW_SECS,
         ));
     }
     if rss.gate_growth_mb_per_hr > rss_gate.effective_mb_per_hr {

--- a/crates/sip/rvoip-sip/tests/perf/perf_soak_receiver.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_soak_receiver.rs
@@ -21,11 +21,12 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 mod support;
 use support::soak::{
     boot_receiver, diagnostic_sample_path, endpoint_metric, endpoint_retention_summary,
-    in_process_resource_sampler_enabled, media_receive_diagnostics, memory_diagnostic_interval,
-    memory_diagnostic_summary, perf_config, read_required_u16_env, resource_sampling_diagnostics,
-    retention_drain_wait, round2, rss_result_metrics, DhatProfile, EndpointRetentionSampler,
-    MemoryDiagnosticSampler, ReceiverDiagnostics, RssGatePolicy, RssGrowthGate, SoakLoadSettings,
-    ALICE_PORT_ENV, BOB_PORT_ENV, READY_FILE_ENV, STOP_FILE_ENV,
+    in_process_resource_sampler_enabled, long_soak_retention_periodic_limit,
+    media_receive_diagnostics, memory_diagnostic_interval, memory_diagnostic_summary, perf_config,
+    read_required_u16_env, resource_sampling_diagnostics, retention_drain_wait, round2,
+    rss_result_metrics, DhatProfile, EndpointRetentionSampler, MemoryDiagnosticSampler,
+    ReceiverDiagnostics, RssGatePolicy, RssGrowthGate, SoakLoadSettings, ALICE_PORT_ENV,
+    BOB_PORT_ENV, READY_FILE_ENV, STOP_FILE_ENV,
 };
 use support::{LoadProfile, ResourceSampler, ResourceSummary, ScenarioReport};
 
@@ -66,8 +67,7 @@ async fn perf_soak_receiver() {
     } else {
         None
     };
-    let retention_periodic_limit =
-        (settings.duration_secs >= 600).then(|| Duration::from_secs(settings.duration_secs - 600));
+    let retention_periodic_limit = long_soak_retention_periodic_limit(settings.duration_secs);
     let retention_sampler = EndpointRetentionSampler::start_with_periodic_limit(
         "receiver",
         receiver.coordinator.clone(),
@@ -115,7 +115,7 @@ async fn perf_soak_receiver() {
         None => ResourceSummary::empty(),
     };
     let active_load_boundary_secs = settings.duration_secs as f64;
-    let rss_gate_policy = if settings.duration_secs >= 600 {
+    let rss_gate_policy = if settings.duration_secs >= support::soak::LONG_SOAK_ACTIVE_WINDOW_SECS {
         RssGatePolicy::ActiveTail1200
     } else {
         RssGatePolicy::PostDrainOrTail
@@ -278,10 +278,14 @@ async fn perf_soak_receiver() {
     if !stop_seen {
         gate_failures.push("receiver stop file was not observed".to_string());
     }
-    if settings.duration_secs >= 600 && !rss.active_tail_window_complete {
+    if settings.duration_secs >= support::soak::LONG_SOAK_ACTIVE_WINDOW_SECS
+        && !rss.active_tail_window_complete
+    {
         gate_failures.push(format!(
-            "receiver active RSS gate window incomplete: measured {:.2}s with {} samples; required 600s",
-            rss.active_tail_window_secs, rss.active_tail_sample_count
+            "receiver active RSS gate window incomplete: measured {:.2}s with {} samples; required {}s",
+            rss.active_tail_window_secs,
+            rss.active_tail_sample_count,
+            support::soak::LONG_SOAK_ACTIVE_WINDOW_SECS,
         ));
     }
     if rss.gate_growth_mb_per_hr > rss_gate.effective_mb_per_hr {

--- a/crates/sip/rvoip-sip/tests/perf/support/soak.rs
+++ b/crates/sip/rvoip-sip/tests/perf/support/soak.rs
@@ -30,6 +30,7 @@ pub const BURST_RSS_QUIET_TAIL_SECS: usize = 60;
 pub const BURST_SETTLED_RSS_SAMPLE_INTERVAL_SECS: u64 = 5;
 pub const MIN_BURST_RETENTION_DRAIN_WAIT_SECS: usize =
     MIN_RETENTION_DRAIN_WAIT_SECS + BURST_RSS_DIAGNOSTIC_SETTLE_SECS + BURST_RSS_QUIET_TAIL_SECS;
+pub const LONG_SOAK_ACTIVE_WINDOW_SECS: u64 = 1_200;
 /// Full endpoint-retention snapshots walk and serialize every owned runtime
 /// index. Keep that diagnostic off the 5-second RSS sampling hot path so the
 /// leak gate does not measure allocator page growth caused by its own report.
@@ -100,9 +101,27 @@ pub fn resource_sampling_diagnostics(role: &str, in_process_enabled: bool) -> se
     })
 }
 
-/// Measure RSS after teardown and exact structural-retention capture have
-/// completed. A new baseline keeps allocator page activity from those
-/// operations out of the authoritative quiescent-runtime slope.
+/// Stop allocator-heavy structural diagnostics before the complete active-tail
+/// window used by a long-soak RSS gate.
+pub fn long_soak_retention_periodic_limit(duration_secs: u64) -> Option<Duration> {
+    (duration_secs >= LONG_SOAK_ACTIVE_WINDOW_SECS)
+        .then(|| Duration::from_secs(duration_secs.saturating_sub(LONG_SOAK_ACTIVE_WINDOW_SECS)))
+}
+
+/// Stop burst structural diagnostics after the offered load and its longest
+/// possible call have completed. An exact final snapshot is still captured
+/// after the authoritative settled-RSS window.
+pub fn burst_retention_periodic_limit(
+    active_duration_secs: u64,
+    maximum_hold: Duration,
+) -> Duration {
+    Duration::from_secs(active_duration_secs).saturating_add(maximum_hold)
+}
+
+/// Measure RSS after teardown and after periodic structural diagnostics have
+/// stopped. The exact final structural-retention capture must happen after
+/// this function returns so its allocations cannot contaminate the
+/// authoritative quiescent-runtime slope.
 pub async fn sample_settled_rss_window(
     role: &'static str,
     minimum_window_secs: f64,
@@ -2261,13 +2280,13 @@ pub fn rss_result_metrics(
     drain_secs: f64,
     gate_policy: RssGatePolicy,
 ) -> RssResultMetrics {
-    const LONG_SOAK_ACTIVE_WINDOW_SECS: f64 = 1200.0;
     const LONG_SOAK_MIN_ACTIVE_COVERAGE_SECS: f64 = 1190.0;
     const LONG_SOAK_MIN_ACTIVE_SAMPLES: usize = 230;
 
     let full_growth_mb_per_hr = resources.rss_growth_mb_per_min * 60.0;
     let sustained_growth_mb_per_hr = resources.rss_tail_growth_mb_per_min * 60.0;
-    let active_tail_start_secs = (active_load_end_secs - LONG_SOAK_ACTIVE_WINDOW_SECS).max(0.0);
+    let active_tail_start_secs =
+        (active_load_end_secs - LONG_SOAK_ACTIVE_WINDOW_SECS as f64).max(0.0);
     let active_tail_samples: Vec<ResourceSample> = resources
         .samples
         .iter()
@@ -2284,7 +2303,7 @@ pub fn rss_result_metrics(
         (Some(first), Some(last)) => (last.t_secs - first.t_secs).max(0.0),
         _ => 0.0,
     };
-    let active_tail_window_complete = active_load_end_secs >= LONG_SOAK_ACTIVE_WINDOW_SECS
+    let active_tail_window_complete = active_load_end_secs >= LONG_SOAK_ACTIVE_WINDOW_SECS as f64
         && active_tail_window_secs >= LONG_SOAK_MIN_ACTIVE_COVERAGE_SECS
         && active_tail_samples.len() >= LONG_SOAK_MIN_ACTIVE_SAMPLES
         && active_tail_theil_sen.is_some()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -335,19 +335,41 @@ class WorkflowPolicyTests(unittest.TestCase):
             runner,
         )
 
-    def test_burst_rss_gate_uses_post_retention_settled_window(self) -> None:
+    def test_burst_rss_gate_precedes_final_structural_snapshot(self) -> None:
         for path in (
             "crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs",
             "crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs",
         ):
             source = (ROOT / path).read_text()
             with self.subTest(path=path):
-                final_retention = source.index("capture_endpoint_retention_sample(")
-                settled_window = source.index("sample_settled_rss_window(", final_retention)
+                periodic_stop = source.index("retention_sampler.stop_periodic()")
+                settled_window = source.index("sample_settled_rss_window(", periodic_stop)
                 rss_gate = source.index("rss_result_metrics(", settled_window)
-                self.assertLess(final_retention, settled_window)
+                final_retention = source.index(
+                    "capture_endpoint_retention_sample(", rss_gate
+                )
+                self.assertLess(periodic_stop, settled_window)
                 self.assertLess(settled_window, rss_gate)
+                self.assertLess(rss_gate, final_retention)
                 self.assertIn("&settled_resources", source[rss_gate : rss_gate + 250])
+
+    def test_release_memory_gates_isolate_structural_diagnostics(self) -> None:
+        receiver = (
+            ROOT / "crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs"
+        ).read_text()
+        self.assertIn(
+            "EndpointRetentionSampler::start_with_periodic_limit(", receiver
+        )
+        self.assertIn("burst_retention_periodic_limit(", receiver)
+
+        for path in (
+            "crates/sip/rvoip-sip/tests/perf/perf_soak_30min.rs",
+            "crates/sip/rvoip-sip/tests/perf/perf_soak_caller.rs",
+            "crates/sip/rvoip-sip/tests/perf/perf_soak_receiver.rs",
+        ):
+            with self.subTest(path=path):
+                source = (ROOT / path).read_text()
+                self.assertIn("long_soak_retention_periodic_limit(", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- stop long-soak structural snapshots before the complete 20-minute authoritative RSS tail
- stop receiver burst snapshots after offered load plus maximum call hold
- measure burst settled RSS before capturing final allocation-heavy retention evidence
- make the 1,200-second long-soak boundary a shared contract
- add unit and workflow-policy regression coverage

## Root cause

The release harness was measuring memory growth while its own deep retention diagnostics were walking and serializing runtime indexes. In burst tests, the final structural snapshot was also captured immediately before the supposedly quiet RSS window. That could manufacture allocator growth even when all runtime ownership had drained to zero.

## Impact

This keeps the release workload, GCP machine classes, soak duration, and memory thresholds unchanged. It isolates test instrumentation from the evidence used for acceptance.

## Validation

- affected SIP performance test binaries compile without running the workloads
- `structural_diagnostic_limits_leave_authoritative_rss_windows_quiet` passes
- 80 release, policy, gate-source, and performance-metric tests pass
- formatting and diff hygiene pass

After the PR Gate passes, the access-edge burst scenario will be rerun on its real ephemeral GCP worker before any full release qualification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to SIP performance test harnesses, scripts, and CI policy; production runtime and acceptance thresholds are unchanged.
> 
> **Overview**
> Release **RSS acceptance gates** were sometimes failing or flapping because the harness measured memory while **allocator-heavy retention snapshots** were still running. This change separates **what we measure** from **what we prove**.
> 
> For **burst** caller and receiver, the flow is now: drain wait → stop active resource sampling → run the **quiet settled-RSS window** and compute `rss_result_metrics` from `settled_resources` → only then capture **`after_drain` structural retention** so that proof cannot inflate the slope under test. The burst receiver also caps **periodic** retention diagnostics via `burst_retention_periodic_limit` (scenario duration + max hold).
> 
> For **long soaks**, periodic structural sampling stops before the full **1,200-second** authoritative active-tail window (`LONG_SOAK_ACTIVE_WINDOW_SECS`, shared constant replacing scattered `600` checks). Soak caller/receiver/monolithic paths use `long_soak_retention_periodic_limit`; docs now describe the **1,200s** tail for `rss_gate_growth_mb_per_hr`.
> 
> **Regression coverage**: unit test for limit helpers, and CI policy asserts burst source order (settled RSS before final snapshot) and that soak/burst binaries use the new limit APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bf1f1740bb8074e97f29e96ab2b572058ce688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->