### PR TITLE
Speed up GCP release linking

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -47,7 +47,7 @@ concurrency:
   cancel-in-progress: ${{ inputs.profile == 'remote-preflight' || inputs.profile == 'remote-diagnostic' }}
 
 env:
-  RELEASE_ENVIRONMENT_ID: rvoip-release-v3-rust-1.91-nextest-0.9.140-prebuilt-perf-v1
+  RELEASE_ENVIRONMENT_ID: rvoip-release-v4-rust-1.91-nextest-0.9.140-prebuilt-perf-v2-lld
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"

--- a/infra/release-runners/gcp-performance-prebuild-startup.sh
+++ b/infra/release-runners/gcp-performance-prebuild-startup.sh
@@ -133,12 +133,18 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y --no-install-recommends \
   build-essential ca-certificates cmake curl git libasound2-dev libopus-dev \
-  libssl-dev pigz pkg-config protobuf-compiler
+  libssl-dev lld pigz pkg-config protobuf-compiler
 
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
   https://sh.rustup.rs -o /tmp/rustup-init.sh
 sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain 1.91.0
 export PATH=/root/.cargo/bin:$PATH
+command -v ld.lld >/dev/null
+ld.lld --version
+# GNU ld dominates an otherwise cache-hot exact-candidate prebuild. Keep the
+# linker choice explicit and release-environment-versioned so evidence built
+# with a different linker can never be reused accidentally.
+export RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 
 git clone --filter=blob:none https://github.com/eisenzopf/rvoip.git "$WORKSPACE"
 cd "$WORKSPACE"
@@ -163,7 +169,7 @@ if curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
   export SCCACHE_CACHE_SIZE=40G
   export SCCACHE_DIR=/var/cache/rvoip-sccache
   export SCCACHE_GCS_BUCKET="$CACHE_BUCKET"
-  export SCCACHE_GCS_KEY_PREFIX=rvoip-release-v1/rust-1.91.0/x86_64-unknown-linux-gnu
+  export SCCACHE_GCS_KEY_PREFIX=rvoip-release-v2-lld/rust-1.91.0/x86_64-unknown-linux-gnu
   export SCCACHE_GCS_RW_MODE=READ_WRITE
   export SCCACHE_IDLE_TIMEOUT=0
   export SCCACHE_MULTILEVEL_CHAIN=disk,gcs

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -126,7 +126,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y --no-install-recommends \
   build-essential ca-certificates cmake curl git jq libasound2-dev libopus-dev \
-  libssl-dev pkg-config protobuf-compiler
+  libssl-dev lld pkg-config protobuf-compiler
 
 if [[ "$RESOURCE_CLASS" == "gcp-interop" \
   || "$RESOURCE_CLASS" == "gcp-proxy-interop" ]]; then
@@ -150,6 +150,12 @@ curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
 sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain 1.91.0 \
   --component clippy,rustfmt
 export PATH=/root/.cargo/bin:$PATH
+command -v ld.lld >/dev/null
+ld.lld --version
+# Match the exact-candidate prebuilder. Some non-performance GCP gates compile
+# directly on their worker, so both paths must use the same versioned linker
+# contract.
+export RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 
 git clone --filter=blob:none https://github.com/eisenzopf/rvoip.git "$WORKSPACE"
 cd "$WORKSPACE"
@@ -210,7 +216,7 @@ if install_sccache; then
   export SCCACHE_CACHE_SIZE=20G
   export SCCACHE_DIR=/var/cache/rvoip-sccache
   export SCCACHE_GCS_BUCKET="$CACHE_BUCKET"
-  export SCCACHE_GCS_KEY_PREFIX=rvoip-release-v1/rust-1.91.0/x86_64-unknown-linux-gnu
+  export SCCACHE_GCS_KEY_PREFIX=rvoip-release-v2-lld/rust-1.91.0/x86_64-unknown-linux-gnu
   export SCCACHE_GCS_RW_MODE=READ_WRITE
   cache_service_account="$(curl --fail --silent --show-error \
     -H 'Metadata-Flavor: Google' \

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -264,6 +264,22 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("bundle digest mismatch", helper)
         self.assertIn("exact candidate", helper)
 
+    def test_gcp_release_builds_use_the_versioned_lld_environment(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        worker = (ROOT / "infra/release-runners/gcp-release-startup.sh").read_text()
+        builder = (
+            ROOT / "infra/release-runners/gcp-performance-prebuild-startup.sh"
+        ).read_text()
+
+        self.assertIn("prebuilt-perf-v2-lld", workflow)
+        for startup in (builder, worker):
+            with self.subTest(startup=startup):
+                self.assertIn("libssl-dev lld", startup)
+                self.assertIn("command -v ld.lld >/dev/null", startup)
+                self.assertIn("ld.lld --version", startup)
+                self.assertIn('RUSTFLAGS="-C link-arg=-fuse-ld=lld"', startup)
+                self.assertIn("rvoip-release-v2-lld", startup)
+
     def test_gcp_artifact_uploads_stream_regular_files(self) -> None:
         for relative in (
             "infra/release-runners/gcp-performance-prebuild-startup.sh",


### PR DESCRIPTION
## Problem

Exact-candidate GCP prebuilds still spend about 14 minutes on a cache-hot build. The latest focused run had a 95.3% compiler-cache hit rate but Cargo took 795 seconds, leaving GNU linking as the fixed diagnostic bottleneck.

## Fix

- install and require LLVM lld on ephemeral GCP builders and workers
- use lld for Rust link steps on both prebuilt and direct-build paths
- isolate the compiler cache under a new linker-specific prefix
- version the release environment so evidence from the old linker cannot be reused
- enforce the linker contract in workflow policy tests

## Tests

- shellcheck on both GCP startup scripts
- release workflow YAML parse
- 26 workflow policy tests
- 31 release gate tests
- 7 prebuilt-performance tests
- release gate catalog validation

## Risk

This changes only release infrastructure and build provenance. Runtime source and public APIs are unchanged. The next focused real-GCP run will measure the actual prebuild improvement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to ephemeral GCP release CI scripts, cache keys, and environment versioning; application runtime code is untouched.
> 
> **Overview**
> GCP exact-candidate Rust builds now **link with LLVM `lld`** instead of GNU `ld`, targeting the long link phase on otherwise cache-hot prebuilds.
> 
> Both **`gcp-performance-prebuild-startup.sh`** and **`gcp-release-startup.sh`** install `lld`, verify `ld.lld`, set `RUSTFLAGS="-C link-arg=-fuse-ld=lld"`, and point **sccache** at a new GCS prefix (`rvoip-release-v2-lld/...`). **`release-qualify.yml`** bumps **`RELEASE_ENVIRONMENT_ID`** to `...-prebuilt-perf-v2-lld` so prior qualification evidence from the old linker cannot be reused.
> 
> A workflow policy test locks in this versioned lld contract across the workflow and both startup scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef041b6efe9401eb87163ff8fd743a9fc381191f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->