### PR TITLE
Allow safe branch-scoped GCP diagnostics

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       candidate:
-        description: Protected main commit or ref to diagnose or qualify
+        description: Main commit to qualify, or same-repository branch head to diagnose
         required: true
         default: main
         type: string
@@ -80,13 +80,26 @@ jobs:
         with:
           toolchain: 1.91.0
 
-      - name: Require candidate to belong to protected origin/main
+      - name: Require protected main candidate or trusted diagnostic branch head
+        env:
+          PROFILE: ${{ inputs.profile }}
         run: |
+          set -euo pipefail
           git fetch origin main
-          git merge-base --is-ancestor HEAD origin/main || {
-            echo "release candidates must be commits on origin/main" >&2
-            exit 1
-          }
+          if [[ "$PROFILE" == remote-diagnostic ]]; then
+            candidate="$(git rev-parse HEAD)"
+            git ls-remote --heads origin \
+              | awk -v candidate="$candidate" '$1 == candidate { found = 1 } END { exit !found }' \
+              || {
+                echo "diagnostic candidates must be the exact head of a branch in this repository" >&2
+                exit 1
+              }
+          else
+            git merge-base --is-ancestor HEAD origin/main || {
+              echo "release candidates must be commits on origin/main" >&2
+              exit 1
+            }
+          fi
 
       - name: Require complete structured release coverage
         if: inputs.profile == 'remote-release'
@@ -173,6 +186,9 @@ jobs:
             echo "- Fresh gates: ${{ steps.plan.outputs.run_count }}"
             echo "- Reused gates: ${{ steps.plan.outputs.reuse_count }}"
             echo "- Runner shards: ${{ steps.plan.outputs.shard_count }}"
+            if [[ '${{ inputs.profile }}' == remote-diagnostic ]]; then
+              echo "- Reusable for release: no"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload qualification plan
@@ -640,12 +656,13 @@ jobs:
           --output target/release-qualification/aggregate.json
 
       - name: Attest release qualification bundle
+        if: inputs.profile != 'remote-diagnostic'
         uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
         with:
           subject-path: target/release-qualification/aggregate.json
 
       - name: Upload reusable release evidence
-        if: always()
+        if: always() && inputs.profile != 'remote-diagnostic'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-gate-evidence
@@ -654,4 +671,16 @@ jobs:
             target/release-evidence/
             target/release-qualification/aggregate.json
           retention-days: 90
+          if-no-files-found: warn
+
+      - name: Upload non-reusable diagnostic evidence
+        if: always() && inputs.profile == 'remote-diagnostic'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: diagnostic-gate-evidence
+          path: |
+            target/release-plan/plan.json
+            target/release-evidence/
+            target/release-qualification/aggregate.json
+          retention-days: 30
           if-no-files-found: warn

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -247,7 +247,10 @@ class WorkflowPolicyTests(unittest.TestCase):
 
         self.assertIn("remote-preflight", workflow)
         self.assertIn('test "$PROFILE" = remote-preflight', workflow)
-        self.assertIn("Require candidate to belong to protected origin/main", workflow)
+        self.assertIn(
+            "Require protected main candidate or trusted diagnostic branch head",
+            workflow,
+        )
         self.assertIn("RVOIP_GCP_WORKLOAD_IDENTITY_PROVIDER", workflow)
         self.assertNotIn("RVOIP_GCP_PILOT_PROVIDER", workflow)
         self.assertIn('export RVOIP_RELEASE_RESOURCE_CLASS="$RESOURCE_CLASS"', startup)
@@ -272,6 +275,11 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('test "$PROFILE" = remote-diagnostic', workflow)
         self.assertIn("inputs.profile != 'remote-diagnostic'", workflow)
         self.assertIn("inputs.diagnostic_gates || 'all'", workflow)
+        self.assertIn("diagnostic candidates must be the exact head", workflow)
+        self.assertIn("git ls-remote --heads origin", workflow)
+        self.assertIn("Upload non-reusable diagnostic evidence", workflow)
+        self.assertIn("name: diagnostic-gate-evidence", workflow)
+        self.assertIn("Reusable for release: no", workflow)
         self.assertIn("at most five prior evidence runs may be combined", workflow)
         self.assertIn('--dir "target/prior-evidence/$run_id"', workflow)
         self.assertIn(


### PR DESCRIPTION
## Problem

Release test fixes currently have to merge before they can be exercised on real GCP workers, making every failed hypothesis consume a full merge-and-rerun cycle.

## Change

- permit remote-diagnostic only when the candidate is the exact head of a branch in this repository
- keep all qualification and release profiles restricted to protected main
- keep GCP authentication bound to the workflow on main
- label diagnostic artifacts separately, skip release attestation, and make them unavailable to the release evidence reuse path

## Verification

- full workflow policy test suite passes
- workflow YAML parses successfully
- no performance workload was run locally

## Risk

The diagnostic dispatch still requires repository write access and remains non-publishing. Fork commits cannot satisfy the same-repository branch-head guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands who can run real GCP release gates to branch heads (still same-repo, write-gated dispatch), but keeps attestation and release evidence reuse off the diagnostic path.
> 
> **Overview**
> **Enables branch-scoped GCP gate diagnosis** without merging to `main`, while keeping qualification and release paths unchanged.
> 
> For **`remote-diagnostic` only**, the plan job accepts a candidate that is the **exact head of a branch on `origin`** (`git ls-remote --heads`), instead of requiring ancestry on `origin/main`. All other profiles still fail closed unless `HEAD` is on protected `origin/main`. The candidate input description is updated to reflect branch-head diagnosis.
> 
> Diagnostic runs are explicitly **non-release**: the job summary notes **“Reusable for release: no”**, build provenance attestation is skipped, reusable `release-gate-evidence` upload is gated off, and a separate **`diagnostic-gate-evidence`** artifact is uploaded with shorter retention (30 vs 90 days)—so publish/reuse paths that only consume `release-gate-evidence` cannot pick up branch diagnostics.
> 
> Workflow policy tests are extended to assert the new guard strings, separate artifact name, and summary line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a8e1d16e29e958032da0812cb4d70ec23a6601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->