### PR TITLE
Stream large GCP release artifacts from disk

### DIFF
--- a/infra/release-runners/gcp-performance-prebuild-startup.sh
+++ b/infra/release-runners/gcp-performance-prebuild-startup.sh
@@ -45,7 +45,7 @@ upload() {
     -X POST \
     -H "Authorization: Bearer ${access_token}" \
     -H 'Content-Type: application/octet-stream' \
-    --data-binary "@${source}" \
+    --upload-file "${source}" \
     "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${encoded}"
 }
 

--- a/infra/release-runners/gcp-pilot-startup.sh
+++ b/infra/release-runners/gcp-pilot-startup.sh
@@ -53,7 +53,7 @@ upload() {
     -X POST \
     -H "Authorization: Bearer ${token}" \
     -H 'Content-Type: application/octet-stream' \
-    --data-binary "@${source}" \
+    --upload-file "${source}" \
     "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${encoded}"
 }
 

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -41,7 +41,7 @@ upload() {
     -X POST \
     -H "Authorization: Bearer ${token}" \
     -H 'Content-Type: application/octet-stream' \
-    --data-binary "@${source}" \
+    --upload-file "${source}" \
     "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${encoded}"
 }
 

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -264,6 +264,17 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("bundle digest mismatch", helper)
         self.assertIn("exact candidate", helper)
 
+    def test_gcp_artifact_uploads_stream_regular_files(self) -> None:
+        for relative in (
+            "infra/release-runners/gcp-performance-prebuild-startup.sh",
+            "infra/release-runners/gcp-release-startup.sh",
+            "infra/release-runners/gcp-pilot-startup.sh",
+        ):
+            startup = (ROOT / relative).read_text()
+            with self.subTest(startup=relative):
+                self.assertIn('--upload-file "${source}"', startup)
+                self.assertNotIn("--data-binary", startup)
+
     def test_release_infrastructure_preflight_is_full_shape_and_non_publishing(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
         startup = (ROOT / "infra/release-runners/gcp-release-startup.sh").read_text()


### PR DESCRIPTION
## Problem

The first full non-publishing qualification compiled all 26 selected performance executables successfully, then failed before creating measurement workers. The bundle contains 6.38 GB of executable data, and curl attempted to buffer the archive in memory through `--data-binary`, ending with `curl: option --data-binary: out of memory`.

## Fix

- stream prebuilt bundles to the GCS media-upload endpoint with `--upload-file`
- use the same bounded-memory upload path for release evidence and pilot receipts
- add a policy regression test that rejects memory-buffering artifact uploads

This changes transfer mechanics only. Candidate binding, SHA-256 verification, GCS destination, retry behavior, test workloads, server types, and acceptance thresholds are unchanged.

## Verification

- Bash syntax passes for all three startup scripts
- ShellCheck passes for all three startup scripts
- 25 workflow-policy tests pass
- a live upload through the exact curl form was downloaded and compared byte-for-byte, then its disposable GCS object was deleted
- failed qualification run 30767269731 created no measurement workers and cleaned up its builder

The next action after merge is to rerun the full non-publishing qualification against the new exact main commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical curl upload change with policy guardrails; same GCS API and verification paths, low blast radius outside large-artifact upload timing.
> 
> **Overview**
> Fixes **OOM failures** when uploading multi‑GB release artifacts (e.g. ~6.4 GB performance prebuild bundles) by switching GCS media uploads from `curl --data-binary` (full in-memory buffering) to **`--upload-file`** in the three GCP startup scripts: performance prebuild, release qualification, and pilot.
> 
> Adds **`test_gcp_artifact_uploads_stream_regular_files`** in workflow policy tests so those scripts must use streaming uploads and must not reintroduce `--data-binary`. Endpoints, auth, retries, and verification behavior are unchanged—only how the file body is sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8d7c1257c217cc7bd10c214f997d5a1222b9b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->