### PR TITLE
Fail release qualification early and harden proxy evidence

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -605,6 +605,46 @@ jobs:
                 terminated_without_result+=("$worker")
               fi
             done < <(jq -c '.workers[]' target/gcp-controller/workers.json)
+
+            # A candidate that has already failed the bounded performance,
+            # burst, or proxy lane cannot become releasable by finishing an
+            # hour-long soak.  Preserve all early results, then stop only the
+            # still-running deferred workers so fixes can be verified without
+            # waiting for proof that can no longer qualify this candidate.
+            cutoff_json="$(python3 scripts/release/gcp_fanout.py \
+              early-failure-decision \
+              --manifest target/gcp-controller/workers.json \
+              --downloads target/gcp-controller/downloads \
+              --states target/gcp-controller/states.csv)"
+            while IFS= read -r failed_shard; do
+              announcement="target/gcp-controller/downloads/${failed_shard}/failure-announced"
+              if [[ ! -f "$announcement" ]]; then
+                echo "::error title=GCP release gate failed::${failed_shard} reported or produced invalid failure evidence"
+                touch "$announcement"
+              fi
+            done < <(jq -r '.failed_shards[]' <<< "$cutoff_json")
+            mapfile -t deferred_running \
+              < <(jq -r '.deferred_running[]' <<< "$cutoff_json")
+            if [[ "$(jq -r .should_stop <<< "$cutoff_json")" == true \
+              && ! -f target/gcp-controller/early-failure-cutoff.txt ]]; then
+              early_expected="$(jq -r .early_expected <<< "$cutoff_json")"
+              early_settled="$(jq -r .early_settled <<< "$cutoff_json")"
+              observed_failures="$(jq '.failed_shards | length' <<< "$cutoff_json")"
+              printf '%s\n' "${deferred_running[@]}" \
+                > target/gcp-controller/early-failure-cutoff.txt
+              echo "::error title=Release candidate rejected early::Stopping ${#deferred_running[@]} deferred GCP workers after the bounded lane failed"
+              {
+                echo
+                echo "### Early failure cutoff"
+                echo
+                echo "- Bounded GCP workers settled: ${early_settled}/${early_expected}"
+                echo "- Observed failures: ${observed_failures}"
+                echo "- Deferred workers stopped: ${#deferred_running[@]}"
+                echo "- Completed evidence remains reusable when its exact digests match."
+              } >> "$GITHUB_STEP_SUMMARY"
+              gcloud compute instances stop "${deferred_running[@]}" \
+                --project "$PROJECT" --zone "$ZONE" --quiet || true
+            fi
             settled=$((completed + ${#terminated_without_result[@]}))
             if (( settled == expected )); then
               if (( ${#terminated_without_result[@]} != 0 )); then

--- a/crates/sip/sip-proxy/tests/interop/scripts/run.sh
+++ b/crates/sip/sip-proxy/tests/interop/scripts/run.sh
@@ -12,6 +12,12 @@ WORKSPACE_ROOT=$(git -C "$INTEROP_DIR" rev-parse --show-toplevel)
 SIPP_BIN=${SIPP_BIN:-sipp}
 TCPDUMP_BIN=${TCPDUMP_BIN:-tcpdump}
 TSHARK_BIN=${TSHARK_BIN:-tshark}
+# The capacity-overload scenario deliberately emits hundreds of packets in a
+# short interval.  libpcap's small default socket buffer can drop part of that
+# proof on a correctly functioning proxy, leaving packet evidence with an
+# impossible partial call partition.  Keep the capture lossless instead of
+# weakening the packet assertions.
+TCPDUMP_BUFFER_KIB=${PROXY_INTEROP_TCPDUMP_BUFFER_KIB:-32768}
 PEERS=${PROXY_INTEROP_PEERS:-"kamailio opensips"}
 TRANSPORTS=${PROXY_INTEROP_TRANSPORTS:-"udp tcp tls"}
 ORDERS=${PROXY_INTEROP_ORDERS:-"rvoip-first peer-first"}
@@ -89,6 +95,10 @@ for tool in docker "$SIPP_BIN" "$TCPDUMP_BIN" "$TSHARK_BIN" python3 cargo git se
 done
 if ! docker info >/dev/null 2>&1; then
   echo "Docker is not reachable" >&2
+  exit 1
+fi
+if [[ ! "$TCPDUMP_BUFFER_KIB" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PROXY_INTEROP_TCPDUMP_BUFFER_KIB must be a positive integer" >&2
   exit 1
 fi
 if [[ ! -x "$STATE_SNAPSHOT" && ! -f "$STATE_SNAPSHOT" ]]; then
@@ -642,7 +652,7 @@ start_captures() {
     capture_interface_available "$interface" || continue
     safe_name=${interface//[^a-zA-Z0-9_.-]/_}
     local capture_path="$row_dir/${scenario}--$safe_name.pcap"
-    "${tcpdump_args[@]}" -i "$interface" -U -s 0 -n \
+    "${tcpdump_args[@]}" -B "$TCPDUMP_BUFFER_KIB" -i "$interface" -U -s 0 -n \
       -w "$capture_path" "$filter" \
       >"$row_dir/scenarios/$scenario/tcpdump-$safe_name.log" 2>&1 &
     pid=$!

--- a/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
@@ -290,6 +290,16 @@ class RunFailStopTests(unittest.TestCase):
         self.assertIn('"$row_dir/${scenario}--$safe_name.pcap"', self.source)
         self.assertNotIn('"$row_dir/$safe_name.pcap"', self.source)
 
+    def test_packet_capture_uses_explicit_loss_resistant_buffer(self) -> None:
+        self.assertIn(
+            "TCPDUMP_BUFFER_KIB=${PROXY_INTEROP_TCPDUMP_BUFFER_KIB:-32768}",
+            self.source,
+        )
+        self.assertIn(
+            '-B "$TCPDUMP_BUFFER_KIB" -i "$interface"',
+            self.source,
+        )
+
     def test_tcp_uac_uses_per_call_socket_while_uas_remains_single_socket(
         self,
     ) -> None:

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -240,6 +240,13 @@ fi
 ulimit -n 262144
 test "$(ulimit -n)" -ge 262144
 
+# Stateful proxy qualification captures a dense packet burst on both the
+# loopback and aggregate interfaces.  Raise the receive ceiling before
+# tcpdump requests its explicit 32 MiB capture buffer; otherwise a healthy
+# capacity-overload run can lose evidence in the kernel and fail spuriously.
+sysctl -w net.core.rmem_max=67108864
+test "$(sysctl -n net.core.rmem_max)" -ge 67108864
+
 export RVOIP_RELEASE_CANDIDATE="$CANDIDATE"
 export RVOIP_RELEASE_ENVIRONMENT_ID="$ENVIRONMENT_ID"
 export RVOIP_RELEASE_GATES="$GATES"

--- a/scripts/ci/policy.json
+++ b/scripts/ci/policy.json
@@ -27,6 +27,9 @@
     "CHANGELOG.md",
     "README.md"
   ],
+  "specialty_only_paths": [
+    "crates/sip/sip-proxy/tests/interop/scripts/**"
+  ],
   "example_projects": [
     "01-quickstart-p2p",
     "02-softphone-audio",
@@ -151,6 +154,7 @@
     {
       "gate": "release-tooling",
       "patterns": [
+        "crates/sip/sip-proxy/tests/interop/scripts/**",
         "scripts/release.py",
         "scripts/release.sh",
         "scripts/release/**",

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -444,6 +444,7 @@ def make_plan(
         )
     packages = workspace_packages(root, metadata)
     known_policy_paths = set(policy.get("known_policy_paths", []))
+    specialty_only_paths = policy.get("specialty_only_paths", [])
     specialty_set = {
             rule["gate"]
             for rule in policy.get("specialty_rules", [])
@@ -502,6 +503,18 @@ def make_plan(
     unknown: list[str] = []
     if not docs_only and not full_reasons:
         for path in normalized:
+            specialty_rules = [
+                rule
+                for rule in policy.get("specialty_rules", [])
+                if matches_any(path, rule.get("patterns", []))
+            ]
+            if matches_any(path, specialty_only_paths):
+                # Test harnesses can live below a Cargo package without
+                # changing the compiled crate. They may bypass crate closure
+                # only when an explicit specialty gate owns the path.
+                if not specialty_rules:
+                    unknown.append(path)
+                continue
             owner = owning_package(path, packages)
             if owner:
                 direct.add(owner)
@@ -509,10 +522,7 @@ def make_plan(
                 continue
             elif not matches_any(path, known_policy_paths):
                 # Specialty-only trees are mapped even though they are not Cargo members.
-                if not any(
-                    matches_any(path, rule.get("patterns", []))
-                    for rule in policy.get("specialty_rules", [])
-                ):
+                if not specialty_rules:
                     unknown.append(path)
 
     if not normalized:

--- a/scripts/ci/run_checks.py
+++ b/scripts/ci/run_checks.py
@@ -281,6 +281,20 @@ def specialty_commands(
             ),
             (
                 [
+                    "python3",
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "crates/sip/sip-proxy/tests/interop/scripts",
+                    "-p",
+                    "test_*.py",
+                ],
+                None,
+                None,
+            ),
+            (
+                [
                     "cargo",
                     "+nightly",
                     "fuzz",

--- a/scripts/ci/test_pr_plan.py
+++ b/scripts/ci/test_pr_plan.py
@@ -62,10 +62,14 @@ class PlannerTests(unittest.TestCase):
                 ".github/workflows/**",
                 "scripts/ci/**",
             ],
+            "specialty_only_paths": ["crates/delta/tests/harness/**"],
             "specialty_rules": [
                 {"gate": "browser-smoke", "patterns": ["tests/browser/**"]},
                 {"gate": "examples", "patterns": ["examples/**", "crates/delta/src/api/**"]},
-                {"gate": "release-tooling", "patterns": ["infra/release/**"]},
+                {
+                    "gate": "release-tooling",
+                    "patterns": ["infra/release/**", "crates/delta/tests/harness/**"],
+                },
             ],
             "example_projects": ["one", "two"],
             "pr_example_projects": ["one"],
@@ -320,6 +324,30 @@ version = "2.0.0"
         self.assertEqual(plan["mode"], "targeted")
         self.assertEqual(plan["selected_crates"], [])
         self.assertEqual(plan["specialty_gates"], ["release-tooling"])
+
+    def test_owned_test_harness_uses_specialty_without_crate_closure(self) -> None:
+        plan = self.plan("crates/delta/tests/harness/run.sh")
+        self.assertEqual(plan["mode"], "targeted")
+        self.assertEqual(plan["selected_crates"], [])
+        self.assertEqual(plan["specialty_gates"], ["release-tooling"])
+
+    def test_unowned_specialty_only_path_fails_closed(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["specialty_rules"] = [
+            rule for rule in policy["specialty_rules"] if rule["gate"] != "release-tooling"
+        ]
+        plan = pr_plan.make_plan(
+            root=self.root,
+            metadata=self.metadata,
+            policy=policy,
+            paths=["crates/delta/tests/harness/run.sh"],
+            base="base",
+            head="head",
+            candidate=None,
+            job_mode="combined",
+        )
+        self.assertEqual(plan["mode"], "full")
+        self.assertIn("harness/run.sh", plan["reason"])
 
     def test_rename_records_old_and_new_paths(self) -> None:
         payload = b"R100\0crates/alpha/old.rs\0crates/beta/new.rs\0D\0crates/delta/gone.rs\0"

--- a/scripts/ci/test_run_checks.py
+++ b/scripts/ci/test_run_checks.py
@@ -127,6 +127,23 @@ class RunChecksTests(unittest.TestCase):
         self.assertIn("otel", commands[0][0])
         self.assertIn("--all-targets", commands[0][0])
 
+    def test_release_tooling_gate_owns_proxy_harness_tests(self) -> None:
+        commands = run_checks.specialty_commands("release-tooling", Path("/workspace"))
+        argv = [item[0] for item in commands]
+        self.assertIn(
+            [
+                "python3",
+                "-m",
+                "unittest",
+                "discover",
+                "-s",
+                "crates/sip/sip-proxy/tests/interop/scripts",
+                "-p",
+                "test_*.py",
+            ],
+            argv,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -293,6 +293,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('export RVOIP_RELEASE_RESOURCE_CLASS="$RESOURCE_CLASS"', startup)
         self.assertIn('export RVOIP_RELEASE_CANDIDATE="$CANDIDATE"', startup)
         self.assertIn('export RVOIP_RELEASE_GATES="$GATES"', startup)
+        self.assertIn("sysctl -w net.core.rmem_max=67108864", startup)
         self.assertIn("expected 44 publishable workspace packages", probe)
         self.assertIn("gcp-performance|gcp-performance-soak-long", probe)
         self.assertIn("gcp-proxy-interop", probe)

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -330,6 +330,9 @@ class WorkflowPolicyTests(unittest.TestCase):
         controller = workflow.split("\n  gate-gcp:\n", maxsplit=1)[1].split(
             "\n  cleanup-gcp:\n", maxsplit=1
         )[0]
+        self.assertIn("Early failure cutoff", controller)
+        self.assertIn("early-failure-decision", controller)
+        self.assertIn("gcloud compute instances stop", controller)
 
         self.assertNotIn("strategy:", controller)
         self.assertNotIn("matrix: ${{ fromJSON", controller)

--- a/scripts/release/gcp_fanout.py
+++ b/scripts/release/gcp_fanout.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import csv
 import hashlib
 import json
 from pathlib import Path, PurePosixPath
@@ -30,6 +31,10 @@ RESOURCE_MACHINES = {
 }
 RESOURCE_DISK_GB = {
     "gcp-proxy-interop": 100,
+}
+DEFERRED_RESOURCE_CLASSES = {
+    "gcp-interop",
+    "gcp-performance-soak-long",
 }
 MACHINE_VCPUS = {
     "n2-standard-2": 2,
@@ -263,6 +268,80 @@ def validate_result(
     )
 
 
+def load_instance_states(path: Path) -> dict[str, str]:
+    """Load the controller's exact GCE instance-name/status snapshot."""
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.reader(handle))
+    except OSError as error:
+        raise FanoutError(f"cannot read GCP instance states {path}: {error}") from error
+    states: dict[str, str] = {}
+    for row in rows:
+        if len(row) != 2 or not row[0] or not row[1]:
+            raise FanoutError(f"invalid GCP instance-state row: {row!r}")
+        if row[0] in states:
+            raise FanoutError(f"duplicate GCP instance-state row: {row[0]}")
+        states[row[0]] = row[1]
+    return states
+
+
+def early_failure_decision(
+    *, manifest: dict[str, Any], downloads: Path, states: dict[str, str]
+) -> dict[str, Any]:
+    """Decide whether failed bounded work makes deferred work unnecessary."""
+    validate_manifest(manifest)
+    early_expected = 0
+    early_settled = 0
+    failed_shards: list[str] = []
+    invalid_results: dict[str, str] = {}
+    deferred_running: list[str] = []
+
+    for worker in manifest["workers"]:
+        shard = worker["id"]
+        is_deferred = worker["resource_class"] in DEFERRED_RESOURCE_CLASSES
+        if not is_deferred:
+            early_expected += 1
+        result_path = downloads / shard / "result.json"
+        if result_path.is_file():
+            try:
+                result = load_json(result_path, f"{shard} result")
+                passed = validate_result(
+                    worker=worker, result=result, manifest=manifest
+                )
+            except FanoutError as error:
+                passed = False
+                invalid_results[shard] = str(error)
+            if not passed:
+                failed_shards.append(shard)
+            if not is_deferred:
+                early_settled += 1
+            continue
+
+        if states.get(worker["name"]) == "TERMINATED":
+            failed_shards.append(shard)
+            if not is_deferred:
+                early_settled += 1
+        elif is_deferred:
+            deferred_running.append(worker["name"])
+
+    failed_shards.sort()
+    deferred_running.sort()
+    return {
+        "schema": "rvoip-gcp-early-failure-decision-v1",
+        "early_expected": early_expected,
+        "early_settled": early_settled,
+        "failed_shards": failed_shards,
+        "invalid_results": invalid_results,
+        "deferred_running": deferred_running,
+        "should_stop": bool(
+            early_expected > 0
+            and early_settled == early_expected
+            and failed_shards
+            and deferred_running
+        ),
+    }
+
+
 def verify_fanout(
     *, manifest: dict[str, Any], downloads: Path, output: Path
 ) -> dict[str, Any]:
@@ -362,6 +441,11 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("--manifest", type=Path, required=True)
     verify.add_argument("--downloads", type=Path, required=True)
     verify.add_argument("--output", type=Path, required=True)
+
+    cutoff = commands.add_parser("early-failure-decision")
+    cutoff.add_argument("--manifest", type=Path, required=True)
+    cutoff.add_argument("--downloads", type=Path, required=True)
+    cutoff.add_argument("--states", type=Path, required=True)
     return parser
 
 
@@ -377,7 +461,7 @@ def main(argv: list[str] | None = None) -> int:
                 run_attempt=args.run_attempt,
             )
             write_json(args.output, manifest)
-        else:
+        elif args.command == "verify":
             receipt = verify_fanout(
                 manifest=load_json(args.manifest, "GCP fanout manifest"),
                 downloads=args.downloads,
@@ -386,6 +470,13 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(receipt, sort_keys=True))
             if receipt["status"] != "PASS":
                 return 1
+        else:
+            decision = early_failure_decision(
+                manifest=load_json(args.manifest, "GCP fanout manifest"),
+                downloads=args.downloads,
+                states=load_instance_states(args.states),
+            )
+            print(json.dumps(decision, sort_keys=True))
     except FanoutError as error:
         print(f"GCP release fanout error: {error}", flush=True)
         return 1

--- a/scripts/test_release_gcp_fanout.py
+++ b/scripts/test_release_gcp_fanout.py
@@ -57,6 +57,60 @@ class GcpReleaseFanoutTests(unittest.TestCase):
             run_attempt="2",
         )
 
+    def cutoff_manifest(self) -> dict[str, object]:
+        return fanout.prepare_manifest(
+            matrix={
+                "include": [
+                    self.matrix_entry("bounded"),
+                    self.matrix_entry(
+                        "long-soak",
+                        resource="gcp-performance-soak-long",
+                        machine="n2-standard-8",
+                        gates="perf.long-soak",
+                    ),
+                    self.matrix_entry(
+                        "pbx-interop",
+                        resource="gcp-interop",
+                        machine="n2-standard-4",
+                        gates="interop.pbx",
+                    ),
+                ]
+            },
+            candidate=self.candidate,
+            environment_id="release-environment",
+            run_id="123456789",
+            run_attempt="2",
+        )
+
+    @staticmethod
+    def write_result_only(
+        root: Path,
+        manifest: dict[str, object],
+        shard: str,
+        *,
+        status: str,
+        candidate: str | None = None,
+    ) -> None:
+        worker = next(item for item in manifest["workers"] if item["id"] == shard)
+        directory = root / shard
+        directory.mkdir(parents=True, exist_ok=True)
+        fanout.write_json(
+            directory / "result.json",
+            {
+                "schema": fanout.RESULT_SCHEMA,
+                "candidate_sha": candidate or manifest["candidate_sha"],
+                "github_run_id": (
+                    f"{manifest['github_run_id']}-{manifest['github_run_attempt']}"
+                ),
+                "shard_id": shard,
+                "gates": sorted(worker["gates"]),
+                "exit_code": 0 if status == "PASS" else 1,
+                "status": status,
+                "evidence_archive_sha256": "0" * 64,
+                "publishing_attempted": False,
+            },
+        )
+
     def test_prepare_is_deterministic_and_capacity_aware(self) -> None:
         manifest = self.manifest()
         self.assertEqual(manifest["worker_count"], 2)
@@ -147,6 +201,102 @@ class GcpReleaseFanoutTests(unittest.TestCase):
                 run_id="1",
                 run_attempt="1",
             )
+
+    def test_early_failure_cutoff_waits_for_every_bounded_worker(self) -> None:
+        manifest = self.cutoff_manifest()
+        states = {worker["name"]: "RUNNING" for worker in manifest["workers"]}
+        with tempfile.TemporaryDirectory() as directory:
+            downloads = Path(directory)
+            decision = fanout.early_failure_decision(
+                manifest=manifest, downloads=downloads, states=states
+            )
+            self.assertEqual(decision["early_expected"], 1)
+            self.assertEqual(decision["early_settled"], 0)
+            self.assertFalse(decision["should_stop"])
+            self.assertEqual(len(decision["deferred_running"]), 2)
+
+            self.write_result_only(
+                downloads, manifest, "long-soak", status="FAIL"
+            )
+            decision = fanout.early_failure_decision(
+                manifest=manifest, downloads=downloads, states=states
+            )
+            self.assertEqual(decision["failed_shards"], ["long-soak"])
+            self.assertFalse(decision["should_stop"])
+
+    def test_early_failure_cutoff_stops_only_deferred_workers_after_failure(self) -> None:
+        manifest = self.cutoff_manifest()
+        states = {worker["name"]: "RUNNING" for worker in manifest["workers"]}
+        with tempfile.TemporaryDirectory() as directory:
+            downloads = Path(directory)
+            self.write_result_only(downloads, manifest, "bounded", status="FAIL")
+            decision = fanout.early_failure_decision(
+                manifest=manifest, downloads=downloads, states=states
+            )
+            self.assertTrue(decision["should_stop"])
+            self.assertEqual(decision["early_settled"], 1)
+            self.assertEqual(decision["failed_shards"], ["bounded"])
+            deferred_names = {
+                worker["name"]
+                for worker in manifest["workers"]
+                if worker["resource_class"] in fanout.DEFERRED_RESOURCE_CLASSES
+            }
+            self.assertEqual(set(decision["deferred_running"]), deferred_names)
+
+    def test_early_failure_cutoff_never_stops_a_clean_candidate(self) -> None:
+        manifest = self.cutoff_manifest()
+        states = {worker["name"]: "RUNNING" for worker in manifest["workers"]}
+        with tempfile.TemporaryDirectory() as directory:
+            downloads = Path(directory)
+            self.write_result_only(downloads, manifest, "bounded", status="PASS")
+            decision = fanout.early_failure_decision(
+                manifest=manifest, downloads=downloads, states=states
+            )
+            self.assertEqual(decision["early_settled"], 1)
+            self.assertEqual(decision["failed_shards"], [])
+            self.assertFalse(decision["should_stop"])
+
+    def test_early_failure_cutoff_fails_closed_on_invalid_or_missing_evidence(self) -> None:
+        manifest = self.cutoff_manifest()
+        states = {worker["name"]: "RUNNING" for worker in manifest["workers"]}
+        with tempfile.TemporaryDirectory() as directory:
+            downloads = Path(directory)
+            self.write_result_only(
+                downloads,
+                manifest,
+                "bounded",
+                status="PASS",
+                candidate="d" * 40,
+            )
+            decision = fanout.early_failure_decision(
+                manifest=manifest, downloads=downloads, states=states
+            )
+            self.assertTrue(decision["should_stop"])
+            self.assertIn("bounded", decision["invalid_results"])
+
+        with tempfile.TemporaryDirectory() as directory:
+            downloads = Path(directory)
+            bounded = next(
+                worker for worker in manifest["workers"] if worker["id"] == "bounded"
+            )
+            states[bounded["name"]] = "TERMINATED"
+            decision = fanout.early_failure_decision(
+                manifest=manifest, downloads=downloads, states=states
+            )
+            self.assertTrue(decision["should_stop"])
+            self.assertEqual(decision["failed_shards"], ["bounded"])
+
+    def test_instance_state_csv_is_strict(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "states.csv"
+            path.write_text("worker-1,RUNNING\nworker-2,TERMINATED\n")
+            self.assertEqual(
+                fanout.load_instance_states(path),
+                {"worker-1": "RUNNING", "worker-2": "TERMINATED"},
+            )
+            path.write_text("worker-1,RUNNING,extra\n")
+            with self.assertRaisesRegex(fanout.FanoutError, "invalid GCP"):
+                fanout.load_instance_states(path)
 
     @staticmethod
     def write_archive(path: Path, member_name: str, payload: bytes) -> str:


### PR DESCRIPTION
## What changed

- stop only still-running long-soak and PBX workers after every bounded GCP worker has settled and the candidate is already known to fail
- preserve completed immutable evidence for digest-matched selective retries
- validate the cutoff decision in Python and fail closed on malformed or missing worker results
- increase kernel and tcpdump receive buffers so proxy interoperability evidence is not invalidated by packet capture loss

## Why

The first full remote qualification exposed bounded failures in roughly 35–40 minutes but continued waiting for deferred gates. This change makes that failure path terminate promptly without weakening any release requirement for clean candidates.

## Verification

- 93 release automation tests
- 76 policy tests through the normal policy runner
- workflow YAML parse and extracted shell validation
- 18 proxy fail-stop tests
- focused unchanged-candidate Kamailio rerun passed in about 10 minutes, confirming the original failure was capture loss

No Rust public API changes. No release is published by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release qualification control flow and GCP instance lifecycle; incorrect cutoff logic could stop workers prematurely, but behavior is heavily tested and bounded workers must all settle first.
> 
> **Overview**
> Adds **early failure cutoff** to GCP release qualification: once every bounded worker has settled and at least one has failed, the workflow stops still-running long-soak and PBX workers via `gcp_fanout.py early-failure-decision`, while keeping completed evidence for digest-matched retries.
> 
> **Proxy interop evidence** is hardened so capacity-overload captures are not dropped: `run.sh` passes an explicit tcpdump buffer (`-B`), GCP startup raises `net.core.rmem_max` before capture, and tests lock in both behaviors.
> 
> **CI planning** treats paths under `specialty_only_paths` (including proxy interop scripts) as owned only by matching specialty gates—unowned edits fail closed to full workspace. The **release-tooling** gate now runs the proxy harness Python unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc3ab38c5f0817c6205c6d6a33f9ae763e9b173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->