### PR TITLE
Fix burst RSS qualification and harden Linux release runners

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -47,7 +47,8 @@ concurrency:
   cancel-in-progress: ${{ inputs.profile == 'remote-preflight' || inputs.profile == 'remote-diagnostic' }}
 
 env:
-  RELEASE_ENVIRONMENT_ID: rvoip-release-v4-rust-1.91-nextest-0.9.140-prebuilt-perf-v2-lld
+  RELEASE_ENVIRONMENT_ID: rvoip-release-v5-rust-1.91-nextest-0.9.140-prebuilt-perf-v2-lld-n2-cascade-lake
+  MIN_CPU_PLATFORM: Intel Cascade Lake
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
@@ -463,6 +464,7 @@ jobs:
               --project "$PROJECT" \
               --zone "$ZONE" \
               --machine-type n2-standard-32 \
+              --min-cpu-platform "$MIN_CPU_PLATFORM" \
               --network "$NETWORK" \
               --subnet "$SUBNET" \
               --image-family ubuntu-2404-lts-amd64 \
@@ -562,6 +564,7 @@ jobs:
                 --project "$PROJECT" \
                 --zone "$ZONE" \
                 --machine-type "$machine_type" \
+                --min-cpu-platform "$MIN_CPU_PLATFORM" \
                 --network "$NETWORK" \
                 --subnet "$SUBNET" \
                 --image-family ubuntu-2404-lts-amd64 \

--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -19,7 +19,7 @@ on:
           - remote-core
           - remote-release
       diagnostic_gates:
-        description: Comma-separated exact GCP gate IDs for remote-diagnostic
+        description: Comma-separated exact release or preflight GCP gate IDs for remote-diagnostic
         required: false
         type: string
       first_candidate:

--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -542,6 +542,7 @@ jobs:
           RUNNER_SERVICE_ACCOUNT: ${{ vars.RVOIP_GCP_RUNNER_SERVICE_ACCOUNT }}
           PREBUILT_URI: ${{ steps.prebuild.outputs.bundle_uri }}
           PREBUILT_SHA256: ${{ steps.prebuild.outputs.bundle_sha256 }}
+          EXTERNAL_MEMORY_DIAGNOSTICS: ${{ inputs.profile == 'remote-diagnostic' && '1' || '0' }}
         run: |
           set -euo pipefail
           mkdir -p target/gcp-controller/create-logs
@@ -574,7 +575,7 @@ jobs:
                 --shielded-vtpm \
                 --shielded-integrity-monitoring \
                 --labels rvoip-role=release-gate,managed-by=github-actions \
-                --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${shard_id},rvoip-resource-class=${resource_class},rvoip-evidence-bucket=${BUCKET},rvoip-cache-bucket=${CACHE_BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64},rvoip-prebuilt-uri=${PREBUILT_URI},rvoip-prebuilt-sha256=${PREBUILT_SHA256}" \
+                --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-shard-id=${shard_id},rvoip-resource-class=${resource_class},rvoip-evidence-bucket=${BUCKET},rvoip-cache-bucket=${CACHE_BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64},rvoip-prebuilt-uri=${PREBUILT_URI},rvoip-prebuilt-sha256=${PREBUILT_SHA256},rvoip-external-memory-diagnostics=${EXTERNAL_MEMORY_DIAGNOSTICS}" \
                 --metadata-from-file startup-script=infra/release-runners/gcp-release-startup.sh
             ) > "target/gcp-controller/create-logs/${shard_id}.log" 2>&1 &
             pids+=("$!")

--- a/crates/foundation/infra-common/Cargo.toml
+++ b/crates/foundation/infra-common/Cargo.toml
@@ -33,11 +33,7 @@ dashmap.workspace = true
 # Crate-specific dependencies
 config = "0.14"
 once_cell = "1.18.0"
-# Keep the production allocator on mimalloc's mature v2 engine. The v3 engine
-# showed delayed resident-page growth after large SIP burst teardown even when
-# every instrumented allocation had been released. Release performance gates
-# exercise this exact production allocator selection.
-mimalloc = { version = "0.1", default-features = false, features = ["v2"] }
+mimalloc = { version = "0.1", default-features = false }
 libmimalloc-sys = { version = "0.1", default-features = false, features = ["extended"], optional = true }
 anyhow = "1.0"
 tokio-util = "0.7.16"

--- a/crates/foundation/infra-common/Cargo.toml
+++ b/crates/foundation/infra-common/Cargo.toml
@@ -33,7 +33,10 @@ dashmap.workspace = true
 # Crate-specific dependencies
 config = "0.14"
 once_cell = "1.18.0"
-mimalloc = { version = "0.1", default-features = false }
+# Linux transparent huge-page promotion can commit partially used mimalloc
+# regions long after a burst has drained. Keep mimalloc's performance and
+# disable only its MADV_HUGEPAGE path so RSS follows live 4 KiB pages.
+mimalloc = { version = "0.1", default-features = false, features = ["no_thp"] }
 libmimalloc-sys = { version = "0.1", default-features = false, features = ["extended"], optional = true }
 anyhow = "1.0"
 tokio-util = "0.7.16"

--- a/crates/foundation/infra-common/Cargo.toml
+++ b/crates/foundation/infra-common/Cargo.toml
@@ -33,7 +33,11 @@ dashmap.workspace = true
 # Crate-specific dependencies
 config = "0.14"
 once_cell = "1.18.0"
-mimalloc = { version = "0.1", default-features = false }
+# Keep the production allocator on mimalloc's mature v2 engine. The v3 engine
+# showed delayed resident-page growth after large SIP burst teardown even when
+# every instrumented allocation had been released. Release performance gates
+# exercise this exact production allocator selection.
+mimalloc = { version = "0.1", default-features = false, features = ["v2"] }
 libmimalloc-sys = { version = "0.1", default-features = false, features = ["extended"], optional = true }
 anyhow = "1.0"
 tokio-util = "0.7.16"

--- a/crates/foundation/infra-common/src/memory_diagnostics.rs
+++ b/crates/foundation/infra-common/src/memory_diagnostics.rs
@@ -215,17 +215,15 @@ pub fn allocator_snapshot() -> Value {
     #[cfg(not(feature = "no-global-allocator"))]
     {
         let process = allocator_process_info();
-        let version = unsafe { libmimalloc_sys::mi_version() };
+        let stats_json = mimalloc::MiMalloc::stats_json()
+            .ok()
+            .and_then(|stats| stats.to_str().ok().map(str::to_owned))
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok());
         json!({
             "enabled": true,
             "active_allocator": active_allocator(),
-            "allocator_version": version,
             "process": process,
-            // mimalloc v2 exposes portable process counters but not the v3
-            // JSON stats API. Process counters plus the RVOIP live-object
-            // registry remain available without changing allocator behavior.
-            "stats": null,
-            "stats_unavailable_reason": "mimalloc v2 does not expose JSON statistics",
+            "stats": stats_json,
         })
     }
 }

--- a/crates/foundation/infra-common/src/memory_diagnostics.rs
+++ b/crates/foundation/infra-common/src/memory_diagnostics.rs
@@ -215,15 +215,17 @@ pub fn allocator_snapshot() -> Value {
     #[cfg(not(feature = "no-global-allocator"))]
     {
         let process = allocator_process_info();
-        let stats_json = mimalloc::MiMalloc::stats_json()
-            .ok()
-            .and_then(|stats| stats.to_str().ok().map(str::to_owned))
-            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok());
+        let version = unsafe { libmimalloc_sys::mi_version() };
         json!({
             "enabled": true,
             "active_allocator": active_allocator(),
+            "allocator_version": version,
             "process": process,
-            "stats": stats_json,
+            // mimalloc v2 exposes portable process counters but not the v3
+            // JSON stats API. Process counters plus the RVOIP live-object
+            // registry remain available without changing allocator behavior.
+            "stats": null,
+            "stats_unavailable_reason": "mimalloc v2 does not expose JSON statistics",
         })
     }
 }

--- a/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh
+++ b/crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh
@@ -6,6 +6,7 @@ WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 CRATE_DIR="${WORKSPACE_ROOT}/crates/sip/rvoip-sip"
 PERF_DIR="${RVOIP_PERF_RESULTS:-${WORKSPACE_ROOT}/target/perf-results}"
 CARGO_ARTIFACT_HELPER="${SCRIPT_DIR}/perf_cargo_artifact.py"
+LINUX_PERF_HOST_EVIDENCE="${WORKSPACE_ROOT}/scripts/release/linux_performance_host.py"
 
 export CARGO_MANIFEST_DIR="${CRATE_DIR}"
 
@@ -162,6 +163,10 @@ normalise_scenarios() {
 
 capture_host_udp_stats() {
   local path="$1"
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    python3 "${LINUX_PERF_HOST_EVIDENCE}" snapshot --output "${path}"
+    return
+  fi
   {
     echo "timestamp_epoch=$(date +%s)"
     echo "command=netstat -s -p udp"
@@ -213,6 +218,18 @@ write_host_udp_delta() {
   local before="$1"
   local after="$2"
   local out="$3"
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    local strict_args=()
+    if [[ -n "${RVOIP_RELEASE_CANDIDATE:-}" ]]; then
+      strict_args+=(--require-zero-drops)
+    fi
+    python3 "${LINUX_PERF_HOST_EVIDENCE}" delta \
+      --before "${before}" \
+      --after "${after}" \
+      --output "${out}" \
+      "${strict_args[@]}"
+    return
+  fi
   {
     echo "before=${before}"
     echo "after=${after}"

--- a/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
@@ -30,10 +30,10 @@ use support::soak::{
     endpoint_metric, endpoint_retained_total, endpoint_retention_summary,
     in_process_resource_sampler_enabled, media_receive_diagnostics, media_setup_raw_diagnostics,
     media_setup_timing_diagnostics, memory_diagnostic_interval, memory_diagnostic_summary,
-    read_required_u16_env, resource_sampling_diagnostics, round2, round4,
+    read_required_u16_env, resource_sampling_diagnostics, round2, round4, rss_window_meets_minimum,
     sample_settled_rss_window, sip_dialog_raw_diagnostics, sip_dialog_timing_diagnostics,
-    sip_udp_diagnostics, DhatProfile, EndpointRetentionSampler, MemoryDiagnosticSampler,
-    RssGrowthGate,
+    sip_udp_diagnostics, wait_for_burst_rss_quiescence, BurstRssQuiescence, DhatProfile,
+    EndpointRetentionSampler, MemoryDiagnosticSampler, RssGrowthGate,
 };
 use support::{
     CallSetupDiagnostics, LatencyHistogram, LoadProfile, ResourceSampler, ResourceSummary,
@@ -308,6 +308,10 @@ async fn perf_burst_caller() {
         );
         RssGrowthGate::resolve(&first_alice_cfg, &receiver_cfg)
     };
+    let rss_limit = scenario
+        .acceptance
+        .max_rss_growth_mb_per_hr
+        .unwrap_or(rss_gate.effective_mb_per_hr);
     let retention_drain_wait = burst_retention_drain_wait();
     let skip_audio_source = read_bool_env(SKIP_AUDIO_SOURCE_ENV);
     let call_timeout = Duration::from_secs(
@@ -422,12 +426,18 @@ async fn perf_burst_caller() {
         Some(sampler) => Some(sampler.stop().await),
         None => None,
     };
-    let (mut settled_resources, settled_observation) = if in_process_resource_sampling {
-        sample_settled_rss_window("burst_caller", scenario.acceptance.min_rss_gate_window_secs)
-            .await
+    let rss_quiescence = if in_process_resource_sampling {
+        wait_for_burst_rss_quiescence("burst_caller", rss_limit).await
     } else {
-        (ResourceSummary::empty(), Duration::ZERO)
+        BurstRssQuiescence::not_sampled(rss_limit)
     };
+    let (mut settled_resources, settled_observation) =
+        if in_process_resource_sampling && rss_quiescence.achieved {
+            sample_settled_rss_window("burst_caller", scenario.acceptance.min_rss_gate_window_secs)
+                .await
+        } else {
+            (ResourceSummary::empty(), Duration::ZERO)
+        };
     let rss = support::soak::rss_result_metrics(
         &settled_resources,
         0.0,
@@ -435,12 +445,20 @@ async fn perf_burst_caller() {
         settled_observation.as_secs_f64(),
         support::soak::RssGatePolicy::SettledFull,
     );
-    let rss_gate_enforced =
-        rss.post_drain_window_secs >= scenario.acceptance.min_rss_gate_window_secs;
-    let rss_gate_reason = if rss_gate_enforced {
+    let rss_gate_enforced = in_process_resource_sampling
+        && rss_quiescence.achieved
+        && rss_window_meets_minimum(
+            rss.post_drain_window_secs,
+            scenario.acceptance.min_rss_gate_window_secs,
+        );
+    let rss_gate_reason = if !in_process_resource_sampling {
+        "in_process_sampling_disabled"
+    } else if !rss_quiescence.achieved {
+        "rss_quiescence_not_achieved"
+    } else if rss_gate_enforced {
         "settled_window_meets_minimum"
     } else {
-        "reported_only_short_settled_window"
+        "settled_window_incomplete"
     };
     // Capture exact structural proof only after authoritative RSS sampling has
     // stopped so the proof cannot manufacture the growth it is meant to find.
@@ -582,13 +600,8 @@ async fn perf_burst_caller() {
         .result("rss_gate_window", rss.gate_window)
         .result("rss_gate_enforced", rss_gate_enforced)
         .result("rss_gate_reason", rss_gate_reason)
-        .result(
-            "rss_acceptance_limit_mb_per_hr",
-            scenario
-                .acceptance
-                .max_rss_growth_mb_per_hr
-                .unwrap_or(rss_gate.effective_mb_per_hr),
-        )
+        .result("rss_quiescence_achieved", rss_quiescence.achieved)
+        .result("rss_acceptance_limit_mb_per_hr", rss_limit)
         .result_block("rss_gate", rss_gate.to_json())
         .result("retained_objects_after_drain", retained_after_drain)
         .result(
@@ -653,6 +666,7 @@ async fn perf_burst_caller() {
                 "post_drain_window_secs": round2(rss.post_drain_window_secs),
             }),
         )
+        .diagnostic_block("rss_quiescence", rss_quiescence.to_json())
         .diagnostic_block(
             "memory_diagnostics",
             memory_diagnostic_summary(memory_series.as_ref()),
@@ -703,10 +717,6 @@ async fn perf_burst_caller() {
     drop(clients);
 
     let mut gate_failures = Vec::new();
-    let rss_limit = scenario
-        .acceptance
-        .max_rss_growth_mb_per_hr
-        .unwrap_or(rss_gate.effective_mb_per_hr);
     if asr < scenario.acceptance.min_asr {
         gate_failures.push(format!(
             "ASR {:.4} below {:.4}",
@@ -786,6 +796,18 @@ async fn perf_burst_caller() {
     if retained_after_drain > scenario.acceptance.max_retained_after_drain {
         gate_failures.push(format!(
             "caller_retained_objects_after_drain={retained_after_drain}"
+        ));
+    }
+    if in_process_resource_sampling && !rss_quiescence.achieved {
+        gate_failures.push(format!(
+            "caller RSS did not become quiescent within {} bounded probes at {:.2} MB/hr",
+            support::soak::BURST_RSS_QUIESCENCE_MAX_PROBES,
+            rss_limit,
+        ));
+    } else if in_process_resource_sampling && !rss_gate_enforced {
+        gate_failures.push(format!(
+            "caller RSS gate captured only {:.3}s of the required {:.3}s window",
+            rss.post_drain_window_secs, scenario.acceptance.min_rss_gate_window_secs,
         ));
     }
     if rss_gate_enforced && rss.gate_growth_mb_per_hr > rss_limit {

--- a/crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_burst_receiver.rs
@@ -31,8 +31,9 @@ use support::soak::{
     endpoint_metric, endpoint_retention_summary, in_process_resource_sampler_enabled,
     media_receive_diagnostics, media_setup_raw_diagnostics, media_setup_timing_diagnostics,
     memory_diagnostic_interval, memory_diagnostic_summary, read_required_u16_env,
-    resource_sampling_diagnostics, round2, sample_settled_rss_window, sip_dialog_raw_diagnostics,
-    sip_dialog_timing_diagnostics, sip_udp_diagnostics, DhatProfile, EndpointRetentionSampler,
+    resource_sampling_diagnostics, round2, rss_window_meets_minimum, sample_settled_rss_window,
+    sip_dialog_raw_diagnostics, sip_dialog_timing_diagnostics, sip_udp_diagnostics,
+    wait_for_burst_rss_quiescence, BurstRssQuiescence, DhatProfile, EndpointRetentionSampler,
     MemoryDiagnosticSampler, RssGrowthGate,
 };
 use support::{
@@ -133,6 +134,10 @@ async fn perf_burst_receiver() {
         BURST_ALICE_MEDIA_END,
     );
     let rss_gate = RssGrowthGate::resolve(&caller_cfg, &receiver_cfg);
+    let rss_limit = scenario
+        .acceptance
+        .max_rss_growth_mb_per_hr
+        .unwrap_or(rss_gate.effective_mb_per_hr);
     let retention_drain_wait = burst_retention_drain_wait();
 
     let received_frames = Arc::new(AtomicU64::new(0));
@@ -209,15 +214,21 @@ async fn perf_burst_receiver() {
         Some(sampler) => Some(sampler.stop().await),
         None => None,
     };
-    let (mut settled_resources, settled_observation) = if in_process_resource_sampling {
-        sample_settled_rss_window(
-            "burst_receiver",
-            scenario.acceptance.min_rss_gate_window_secs,
-        )
-        .await
+    let rss_quiescence = if in_process_resource_sampling {
+        wait_for_burst_rss_quiescence("burst_receiver", rss_limit).await
     } else {
-        (ResourceSummary::empty(), Duration::ZERO)
+        BurstRssQuiescence::not_sampled(rss_limit)
     };
+    let (mut settled_resources, settled_observation) =
+        if in_process_resource_sampling && rss_quiescence.achieved {
+            sample_settled_rss_window(
+                "burst_receiver",
+                scenario.acceptance.min_rss_gate_window_secs,
+            )
+            .await
+        } else {
+            (ResourceSummary::empty(), Duration::ZERO)
+        };
     let rss = support::soak::rss_result_metrics(
         &settled_resources,
         0.0,
@@ -225,12 +236,20 @@ async fn perf_burst_receiver() {
         settled_observation.as_secs_f64(),
         support::soak::RssGatePolicy::SettledFull,
     );
-    let rss_gate_enforced =
-        rss.post_drain_window_secs >= scenario.acceptance.min_rss_gate_window_secs;
-    let rss_gate_reason = if rss_gate_enforced {
+    let rss_gate_enforced = in_process_resource_sampling
+        && rss_quiescence.achieved
+        && rss_window_meets_minimum(
+            rss.post_drain_window_secs,
+            scenario.acceptance.min_rss_gate_window_secs,
+        );
+    let rss_gate_reason = if !in_process_resource_sampling {
+        "in_process_sampling_disabled"
+    } else if !rss_quiescence.achieved {
+        "rss_quiescence_not_achieved"
+    } else if rss_gate_enforced {
         "settled_window_meets_minimum"
     } else {
-        "reported_only_short_settled_window"
+        "settled_window_incomplete"
     };
     // Capture exact structural proof only after authoritative RSS sampling has
     // stopped so the proof cannot manufacture the growth it is meant to find.
@@ -305,13 +324,8 @@ async fn perf_burst_receiver() {
         .result("rss_gate_window", rss.gate_window)
         .result("rss_gate_enforced", rss_gate_enforced)
         .result("rss_gate_reason", rss_gate_reason)
-        .result(
-            "rss_acceptance_limit_mb_per_hr",
-            scenario
-                .acceptance
-                .max_rss_growth_mb_per_hr
-                .unwrap_or(rss_gate.effective_mb_per_hr),
-        )
+        .result("rss_quiescence_achieved", rss_quiescence.achieved)
+        .result("rss_acceptance_limit_mb_per_hr", rss_limit)
         .result_block("rss_gate", rss_gate.to_json())
         .result("retained_objects_after_drain", retained_after_drain)
         .result(
@@ -342,6 +356,7 @@ async fn perf_burst_receiver() {
                 "final_retained_objects": retained_after_drain,
             }),
         )
+        .diagnostic_block("rss_quiescence", rss_quiescence.to_json())
         .diagnostic_block(
             "rss_windows",
             json!({
@@ -402,12 +417,20 @@ async fn perf_burst_receiver() {
     let _ = tokio::time::timeout(Duration::from_secs(3), receiver.task).await;
 
     let mut gate_failures = Vec::new();
-    let rss_limit = scenario
-        .acceptance
-        .max_rss_growth_mb_per_hr
-        .unwrap_or(rss_gate.effective_mb_per_hr);
     if !stop_seen {
         gate_failures.push("receiver stop file was not observed".to_string());
+    }
+    if in_process_resource_sampling && !rss_quiescence.achieved {
+        gate_failures.push(format!(
+            "receiver RSS did not become quiescent within {} bounded probes at {:.2} MB/hr",
+            support::soak::BURST_RSS_QUIESCENCE_MAX_PROBES,
+            rss_limit,
+        ));
+    } else if in_process_resource_sampling && !rss_gate_enforced {
+        gate_failures.push(format!(
+            "receiver RSS gate captured only {:.3}s of the required {:.3}s window",
+            rss.post_drain_window_secs, scenario.acceptance.min_rss_gate_window_secs,
+        ));
     }
     if rss_gate_enforced && rss.gate_growth_mb_per_hr > rss_limit {
         gate_failures.push(format!(

--- a/crates/sip/rvoip-sip/tests/perf/support/sampler.rs
+++ b/crates/sip/rvoip-sip/tests/perf/support/sampler.rs
@@ -269,6 +269,10 @@ impl ResourceSampler {
     }
 
     fn start_inner(interval: Duration, samples_path: Option<PathBuf>) -> Self {
+        assert!(
+            !interval.is_zero(),
+            "resource sample interval must be non-zero"
+        );
         let samples: Arc<Mutex<Vec<ResourceSample>>> = Arc::new(Mutex::new(Vec::new()));
         let stop = Arc::new(AtomicBool::new(false));
         let samples_task = Arc::clone(&samples);
@@ -278,7 +282,13 @@ impl ResourceSampler {
         let pid = Pid::from_u32(std::process::id());
         let task_samples_path = samples_path.clone();
 
-        let task = tokio::spawn(async move {
+        // Keep procfs reads and JSONL writes on one dedicated OS thread. A
+        // movable async task can resume on a different Tokio worker after
+        // every tick; under mimalloc that touches another thread-local heap
+        // and can make the observer itself look like sustained process RSS
+        // growth. `spawn_blocking` gives this long-lived sampler one stable
+        // worker while retaining the existing async join handle.
+        let task = tokio::task::spawn_blocking(move || {
             #[cfg(not(target_os = "linux"))]
             let mut sys = System::new();
             #[cfg(target_os = "linux")]
@@ -292,10 +302,7 @@ impl ResourceSampler {
                 }
                 BufWriter::new(File::create(path).expect("create resource sample JSONL"))
             });
-            let mut ticker = tokio::time::interval(interval);
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
-                ticker.tick().await;
                 // Refresh CPU + memory for our PID. Both backends report the
                 // first CPU reading as 0 because there is no preceding sample;
                 // it is retained and excluded from the final CPU average.
@@ -329,6 +336,7 @@ impl ResourceSampler {
                 if stop_task.load(Ordering::Relaxed) {
                     break;
                 }
+                std::thread::sleep(interval);
             }
         });
 
@@ -694,6 +702,31 @@ mod tests {
         assert_eq!(summary.samples.len(), summary.sample_count);
         assert_eq!(summary.samples_path.as_deref(), Some(path.as_path()));
         std::fs::remove_file(path).expect("remove resource sample test output");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sampler_progress_is_independent_of_the_application_runtime() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "rvoip-dedicated-resource-samples-{}-{unique}.jsonl",
+            std::process::id()
+        ));
+        let sampler = ResourceSampler::start_with_output(Duration::from_millis(10), path.clone());
+
+        // Deliberately occupy the only Tokio worker. The resource sampler must
+        // continue collecting on its dedicated blocking worker.
+        std::thread::sleep(Duration::from_millis(80));
+
+        let summary = sampler.stop().await;
+        assert!(
+            summary.sample_count >= 3,
+            "dedicated sampler stalled with the application runtime: {} samples",
+            summary.sample_count
+        );
+        std::fs::remove_file(path).expect("remove dedicated sampler test output");
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/sip/rvoip-sip/tests/perf/support/soak.rs
+++ b/crates/sip/rvoip-sip/tests/perf/support/soak.rs
@@ -28,6 +28,9 @@ pub const DEFAULT_RETENTION_DRAIN_WAIT_SECS: usize = MIN_RETENTION_DRAIN_WAIT_SE
 pub const BURST_RSS_DIAGNOSTIC_SETTLE_SECS: usize = 5;
 pub const BURST_RSS_QUIET_TAIL_SECS: usize = 60;
 pub const BURST_SETTLED_RSS_SAMPLE_INTERVAL_SECS: u64 = 5;
+pub const BURST_RSS_QUIESCENCE_WINDOW_SECS: u64 = 60;
+pub const BURST_RSS_QUIESCENCE_MAX_PROBES: usize = 5;
+pub const RSS_WINDOW_COVERAGE_TOLERANCE_SECS: f64 = 0.5;
 pub const MIN_BURST_RETENTION_DRAIN_WAIT_SECS: usize =
     MIN_RETENTION_DRAIN_WAIT_SECS + BURST_RSS_DIAGNOSTIC_SETTLE_SECS + BURST_RSS_QUIET_TAIL_SECS;
 pub const LONG_SOAK_ACTIVE_WINDOW_SECS: u64 = 1_200;
@@ -116,6 +119,128 @@ pub fn burst_retention_periodic_limit(
     maximum_hold: Duration,
 ) -> Duration {
     Duration::from_secs(active_duration_secs).saturating_add(maximum_hold)
+}
+
+#[derive(Debug)]
+pub struct BurstRssQuiescence {
+    pub attempted: bool,
+    pub achieved: bool,
+    pub max_growth_mb_per_hr: f64,
+    pub probes: Vec<Value>,
+}
+
+impl BurstRssQuiescence {
+    pub fn not_sampled(max_growth_mb_per_hr: f64) -> Self {
+        Self {
+            attempted: false,
+            achieved: false,
+            max_growth_mb_per_hr,
+            probes: Vec::new(),
+        }
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "attempted": self.attempted,
+            "achieved": self.achieved,
+            "max_growth_mb_per_hr": round2(self.max_growth_mb_per_hr),
+            "probe_window_secs": BURST_RSS_QUIESCENCE_WINDOW_SECS,
+            "max_probes": BURST_RSS_QUIESCENCE_MAX_PROBES,
+            "probes": self.probes.clone(),
+        })
+    }
+}
+
+pub fn rss_window_meets_minimum(observed_secs: f64, minimum_secs: f64) -> bool {
+    observed_secs.is_finite()
+        && minimum_secs.is_finite()
+        && observed_secs + RSS_WINDOW_COVERAGE_TOLERANCE_SECS >= minimum_secs
+}
+
+pub fn burst_rss_probe_is_quiescent(
+    observed_secs: f64,
+    minimum_secs: f64,
+    growth_mb_per_hr: f64,
+    max_growth_mb_per_hr: f64,
+) -> bool {
+    growth_mb_per_hr.is_finite()
+        && max_growth_mb_per_hr.is_finite()
+        && rss_window_meets_minimum(observed_secs, minimum_secs)
+        && growth_mb_per_hr <= max_growth_mb_per_hr
+}
+
+/// Require the process to demonstrate a quiet RSS interval before opening the
+/// independent authoritative gate window. This is a bounded precondition, not
+/// a retry of the gate: a process that keeps growing exhausts the probes and
+/// fails without receiving a new authoritative window.
+pub async fn wait_for_burst_rss_quiescence(
+    role: &'static str,
+    max_growth_mb_per_hr: f64,
+) -> BurstRssQuiescence {
+    assert!(
+        max_growth_mb_per_hr.is_finite() && max_growth_mb_per_hr >= 0.0,
+        "burst RSS quiescence limit must be finite and non-negative"
+    );
+
+    let minimum_window_secs = BURST_RSS_QUIESCENCE_WINDOW_SECS as f64;
+    let observation = Duration::from_secs(
+        BURST_RSS_QUIESCENCE_WINDOW_SECS.saturating_add(BURST_SETTLED_RSS_SAMPLE_INTERVAL_SECS),
+    );
+    let mut probes = Vec::with_capacity(BURST_RSS_QUIESCENCE_MAX_PROBES);
+
+    for attempt in 1..=BURST_RSS_QUIESCENCE_MAX_PROBES {
+        let sample_kind = format!("rss_quiescence_probe_{attempt}");
+        let sampler = ResourceSampler::start_with_output(
+            Duration::from_secs(BURST_SETTLED_RSS_SAMPLE_INTERVAL_SECS),
+            diagnostic_sample_path(role, &sample_kind),
+        );
+        tokio::time::sleep(observation).await;
+        let mut resources = sampler.stop().await;
+        let metrics = rss_result_metrics(
+            &resources,
+            0.0,
+            0.0,
+            observation.as_secs_f64(),
+            RssGatePolicy::SettledFull,
+        );
+        let quiescent = burst_rss_probe_is_quiescent(
+            metrics.post_drain_window_secs,
+            minimum_window_secs,
+            metrics.gate_growth_mb_per_hr,
+            max_growth_mb_per_hr,
+        );
+        probes.push(json!({
+            "attempt": attempt,
+            "observation_secs": round2(observation.as_secs_f64()),
+            "sample_count": resources.sample_count,
+            "samples_path": resources.samples_path.as_ref().map(|path| path.display().to_string()),
+            "baseline_rss_mb": round2(resources.baseline_rss_mb),
+            "peak_rss_mb": round2(resources.peak_rss_mb),
+            "window_secs": round2(metrics.post_drain_window_secs),
+            "growth_mb_per_hr": round2(metrics.gate_growth_mb_per_hr),
+            "complete": rss_window_meets_minimum(
+                metrics.post_drain_window_secs,
+                minimum_window_secs,
+            ),
+            "quiescent": quiescent,
+        }));
+        resources.samples.clear();
+        if quiescent {
+            return BurstRssQuiescence {
+                attempted: true,
+                achieved: true,
+                max_growth_mb_per_hr,
+                probes,
+            };
+        }
+    }
+
+    BurstRssQuiescence {
+        attempted: true,
+        achieved: false,
+        max_growth_mb_per_hr,
+        probes,
+    }
 }
 
 /// Measure RSS after teardown and after periodic structural diagnostics have
@@ -2720,5 +2845,26 @@ fn ratio(numerator: u64, denominator: u64) -> f64 {
         0.0
     } else {
         numerator as f64 / denominator as f64
+    }
+}
+
+#[cfg(test)]
+mod rss_quiescence_tests {
+    use super::*;
+
+    #[test]
+    fn rss_window_coverage_tolerates_sampler_jitter_but_not_a_missing_sample() {
+        assert!(rss_window_meets_minimum(119.999_661_976, 120.0));
+        assert!(!rss_window_meets_minimum(119.4, 120.0));
+        assert!(!rss_window_meets_minimum(f64::NAN, 120.0));
+    }
+
+    #[test]
+    fn burst_quiescence_fails_closed_for_growth_or_unknown_evidence() {
+        assert!(burst_rss_probe_is_quiescent(60.0, 60.0, -3.0, 15.0));
+        assert!(burst_rss_probe_is_quiescent(59.999, 60.0, 15.0, 15.0));
+        assert!(!burst_rss_probe_is_quiescent(60.0, 60.0, 15.01, 15.0));
+        assert!(!burst_rss_probe_is_quiescent(55.0, 60.0, 0.0, 15.0));
+        assert!(!burst_rss_probe_is_quiescent(60.0, 60.0, f64::NAN, 15.0,));
     }
 }

--- a/infra/release-runners/README.md
+++ b/infra/release-runners/README.md
@@ -42,6 +42,16 @@ candidate SHA and gate list, uploads an immutable result and evidence archive,
 shuts down, and is deleted with its auto-delete disk. Controller and follow-up
 sweep cleanup both run on failure; there is no idle release fleet.
 
+Release builders and workers use N2 machines with an `Intel Cascade Lake`
+minimum CPU platform. Every worker keeps a 262,144 descriptor limit, sets
+64 MiB receive and send UDP ceilings, and proves an 8 MiB SIP socket-buffer
+request with `getsockopt` before load. Performance evidence records the actual
+CPU model, process limits, file-table state, port ranges, UDP memory limits,
+pressure/swap state, and Linux `/proc` UDP, softnet, socket, and loopback-drop
+counters. Release burst gates fail closed when mandatory Linux counters are
+missing or when receive-buffer, send-buffer, softnet, or loopback drops rise
+during the measured scenario.
+
 For diagnostics and `remote-release` runs that select executable performance
 gates, the controller first creates one ephemeral `n2-standard-32` builder. It
 compiles the exact candidate once, packages only the selected test executables,

--- a/infra/release-runners/README.md
+++ b/infra/release-runners/README.md
@@ -29,11 +29,13 @@ before a full qualification begins. It is non-publishing and cannot qualify a
 release.
 
 Its `remote-diagnostic` profile accepts only named executable GCP gates already
-present in `remote-release`. It expands their dependency closure and uses the
-same machines, startup path, commands, workloads, thresholds, immutable
-evidence, and cleanup. It cannot publish or qualify a release. A later complete
-qualification can combine exact receipts from up to five prior runs, avoiding
-a full rerun after a corrected or transient isolated failure.
+present in `remote-release` or `remote-preflight`. It expands their dependency
+closure and uses the same machines, startup path, commands, workloads,
+thresholds, immutable evidence, and cleanup. This allows one infrastructure
+shape to be checked without provisioning the complete preflight fleet. It
+cannot publish or qualify a release. A later complete qualification can combine
+exact receipts from up to five prior runs, avoiding a full rerun after a
+corrected or transient isolated failure.
 
 For both preflight and the complete `remote-release` profile, a single GitHub
 controller launches every duration-balanced GCP shard concurrently rather than

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -24,6 +24,9 @@ PREBUILT_SHA256="$(metadata rvoip-prebuilt-sha256)"
 EXTERNAL_MEMORY_DIAGNOSTICS="$(
   metadata rvoip-external-memory-diagnostics 2>/dev/null || printf '0'
 )"
+MIMALLOC_ALLOW_THP_OVERRIDE="$(
+  metadata rvoip-mimalloc-allow-thp 2>/dev/null || true
+)"
 WORKSPACE=/opt/rvoip
 EVIDENCE=/tmp/release-shard
 ARCHIVE=/tmp/release-shard.tar.gz
@@ -135,6 +138,7 @@ capture_host_memory_policy() {
   local path
   {
     echo "captured_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "mimalloc_allow_thp_override=${MIMALLOC_ALLOW_THP_OVERRIDE:-unset}"
     uname -a
     for path in \
       /sys/kernel/mm/transparent_hugepage/enabled \
@@ -352,6 +356,18 @@ export RVOIP_RELEASE_GATES="$GATES"
 export RVOIP_RELEASE_RESOURCE_CLASS="$RESOURCE_CLASS"
 export RVOIP_RELEASE_RUN_ID="$RUN_ID"
 export RVOIP_RELEASE_SHARD_ID="$SHARD_ID"
+
+case "$MIMALLOC_ALLOW_THP_OVERRIDE" in
+  "") ;;
+  0|1)
+    export MIMALLOC_ALLOW_THP="$MIMALLOC_ALLOW_THP_OVERRIDE"
+    echo "mimalloc THP override set to ${MIMALLOC_ALLOW_THP} for diagnostic A/B"
+    ;;
+  *)
+    echo "rvoip-mimalloc-allow-thp must be 0, 1, or unset" >&2
+    exit 1
+    ;;
+esac
 
 if [[ "$EXTERNAL_MEMORY_DIAGNOSTICS" == "1" ]]; then
   capture_host_memory_policy

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -166,10 +166,19 @@ test "$(git rev-parse HEAD)" = "$CANDIDATE"
 prebuilt_gate_ids="$(python3 scripts/release/prebuilt_performance.py select-gates \
   --catalog scripts/release/gates.json --gates "$GATES")"
 if [[ -n "$prebuilt_gate_ids" ]]; then
-  expected_prefix="gs://${BUCKET}/release/${RUN_ID}/prebuild/"
-  if [[ "$PREBUILT_URI" != "${expected_prefix}"* \
-    || ! "$PREBUILT_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  run_bundle_prefix="gs://${BUCKET}/release/${RUN_ID}/prebuild/"
+  cache_bundle_prefix="gs://${BUCKET}/release-cache/performance-prebuilt-v1/"
+  if [[ ! "$PREBUILT_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
     echo "performance worker lacks an exact-run prebuilt bundle" >&2
+    exit 1
+  fi
+  if [[ "$PREBUILT_URI" == "${run_bundle_prefix}"* ]]; then
+    : # Compatibility with run-scoped bundles created before cache rollout.
+  elif [[ "$PREBUILT_URI" == "${cache_bundle_prefix}"* \
+    && "$PREBUILT_URI" == *"/bundles/${PREBUILT_SHA256}.tar.gz" ]]; then
+    : # Verified controller cache hits are content-addressed by this digest.
+  else
+    echo "performance worker lacks an exact-run or content-addressed cached bundle" >&2
     exit 1
   fi
   prebuilt_object="${PREBUILT_URI#"gs://${BUCKET}/"}"

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -21,12 +21,16 @@ GATES="$(metadata rvoip-gates-b64 | base64 --decode)"
 ENVIRONMENT_ID="$(metadata rvoip-environment-b64 | base64 --decode)"
 PREBUILT_URI="$(metadata rvoip-prebuilt-uri)"
 PREBUILT_SHA256="$(metadata rvoip-prebuilt-sha256)"
+EXTERNAL_MEMORY_DIAGNOSTICS="$(
+  metadata rvoip-external-memory-diagnostics 2>/dev/null || printf '0'
+)"
 WORKSPACE=/opt/rvoip
 EVIDENCE=/tmp/release-shard
 ARCHIVE=/tmp/release-shard.tar.gz
 RESULT=/tmp/result.json
 STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 START_SECONDS="$(date +%s)"
+EXTERNAL_MEMORY_SAMPLER_PID=""
 
 upload() {
   local source="$1"
@@ -64,6 +68,11 @@ finish() {
   local exit_code=$?
   local ended_at duration archive_sha
   trap - EXIT
+  if [[ -n "$EXTERNAL_MEMORY_SAMPLER_PID" ]]; then
+    kill "$EXTERNAL_MEMORY_SAMPLER_PID" >/dev/null 2>&1 || true
+    wait "$EXTERNAL_MEMORY_SAMPLER_PID" 2>/dev/null || true
+    EXTERNAL_MEMORY_SAMPLER_PID=""
+  fi
   ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   duration="$(( $(date +%s) - START_SECONDS ))"
   archive_sha=""
@@ -121,6 +130,81 @@ PY
   exit "$exit_code"
 }
 trap finish EXIT
+
+capture_host_memory_policy() {
+  local path
+  {
+    echo "captured_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    uname -a
+    for path in \
+      /sys/kernel/mm/transparent_hugepage/enabled \
+      /sys/kernel/mm/transparent_hugepage/defrag \
+      /sys/kernel/mm/transparent_hugepage/shmem_enabled \
+      /sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs \
+      /sys/kernel/mm/transparent_hugepage/khugepaged/alloc_sleep_millisecs \
+      /sys/kernel/mm/transparent_hugepage/khugepaged/pages_to_scan; do
+      if [[ -r "$path" ]]; then
+        printf '%s=' "$path"
+        cat "$path"
+      fi
+    done
+  } > "$EVIDENCE/_host-memory-policy.txt"
+}
+
+capture_external_memory() {
+  local output="$EVIDENCE/_external-process-memory.tsv"
+  local process pid cmdline role process_memory thp_memory now uptime
+  printf '%s\n' \
+    $'captured_at_utc\tuptime_secs\tpid\trole\trss_kb\tpss_kb\tpss_anon_kb\tpss_file_kb\tprivate_clean_kb\tprivate_dirty_kb\tanonymous_kb\tlazy_free_kb\tanon_huge_pages_kb\tswap_kb\tthp_collapse_alloc\tthp_collapse_alloc_failed\tthp_fault_alloc\tthp_fault_fallback\tthp_split_page\tthp_deferred_split_page\tthp_split_pmd' \
+    > "$output"
+  while true; do
+    now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    uptime="$(awk '{print $1}' /proc/uptime)"
+    thp_memory="$(awk '
+      BEGIN { names["thp_collapse_alloc"]; names["thp_collapse_alloc_failed"];
+              names["thp_fault_alloc"]; names["thp_fault_fallback"];
+              names["thp_split_page"]; names["thp_deferred_split_page"];
+              names["thp_split_pmd"] }
+      $1 in names { value[$1] = $2 }
+      END { printf "%s\t%s\t%s\t%s\t%s\t%s\t%s",
+        value["thp_collapse_alloc"] + 0,
+        value["thp_collapse_alloc_failed"] + 0,
+        value["thp_fault_alloc"] + 0,
+        value["thp_fault_fallback"] + 0,
+        value["thp_split_page"] + 0,
+        value["thp_deferred_split_page"] + 0,
+        value["thp_split_pmd"] + 0 }
+    ' /proc/vmstat)"
+    for process in /proc/[0-9]*; do
+      pid="${process##*/}"
+      [[ -r "$process/cmdline" && -r "$process/smaps_rollup" ]] || continue
+      cmdline="$(tr '\0' ' ' < "$process/cmdline" 2>/dev/null || true)"
+      case "$cmdline" in
+        *perf_burst_receiver*) role=burst_receiver ;;
+        *perf_burst_caller*) role=burst_caller ;;
+        *perf_soak_receiver*) role=soak_receiver ;;
+        *perf_soak_caller*) role=soak_caller ;;
+        *) continue ;;
+      esac
+      process_memory="$(awk '
+        /^(Rss|Pss|Pss_Anon|Pss_File|Private_Clean|Private_Dirty|Anonymous|LazyFree|AnonHugePages|Swap):/ {
+          name=$1; sub(/:$/, "", name); value[name]=$2
+        }
+        END { printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
+          value["Rss"] + 0, value["Pss"] + 0, value["Pss_Anon"] + 0,
+          value["Pss_File"] + 0, value["Private_Clean"] + 0,
+          value["Private_Dirty"] + 0, value["Anonymous"] + 0,
+          value["LazyFree"] + 0, value["AnonHugePages"] + 0,
+          value["Swap"] + 0 }
+      ' "$process/smaps_rollup" 2>/dev/null || true)"
+      [[ -n "$process_memory" ]] || continue
+      printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$now" "$uptime" "$pid" "$role" "$process_memory" "$thp_memory" \
+        >> "$output"
+    done
+    sleep 5
+  done
+}
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
@@ -269,8 +353,25 @@ export RVOIP_RELEASE_RESOURCE_CLASS="$RESOURCE_CLASS"
 export RVOIP_RELEASE_RUN_ID="$RUN_ID"
 export RVOIP_RELEASE_SHARD_ID="$SHARD_ID"
 
+if [[ "$EXTERNAL_MEMORY_DIAGNOSTICS" == "1" ]]; then
+  capture_host_memory_policy
+  capture_external_memory &
+  EXTERNAL_MEMORY_SAMPLER_PID="$!"
+  echo "external process memory and THP diagnostics enabled"
+fi
+
+set +e
 python3 scripts/release/gates.py run-shard \
   --candidate "$CANDIDATE" \
   --environment-id "$ENVIRONMENT_ID" \
   --gates "$GATES" \
   --output "$EVIDENCE"
+SHARD_STATUS=$?
+set -e
+
+if [[ -n "$EXTERNAL_MEMORY_SAMPLER_PID" ]]; then
+  kill "$EXTERNAL_MEMORY_SAMPLER_PID" >/dev/null 2>&1 || true
+  wait "$EXTERNAL_MEMORY_SAMPLER_PID" 2>/dev/null || true
+  EXTERNAL_MEMORY_SAMPLER_PID=""
+fi
+exit "$SHARD_STATUS"

--- a/infra/release-runners/gcp-release-startup.sh
+++ b/infra/release-runners/gcp-release-startup.sh
@@ -344,11 +344,13 @@ ulimit -n 262144
 test "$(ulimit -n)" -ge 262144
 
 # Stateful proxy qualification captures a dense packet burst on both the
-# loopback and aggregate interfaces.  Raise the receive ceiling before
-# tcpdump requests its explicit 32 MiB capture buffer; otherwise a healthy
-# capacity-overload run can lose evidence in the kernel and fail spuriously.
+# loopback and aggregate interfaces, while SIP performance recipes request
+# 8 MiB in both directions. Keep symmetric ceilings so the kernel can grant
+# every declared receive and send request; the preflight reads both back.
 sysctl -w net.core.rmem_max=67108864
+sysctl -w net.core.wmem_max=67108864
 test "$(sysctl -n net.core.rmem_max)" -ge 67108864
+test "$(sysctl -n net.core.wmem_max)" -ge 67108864
 
 export RVOIP_RELEASE_CANDIDATE="$CANDIDATE"
 export RVOIP_RELEASE_ENVIRONMENT_ID="$ENVIRONMENT_ID"

--- a/infra/release-runners/release-infrastructure-preflight.sh
+++ b/infra/release-runners/release-infrastructure-preflight.sh
@@ -35,14 +35,44 @@ test -z "${CARGO_REGISTRY_TOKEN:-}"
 test -z "${CRATES_IO_TOKEN:-}"
 
 ACTUAL_VCPUS="$(nproc)"
-NOFILE_LIMIT="$(ulimit -n)"
+NOFILE_SOFT="$(ulimit -Sn)"
+NOFILE_HARD="$(ulimit -Hn)"
 MEMORY_KIB="$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)"
+SWAP_TOTAL_KIB="$(awk '/^SwapTotal:/ { print $2 }' /proc/meminfo)"
 DISK_BYTES="$(df --output=size -B1 / | tail -n 1 | tr -d ' ')"
+FS_NR_OPEN="$(sysctl -n fs.nr_open)"
+FS_FILE_MAX="$(sysctl -n fs.file-max)"
+FS_FILE_NR="$(sysctl -n fs.file-nr)"
+IP_LOCAL_PORT_RANGE="$(sysctl -n net.ipv4.ip_local_port_range)"
+IP_LOCAL_RESERVED_PORTS="$(sysctl -n net.ipv4.ip_local_reserved_ports)"
+RMEM_DEFAULT="$(sysctl -n net.core.rmem_default)"
+RMEM_MAX="$(sysctl -n net.core.rmem_max)"
+WMEM_DEFAULT="$(sysctl -n net.core.wmem_default)"
+WMEM_MAX="$(sysctl -n net.core.wmem_max)"
+UDP_MEM="$(sysctl -n net.ipv4.udp_mem)"
+CPU_MODEL="$(awk -F: '/^model name/ { sub(/^[ \t]+/, "", $2); print $2; exit }' /proc/cpuinfo)"
 
 test "$ACTUAL_VCPUS" -ge "$EXPECTED_VCPUS"
-test "$NOFILE_LIMIT" -ge 262144
+test "$NOFILE_SOFT" -ge 262144
+test "$NOFILE_HARD" -ge "$NOFILE_SOFT"
+test "$FS_NR_OPEN" -ge "$NOFILE_HARD"
 test "$MEMORY_KIB" -ge "$(( EXPECTED_MEMORY_GIB * 1024 * 1024 ))"
 test "$DISK_BYTES" -ge "$(( EXPECTED_DISK_GIB * 1024 * 1024 * 1024 ))"
+test "$RMEM_MAX" -ge 8388608
+test "$WMEM_MAX" -ge 8388608
+test -n "$CPU_MODEL"
+
+for telemetry in \
+  /proc/net/snmp \
+  /proc/net/sockstat \
+  /proc/net/softnet_stat \
+  /proc/pressure/cpu \
+  /proc/pressure/memory \
+  /proc/pressure/io \
+  /sys/class/net/lo/statistics/rx_dropped \
+  /sys/class/net/lo/statistics/tx_dropped; do
+  test -r "$telemetry"
+done
 
 for program in cargo cmake git jq pkg-config protoc rustc; do
   command -v "$program" >/dev/null
@@ -64,6 +94,54 @@ fi
 mkdir -p "$ARTIFACT_DIR"
 cargo metadata --locked --no-deps --format-version 1 \
   > "$ARTIFACT_DIR/cargo-metadata.json"
+
+# Preserve the host contract independently of the summarized JSON below.
+cat /proc/self/limits > "$ARTIFACT_DIR/process-limits.txt"
+cat /proc/meminfo > "$ARTIFACT_DIR/meminfo.txt"
+cat /proc/stat > "$ARTIFACT_DIR/proc-stat.txt"
+cat /proc/pressure/cpu > "$ARTIFACT_DIR/pressure-cpu.txt"
+cat /proc/pressure/memory > "$ARTIFACT_DIR/pressure-memory.txt"
+cat /proc/pressure/io > "$ARTIFACT_DIR/pressure-io.txt"
+lscpu > "$ARTIFACT_DIR/lscpu.txt"
+python3 scripts/release/linux_performance_host.py snapshot \
+  --output "$ARTIFACT_DIR/linux-udp-snapshot.txt"
+
+# Prove that this kernel grants the largest current SIP recipe request. Linux
+# reports doubled values for SO_RCVBUF/SO_SNDBUF accounting; the pass condition
+# intentionally checks only that the returned capacity is not below the
+# application request.
+python3 - "$ARTIFACT_DIR/socket-buffer-probe.json" <<'PY'
+import json
+import socket
+import sys
+
+requested = 8_388_608
+probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, requested)
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, requested)
+    effective_receive = probe.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+    effective_send = probe.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF)
+finally:
+    probe.close()
+if effective_receive < requested or effective_send < requested:
+    raise SystemExit(
+        "kernel did not grant required SIP UDP buffers: "
+        f"requested={requested} receive={effective_receive} send={effective_send}"
+    )
+payload = {
+    "schema": "rvoip-linux-socket-buffer-probe-v1",
+    "requested_receive_bytes": requested,
+    "requested_send_bytes": requested,
+    "effective_receive_bytes": effective_receive,
+    "effective_send_bytes": effective_send,
+    "linux_returned_value_includes_accounting_overhead": True,
+    "status": "PASS",
+}
+with open(sys.argv[1], "w", encoding="utf-8") as output:
+    json.dump(payload, output, indent=2, sort_keys=True)
+    output.write("\n")
+PY
 
 python3 - "$ARTIFACT_DIR/cargo-metadata.json" <<'PY'
 import json
@@ -100,27 +178,78 @@ python3 - \
   "$ARTIFACT_DIR/system.json" \
   "$EXPECTED_RESOURCE" \
   "$ACTUAL_VCPUS" \
-  "$NOFILE_LIMIT" \
+  "$NOFILE_SOFT" \
+  "$NOFILE_HARD" \
   "$MEMORY_KIB" \
-  "$DISK_BYTES" <<'PY'
+  "$SWAP_TOTAL_KIB" \
+  "$DISK_BYTES" \
+  "$FS_NR_OPEN" \
+  "$FS_FILE_MAX" \
+  "$FS_FILE_NR" \
+  "$IP_LOCAL_PORT_RANGE" \
+  "$IP_LOCAL_RESERVED_PORTS" \
+  "$RMEM_DEFAULT" \
+  "$RMEM_MAX" \
+  "$WMEM_DEFAULT" \
+  "$WMEM_MAX" \
+  "$UDP_MEM" \
+  "$CPU_MODEL" <<'PY'
 import json
 import os
 import platform
 import sys
 
-path, resource, vcpus, nofile, memory_kib, disk_bytes = sys.argv[1:]
+(
+    path,
+    resource,
+    vcpus,
+    nofile_soft,
+    nofile_hard,
+    memory_kib,
+    swap_total_kib,
+    disk_bytes,
+    fs_nr_open,
+    fs_file_max,
+    fs_file_nr,
+    ip_local_port_range,
+    ip_local_reserved_ports,
+    rmem_default,
+    rmem_max,
+    wmem_default,
+    wmem_max,
+    udp_mem,
+    cpu_model,
+) = sys.argv[1:]
+with open(os.path.join(os.path.dirname(path), "socket-buffer-probe.json"), encoding="utf-8") as source:
+    socket_buffer_probe = json.load(source)
 payload = {
     "schema": "rvoip-release-infrastructure-preflight-v1",
     "candidate_sha": os.environ["RVOIP_RELEASE_CANDIDATE"],
+    "cpu_model": cpu_model,
     "gate_ids": sorted(filter(None, os.environ["RVOIP_RELEASE_GATES"].split(","))),
+    "fs_file_max": int(fs_file_max),
+    "fs_file_nr": [int(value) for value in fs_file_nr.split()],
+    "fs_nr_open": int(fs_nr_open),
+    "ip_local_port_range": [int(value) for value in ip_local_port_range.split()],
+    "ip_local_reserved_ports": ip_local_reserved_ports,
     "kernel": platform.release(),
     "memory_kib": int(memory_kib),
-    "nofile_limit": int(nofile),
+    "nofile_hard": int(nofile_hard),
+    "nofile_limit": int(nofile_soft),
+    "nofile_soft": int(nofile_soft),
     "publishing_credentials_present": False,
     "resource_class": resource,
+    "rmem_default": int(rmem_default),
+    "rmem_max": int(rmem_max),
     "root_disk_bytes": int(disk_bytes),
+    "rust_test_threads": os.environ.get("RUST_TEST_THREADS"),
     "shard_id": os.environ["RVOIP_RELEASE_SHARD_ID"],
+    "socket_buffer_probe": socket_buffer_probe,
+    "swap_total_kib": int(swap_total_kib),
+    "udp_mem": [int(value) for value in udp_mem.split()],
     "vcpus": int(vcpus),
+    "wmem_default": int(wmem_default),
+    "wmem_max": int(wmem_max),
 }
 with open(path, "w", encoding="utf-8") as output:
     json.dump(payload, output, indent=2, sort_keys=True)

--- a/scripts/ci/test_linux_performance_host.py
+++ b/scripts/ci/test_linux_performance_host.py
@@ -1,0 +1,114 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts/release/linux_performance_host.py"
+SPEC = importlib.util.spec_from_file_location("linux_performance_host", MODULE_PATH)
+assert SPEC and SPEC.loader
+HOST = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HOST)
+
+
+class LinuxPerformanceHostTests(unittest.TestCase):
+    def make_roots(self, directory: Path, *, rcvbuf: int = 0, sndbuf: int = 0):
+        proc = directory / "proc"
+        sys = directory / "sys"
+        (proc / "net").mkdir(parents=True)
+        loopback = sys / "class/net/lo/statistics"
+        loopback.mkdir(parents=True)
+        (proc / "net/snmp").write_text(
+            "Ip: Forwarding DefaultTTL\n"
+            "Ip: 2 64\n"
+            "Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors\n"
+            f"Udp: 100 4 {rcvbuf + sndbuf} 120 {rcvbuf} {sndbuf} 0 0 0\n",
+            encoding="utf-8",
+        )
+        (proc / "net/sockstat").write_text(
+            "sockets: used 20\nUDP: inuse 8 mem 21\n",
+            encoding="utf-8",
+        )
+        (proc / "net/softnet_stat").write_text(
+            "0000000a 00000002 00000003 00000000\n"
+            "0000000b 00000004 00000005 00000000\n",
+            encoding="utf-8",
+        )
+        (loopback / "rx_dropped").write_text("7\n", encoding="utf-8")
+        (loopback / "tx_dropped").write_text("9\n", encoding="utf-8")
+        return proc, sys
+
+    def test_snapshot_uses_linux_native_counters(self):
+        with tempfile.TemporaryDirectory() as raw:
+            proc, sys = self.make_roots(Path(raw), rcvbuf=2, sndbuf=3)
+            snapshot = HOST.capture_snapshot(proc, sys)
+
+        self.assertEqual(snapshot["udp_datagrams_received"], 100)
+        self.assertEqual(snapshot["udp_dropped_no_socket"], 4)
+        self.assertEqual(snapshot["udp_dropped_full_socket_buffers"], 5)
+        self.assertEqual(snapshot["udp_open_sockets"], 8)
+        self.assertEqual(snapshot["udp_memory_pages"], 21)
+        self.assertEqual(snapshot["softnet_dropped_total"], 6)
+        self.assertEqual(snapshot["softnet_time_squeeze_total"], 8)
+        self.assertEqual(snapshot["loopback_rx_dropped"], 7)
+        self.assertEqual(snapshot["loopback_tx_dropped"], 9)
+
+    def test_delta_preserves_existing_keys_and_passes_zero_drops(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            before = {
+                "schema": HOST.SNAPSHOT_SCHEMA,
+                "platform": "linux",
+                **{key: 10 for key in HOST.COUNTER_KEYS},
+                **{key: 20 for key in HOST.GAUGE_KEYS},
+            }
+            after = dict(before)
+            after["udp_datagrams_received"] = 110
+            after["udp_datagram_output"] = 95
+            after["udp_dropped_no_socket"] = 12
+            after["udp_open_sockets"] = 18
+            before_path = directory / "before.txt"
+            after_path = directory / "after.txt"
+            HOST.write_key_values(before_path, before)
+            HOST.write_key_values(after_path, after)
+            delta = HOST.calculate_delta(before_path, after_path, True)
+
+        self.assertEqual(delta["udp_datagrams_received_delta"], 100)
+        self.assertEqual(delta["udp_dropped_no_socket_delta"], 2)
+        self.assertEqual(delta["udp_open_sockets_delta"], -2)
+        self.assertEqual(delta["zero_drop_validation"], "PASS")
+
+    def test_release_validation_fails_on_buffer_drop(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            before = {
+                "schema": HOST.SNAPSHOT_SCHEMA,
+                "platform": "linux",
+                **{key: 10 for key in HOST.COUNTER_KEYS},
+                **{key: 20 for key in HOST.GAUGE_KEYS},
+            }
+            after = dict(before)
+            after["udp_rcvbuf_errors"] = 11
+            before_path = directory / "before.txt"
+            after_path = directory / "after.txt"
+            HOST.write_key_values(before_path, before)
+            HOST.write_key_values(after_path, after)
+            delta = HOST.calculate_delta(before_path, after_path, True)
+            with self.assertRaisesRegex(HOST.EvidenceError, "udp_rcvbuf_errors=1"):
+                HOST.validate_delta(delta)
+
+    def test_missing_mandatory_snmp_counter_fails_closed(self):
+        with tempfile.TemporaryDirectory() as raw:
+            proc, sys = self.make_roots(Path(raw))
+            (proc / "net/snmp").write_text(
+                "Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors\n"
+                "Udp: 1 2 3 4 5\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(HOST.EvidenceError, "SndbufErrors"):
+                HOST.capture_snapshot(proc, sys)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -214,6 +214,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("docker compose version >/dev/null", startup)
         self.assertIn("ulimit -n 262144", startup)
         self.assertIn('test "$(ulimit -n)" -ge 262144', startup)
+        self.assertIn("sysctl -w net.core.rmem_max=67108864", startup)
+        self.assertIn("sysctl -w net.core.wmem_max=67108864", startup)
         self.assertIn("-name '*.jsonl'", startup)
         self.assertNotRegex(startup, r"apt-get install[^\n]*\bsipp\b")
 
@@ -351,6 +353,9 @@ class WorkflowPolicyTests(unittest.TestCase):
         probe = (
             ROOT / "infra/release-runners/release-infrastructure-preflight.sh"
         ).read_text()
+        burst = (
+            ROOT / "crates/sip/rvoip-sip/scripts/perf_burst_matrix.sh"
+        ).read_text()
 
         self.assertIn("remote-preflight", workflow)
         self.assertIn('test "$PROFILE" = remote-preflight', workflow)
@@ -364,11 +369,21 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('export RVOIP_RELEASE_CANDIDATE="$CANDIDATE"', startup)
         self.assertIn('export RVOIP_RELEASE_GATES="$GATES"', startup)
         self.assertIn("sysctl -w net.core.rmem_max=67108864", startup)
+        self.assertIn("sysctl -w net.core.wmem_max=67108864", startup)
+        self.assertEqual(workflow.count('--min-cpu-platform "$MIN_CPU_PLATFORM"'), 2)
+        self.assertIn("MIN_CPU_PLATFORM: Intel Cascade Lake", workflow)
+        self.assertIn("n2-cascade-lake", workflow)
         self.assertIn("expected 44 publishable workspace packages", probe)
         self.assertIn("gcp-performance|gcp-performance-soak-long", probe)
         self.assertIn("gcp-proxy-interop", probe)
         self.assertIn("for _ in range(4096)", probe)
-        self.assertIn('test "$NOFILE_LIMIT" -ge 262144', probe)
+        self.assertIn('test "$NOFILE_SOFT" -ge 262144', probe)
+        self.assertIn('test "$RMEM_MAX" -ge 8388608', probe)
+        self.assertIn('test "$WMEM_MAX" -ge 8388608', probe)
+        self.assertIn("linux_performance_host.py snapshot", probe)
+        self.assertIn("socket-buffer-probe.json", probe)
+        self.assertIn("linux_performance_host.py", burst)
+        self.assertIn("--require-zero-drops", burst)
         self.assertIn('test -z "${CARGO_REGISTRY_TOKEN:-}"', probe)
         self.assertIn('test -z "${CRATES_IO_TOKEN:-}"', probe)
         self.assertIn('"publishing_credentials_present": False', probe)

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -257,6 +257,18 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("rvoip-prebuilt-sha256=${PREBUILT_SHA256}", workflow)
         self.assertIn("install-bundle", startup)
         self.assertIn("RVOIP_PERF_PREBUILT_MANIFEST", startup)
+        self.assertIn(
+            'run_bundle_prefix="gs://${BUCKET}/release/${RUN_ID}/prebuild/"',
+            startup,
+        )
+        self.assertIn(
+            'cache_bundle_prefix="gs://${BUCKET}/release-cache/performance-prebuilt-v1/"',
+            startup,
+        )
+        self.assertIn(
+            '"/bundles/${PREBUILT_SHA256}.tar.gz"',
+            startup,
+        )
         self.assertIn("performance-prebuilt.tar.gz", builder)
         self.assertIn('download "$MANIFEST_OBJECT"', builder)
         self.assertIn("performance-manifest-readback.json", builder)

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -272,6 +272,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("capture_external_memory", startup)
         self.assertIn("AnonHugePages", startup)
         self.assertIn("thp_collapse_alloc", startup)
+        self.assertIn("rvoip-mimalloc-allow-thp", startup)
+        self.assertIn('export MIMALLOC_ALLOW_THP="$MIMALLOC_ALLOW_THP_OVERRIDE"', startup)
         self.assertIn(
             '"/bundles/${PREBUILT_SHA256}.tar.gz"',
             startup,
@@ -282,6 +284,14 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("publishing_attempted", builder)
         self.assertIn("bundle digest mismatch", helper)
         self.assertIn("exact candidate", helper)
+
+    def test_production_allocator_disables_transparent_huge_pages(self) -> None:
+        manifest = tomllib.loads(
+            (ROOT / "crates/foundation/infra-common/Cargo.toml").read_text()
+        )
+        mimalloc = manifest["dependencies"]["mimalloc"]
+        self.assertFalse(mimalloc["default-features"])
+        self.assertIn("no_thp", mimalloc["features"])
 
     def test_exact_candidate_performance_bundle_is_reused_fail_closed(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -265,6 +265,13 @@ class WorkflowPolicyTests(unittest.TestCase):
             'cache_bundle_prefix="gs://${BUCKET}/release-cache/performance-prebuilt-v1/"',
             startup,
         )
+        self.assertIn("rvoip-external-memory-diagnostics", workflow)
+        self.assertIn(
+            "inputs.profile == 'remote-diagnostic' && '1' || '0'", workflow
+        )
+        self.assertIn("capture_external_memory", startup)
+        self.assertIn("AnonHugePages", startup)
+        self.assertIn("thp_collapse_alloc", startup)
         self.assertIn(
             '"/bundles/${PREBUILT_SHA256}.tar.gz"',
             startup,

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -505,12 +505,12 @@ def profile_selection(
             f"remote-diagnostic accepts at most {MAX_DIAGNOSTIC_GATES} requested gates"
         )
 
-    release_ids = set(profiles["remote-release"])
+    diagnostic_ids = set(profiles["remote-release"]) | set(profiles["remote-preflight"])
     by_id = gate_map(catalog)
-    unknown = sorted(set(requested) - release_ids)
+    unknown = sorted(set(requested) - diagnostic_ids)
     if unknown:
         raise GateError(
-            "remote-diagnostic gate IDs must belong to remote-release: "
+            "remote-diagnostic gate IDs must belong to remote-release or remote-preflight: "
             + ", ".join(unknown)
         )
     invalid = sorted(
@@ -533,9 +533,9 @@ def profile_selection(
     while pending:
         gate_id = pending.pop()
         for dependency in by_id[gate_id].get("dependencies", []):
-            if dependency not in release_ids:
+            if dependency not in diagnostic_ids:
                 raise GateError(
-                    f"remote-diagnostic dependency {dependency!r} is outside remote-release"
+                    f"remote-diagnostic dependency {dependency!r} is outside the release and preflight profiles"
                 )
             if dependency not in selected:
                 selected.add(dependency)

--- a/scripts/release/gcp_fanout.py
+++ b/scripts/release/gcp_fanout.py
@@ -22,6 +22,15 @@ COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 RUN_NUMBER = re.compile(r"^[1-9][0-9]*$")
 SHARD_ID = re.compile(r"^[a-z0-9][a-z0-9-]{0,47}$")
 GATE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+CONTROLLER_EVIDENCE_DIR = "_gcp-controller"
+WORKER_EVIDENCE_DIR = "_gcp-workers"
+WORKER_SIDECAR_NAMES = frozenset(
+    {
+        "_external-process-memory.tsv",
+        "_host-memory-policy.txt",
+        "_sccache-stats.txt",
+    }
+)
 RESOURCE_MACHINES = {
     "gcp-interop": "n2-standard-4",
     "gcp-performance": "n2-standard-8",
@@ -210,17 +219,33 @@ def safe_archive_members(archive: Path) -> list[tarfile.TarInfo]:
             or path.parts[0] != "release-shard"
         ):
             raise FanoutError(f"unsafe evidence archive path: {member.name!r}")
+        relative = path.relative_to("release-shard")
+        if relative.parts and relative.parts[0] in {
+            CONTROLLER_EVIDENCE_DIR,
+            WORKER_EVIDENCE_DIR,
+        }:
+            raise FanoutError(
+                f"evidence archive uses a reserved controller path: {member.name!r}"
+            )
         if not (member.isdir() or member.isfile()):
             raise FanoutError(f"unsupported evidence archive member: {member.name!r}")
     return members
 
 
-def merge_archive(archive: Path, destination: Path) -> None:
+def merge_archive(archive: Path, destination: Path, shard_id: str) -> None:
+    if not SHARD_ID.fullmatch(shard_id):
+        raise FanoutError(f"unsafe GCP shard id: {shard_id!r}")
     members = safe_archive_members(archive)
     with tarfile.open(archive, "r:gz") as bundle:
         for member in members:
             relative = PurePosixPath(member.name).relative_to("release-shard")
-            target = destination.joinpath(*relative.parts)
+            if member.isfile() and str(relative) in WORKER_SIDECAR_NAMES:
+                # These files describe an individual worker rather than a release
+                # gate. Preserve each copy without weakening duplicate detection
+                # for the shared gate-evidence namespace.
+                target = destination / WORKER_EVIDENCE_DIR / shard_id / relative.name
+            else:
+                target = destination.joinpath(*relative.parts)
             if member.isdir():
                 target.mkdir(parents=True, exist_ok=True)
                 continue
@@ -354,7 +379,7 @@ def verify_fanout(
     output.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=f".{output.name}-", dir=output.parent))
     try:
-        controller = staging / "_gcp-controller"
+        controller = staging / CONTROLLER_EVIDENCE_DIR
         controller.mkdir()
         errors: list[str] = []
         failed_shards: list[str] = []
@@ -393,7 +418,7 @@ def verify_fanout(
                 failed_shards.append(shard)
                 continue
             try:
-                merge_archive(archive_path, staging)
+                merge_archive(archive_path, staging, shard)
             except FanoutError as error:
                 errors.append(str(error))
                 failed_shards.append(shard)

--- a/scripts/release/linux_performance_host.py
+++ b/scripts/release/linux_performance_host.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Capture and validate Linux UDP performance-host evidence.
+
+The release workers deliberately read stable procfs/sysfs counters instead of
+parsing distro-specific ``netstat`` output.  Snapshots are written as simple
+``key=value`` files to preserve the existing burst-artifact contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+from typing import Iterable
+
+
+SNAPSHOT_SCHEMA = "rvoip-linux-udp-snapshot-v1"
+DELTA_SCHEMA = "rvoip-linux-udp-delta-v1"
+
+COUNTER_KEYS = (
+    "udp_datagrams_received",
+    "udp_dropped_no_socket",
+    "udp_receive_errors",
+    "udp_datagram_output",
+    "udp_rcvbuf_errors",
+    "udp_sndbuf_errors",
+    "udp_dropped_full_socket_buffers",
+    "softnet_dropped_total",
+    "softnet_time_squeeze_total",
+    "loopback_rx_dropped",
+    "loopback_tx_dropped",
+)
+
+GAUGE_KEYS = (
+    "udp_open_sockets",
+    "udp_memory_pages",
+)
+
+ZERO_DROP_KEYS = (
+    "udp_receive_errors",
+    "udp_rcvbuf_errors",
+    "udp_sndbuf_errors",
+    "softnet_dropped_total",
+    "loopback_rx_dropped",
+    "loopback_tx_dropped",
+)
+
+
+class EvidenceError(RuntimeError):
+    """Raised when mandatory Linux performance evidence is unavailable."""
+
+
+def _read_lines(path: Path, description: str) -> list[str]:
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise EvidenceError(f"cannot read {description} {path}: {error}") from error
+
+
+def parse_udp_snmp(path: Path) -> dict[str, int]:
+    lines = _read_lines(path, "UDP SNMP counters")
+    for index, header_line in enumerate(lines[:-1]):
+        if not header_line.startswith("Udp:"):
+            continue
+        value_line = lines[index + 1]
+        if not value_line.startswith("Udp:"):
+            continue
+        headers = header_line.split()[1:]
+        values = value_line.split()[1:]
+        if len(headers) != len(values):
+            raise EvidenceError("/proc/net/snmp UDP header/value lengths differ")
+        try:
+            result = dict(zip(headers, map(int, values), strict=True))
+        except ValueError as error:
+            raise EvidenceError("/proc/net/snmp UDP counters are not integers") from error
+        required = {
+            "InDatagrams",
+            "NoPorts",
+            "InErrors",
+            "OutDatagrams",
+            "RcvbufErrors",
+            "SndbufErrors",
+        }
+        missing = sorted(required - result.keys())
+        if missing:
+            raise EvidenceError(f"/proc/net/snmp lacks UDP counters: {', '.join(missing)}")
+        return result
+    raise EvidenceError("/proc/net/snmp does not contain a UDP counter pair")
+
+
+def parse_udp_sockstat(path: Path) -> dict[str, int]:
+    for line in _read_lines(path, "UDP socket statistics"):
+        fields = line.split()
+        if not fields or fields[0] != "UDP:":
+            continue
+        values = fields[1:]
+        if len(values) % 2:
+            raise EvidenceError("/proc/net/sockstat UDP row is malformed")
+        try:
+            result = {
+                values[index]: int(values[index + 1])
+                for index in range(0, len(values), 2)
+            }
+        except ValueError as error:
+            raise EvidenceError("/proc/net/sockstat UDP values are not integers") from error
+        missing = sorted({"inuse", "mem"} - result.keys())
+        if missing:
+            raise EvidenceError(f"/proc/net/sockstat lacks UDP fields: {', '.join(missing)}")
+        return result
+    raise EvidenceError("/proc/net/sockstat does not contain a UDP row")
+
+
+def parse_softnet(path: Path) -> tuple[int, int]:
+    dropped = 0
+    time_squeeze = 0
+    lines = _read_lines(path, "softnet statistics")
+    if not lines:
+        raise EvidenceError("/proc/net/softnet_stat is empty")
+    for line in lines:
+        fields = line.split()
+        if len(fields) < 3:
+            raise EvidenceError("/proc/net/softnet_stat row has fewer than three fields")
+        try:
+            dropped += int(fields[1], 16)
+            time_squeeze += int(fields[2], 16)
+        except ValueError as error:
+            raise EvidenceError("/proc/net/softnet_stat fields are not hexadecimal") from error
+    return dropped, time_squeeze
+
+
+def read_integer(path: Path, description: str) -> int:
+    lines = _read_lines(path, description)
+    if len(lines) != 1:
+        raise EvidenceError(f"{description} {path} must contain exactly one line")
+    try:
+        return int(lines[0].strip())
+    except ValueError as error:
+        raise EvidenceError(f"{description} {path} is not an integer") from error
+
+
+def capture_snapshot(proc_root: Path = Path("/proc"), sys_root: Path = Path("/sys")) -> dict[str, int | str]:
+    udp = parse_udp_snmp(proc_root / "net/snmp")
+    sockstat = parse_udp_sockstat(proc_root / "net/sockstat")
+    softnet_dropped, softnet_time_squeeze = parse_softnet(proc_root / "net/softnet_stat")
+    loopback = sys_root / "class/net/lo/statistics"
+    rcvbuf_errors = udp["RcvbufErrors"]
+    sndbuf_errors = udp["SndbufErrors"]
+    return {
+        "schema": SNAPSHOT_SCHEMA,
+        "platform": "linux",
+        "timestamp_epoch": int(time.time()),
+        "source": "procfs-sysfs",
+        "udp_datagrams_received": udp["InDatagrams"],
+        "udp_delivered": udp["InDatagrams"],
+        "udp_dropped_no_socket": udp["NoPorts"],
+        "udp_receive_errors": udp["InErrors"],
+        "udp_datagram_output": udp["OutDatagrams"],
+        "udp_rcvbuf_errors": rcvbuf_errors,
+        "udp_sndbuf_errors": sndbuf_errors,
+        "udp_dropped_full_socket_buffers": rcvbuf_errors + sndbuf_errors,
+        "udp_open_sockets": sockstat["inuse"],
+        "udp_memory_pages": sockstat["mem"],
+        "softnet_dropped_total": softnet_dropped,
+        "softnet_time_squeeze_total": softnet_time_squeeze,
+        "loopback_rx_dropped": read_integer(loopback / "rx_dropped", "loopback RX drops"),
+        "loopback_tx_dropped": read_integer(loopback / "tx_dropped", "loopback TX drops"),
+    }
+
+
+def write_key_values(path: Path, values: dict[str, int | str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ordered = ["schema", "platform", "timestamp_epoch", "source"]
+    keys = [key for key in ordered if key in values]
+    keys.extend(sorted(set(values) - set(keys)))
+    path.write_text(
+        "".join(f"{key}={values[key]}\n" for key in keys),
+        encoding="utf-8",
+    )
+
+
+def read_key_values(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw in _read_lines(path, "Linux UDP snapshot"):
+        if not raw or raw.startswith("#") or "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        result[key] = value
+    if result.get("schema") != SNAPSHOT_SCHEMA:
+        raise EvidenceError(f"snapshot {path} has an unsupported schema")
+    return result
+
+
+def _required_integer(values: dict[str, str], key: str, path: Path) -> int:
+    try:
+        return int(values[key])
+    except KeyError as error:
+        raise EvidenceError(f"snapshot {path} lacks {key}") from error
+    except ValueError as error:
+        raise EvidenceError(f"snapshot {path} has non-integer {key}") from error
+
+
+def calculate_delta(before_path: Path, after_path: Path, require_zero_drops: bool) -> dict[str, int | str]:
+    before = read_key_values(before_path)
+    after = read_key_values(after_path)
+    result: dict[str, int | str] = {
+        "schema": DELTA_SCHEMA,
+        "platform": "linux",
+        "before": str(before_path),
+        "after": str(after_path),
+    }
+    deltas: dict[str, int] = {}
+    for key in (*COUNTER_KEYS, *GAUGE_KEYS):
+        before_value = _required_integer(before, key, before_path)
+        after_value = _required_integer(after, key, after_path)
+        delta = after_value - before_value
+        if key in COUNTER_KEYS and delta < 0:
+            raise EvidenceError(f"monotonic Linux counter {key} moved backwards")
+        result[f"{key}_before"] = before_value
+        result[f"{key}_after"] = after_value
+        result[f"{key}_delta"] = delta
+        deltas[key] = delta
+    if require_zero_drops:
+        nonzero = {key: deltas[key] for key in ZERO_DROP_KEYS if deltas[key] != 0}
+        if nonzero:
+            details = ", ".join(f"{key}={value}" for key, value in sorted(nonzero.items()))
+            result["zero_drop_validation"] = "FAIL"
+            result["unexpected_drop_deltas"] = details
+        else:
+            result["zero_drop_validation"] = "PASS"
+            result["unexpected_drop_deltas"] = ""
+    else:
+        result["zero_drop_validation"] = "NOT_REQUESTED"
+        result["unexpected_drop_deltas"] = ""
+    return result
+
+
+def validate_delta(result: dict[str, int | str]) -> None:
+    if result.get("zero_drop_validation") == "FAIL":
+        raise EvidenceError(
+            f"unexpected Linux network drop deltas: {result['unexpected_drop_deltas']}"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snapshot = subparsers.add_parser("snapshot")
+    snapshot.add_argument("--output", type=Path, required=True)
+    snapshot.add_argument("--proc-root", type=Path, default=Path("/proc"))
+    snapshot.add_argument("--sys-root", type=Path, default=Path("/sys"))
+
+    delta = subparsers.add_parser("delta")
+    delta.add_argument("--before", type=Path, required=True)
+    delta.add_argument("--after", type=Path, required=True)
+    delta.add_argument("--output", type=Path, required=True)
+    delta.add_argument("--require-zero-drops", action="store_true")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "snapshot":
+            write_key_values(args.output, capture_snapshot(args.proc_root, args.sys_root))
+        else:
+            result = calculate_delta(args.before, args.after, args.require_zero_drops)
+            write_key_values(args.output, result)
+            validate_delta(result)
+    except EvidenceError as error:
+        raise SystemExit(f"Linux performance evidence error: {error}") from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -292,11 +292,19 @@ class GateFrameworkTests(unittest.TestCase):
             set(builder.PROXY_INTEROP_GATE_IDS) | {"perf.monolithic-soak"},
         )
 
+        preflight = gates.profile_selection(
+            self.catalog, "remote-diagnostic", ["preflight.performance-01"]
+        )
+        self.assertEqual(
+            set(preflight),
+            {"preflight.performance-01"},
+        )
+
         invalid_cases = (
             ([], "requires at least one"),
             (["core.rvoip"], "executable GCP gates"),
             (["perf.media-burst-matrix"], "executable GCP gates"),
-            (["not.a.gate"], "must belong to remote-release"),
+            (["not.a.gate"], "must belong to remote-release or remote-preflight"),
             ([f"gate-{index}" for index in range(21)], "at most 20"),
         )
         for gate_ids, message in invalid_cases:

--- a/scripts/test_release_gcp_fanout.py
+++ b/scripts/test_release_gcp_fanout.py
@@ -299,11 +299,21 @@ class GcpReleaseFanoutTests(unittest.TestCase):
                 fanout.load_instance_states(path)
 
     @staticmethod
-    def write_archive(path: Path, member_name: str, payload: bytes) -> str:
+    def write_archive(
+        path: Path,
+        member_name: str,
+        payload: bytes,
+        *,
+        sidecars: dict[str, bytes] | None = None,
+    ) -> str:
         with tarfile.open(path, "w:gz") as bundle:
             member = tarfile.TarInfo(member_name)
             member.size = len(payload)
             bundle.addfile(member, io.BytesIO(payload))
+            for sidecar_name, sidecar_payload in (sidecars or {}).items():
+                sidecar = tarfile.TarInfo(sidecar_name)
+                sidecar.size = len(sidecar_payload)
+                bundle.addfile(sidecar, io.BytesIO(sidecar_payload))
         return hashlib.sha256(path.read_bytes()).hexdigest()
 
     def populate_downloads(
@@ -322,7 +332,14 @@ class GcpReleaseFanoutTests(unittest.TestCase):
                 if unsafe and index == 0
                 else f"release-shard/{shard}/receipt.json"
             )
-            archive_sha = self.write_archive(archive, member, b'{"status":"PASS"}\n')
+            archive_sha = self.write_archive(
+                archive,
+                member,
+                b'{"status":"PASS"}\n',
+                sidecars={
+                    "release-shard/_sccache-stats.txt": f"{shard}\n".encode()
+                },
+            )
             result = {
                 "schema": fanout.RESULT_SCHEMA,
                 "candidate_sha": manifest["candidate_sha"],
@@ -352,6 +369,15 @@ class GcpReleaseFanoutTests(unittest.TestCase):
             self.assertEqual(receipt["worker_count"], 2)
             for worker in manifest["workers"]:
                 self.assertTrue((output / worker["id"] / "receipt.json").is_file())
+                self.assertEqual(
+                    (
+                        output
+                        / fanout.WORKER_EVIDENCE_DIR
+                        / worker["id"]
+                        / "_sccache-stats.txt"
+                    ).read_text(),
+                    f"{worker['id']}\n",
+                )
                 self.assertTrue(
                     (
                         output
@@ -364,6 +390,66 @@ class GcpReleaseFanoutTests(unittest.TestCase):
                 (output / "_gcp-controller" / "fanout-receipt.json").read_text()
             )
             self.assertFalse(fanout_receipt["publishing_attempted"])
+
+    def test_verify_keeps_gate_evidence_duplicates_fail_closed(self) -> None:
+        manifest = self.manifest()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            downloads = root / "downloads"
+            downloads.mkdir()
+            self.populate_downloads(downloads, manifest)
+            for worker in manifest["workers"]:
+                shard = worker["id"]
+                archive = downloads / shard / "release-shard.tar.gz"
+                archive_sha = self.write_archive(
+                    archive,
+                    "release-shard/perf.shared/receipt.json",
+                    b'{"status":"PASS"}\n',
+                )
+                result_path = downloads / shard / "result.json"
+                result = json.loads(result_path.read_text())
+                result["evidence_archive_sha256"] = archive_sha
+                fanout.write_json(result_path, result)
+
+            receipt = fanout.verify_fanout(
+                manifest=manifest,
+                downloads=downloads,
+                output=root / "release-shard",
+            )
+            self.assertEqual(receipt["status"], "FAIL")
+            self.assertEqual(receipt["trusted_shards"], [manifest["workers"][0]["id"]])
+            self.assertTrue(
+                any("duplicate evidence path" in error for error in receipt["errors"])
+            )
+
+    def test_verify_rejects_worker_archives_using_controller_namespaces(self) -> None:
+        manifest = self.manifest()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            downloads = root / "downloads"
+            downloads.mkdir()
+            self.populate_downloads(downloads, manifest)
+            worker = manifest["workers"][0]
+            archive = downloads / worker["id"] / "release-shard.tar.gz"
+            archive_sha = self.write_archive(
+                archive,
+                "release-shard/_gcp-controller/injected.json",
+                b"{}\n",
+            )
+            result_path = downloads / worker["id"] / "result.json"
+            result = json.loads(result_path.read_text())
+            result["evidence_archive_sha256"] = archive_sha
+            fanout.write_json(result_path, result)
+
+            receipt = fanout.verify_fanout(
+                manifest=manifest,
+                downloads=downloads,
+                output=root / "release-shard",
+            )
+            self.assertEqual(receipt["status"], "FAIL")
+            self.assertTrue(
+                any("reserved controller path" in error for error in receipt["errors"])
+            )
 
     def test_verify_rejects_tampering_and_archive_traversal(self) -> None:
         manifest = self.manifest()


### PR DESCRIPTION
## Problem

Release qualification exposed two independent failures:

1. mimalloc transparent-huge-page collapse made burst-process RSS continue rising after all instrumented calls and lifecycle objects had drained. The original RSS gate also allowed a rounded, slightly-short evidence window to display as complete without enforcing the threshold.
2. Linux GCP workers did not bind release evidence to all of the host conditions that affect performance: effective socket buffers, native UDP/drop counters, file limits, CPU generation, swap, and pressure. When two passing GCP shards were combined, their per-worker cache sidecars also collided even though their gate evidence was disjoint.

## Fix

- Compile mimalloc with its supported `no_thp` feature instead of changing workload size or acceptance thresholds.
- Require bounded procfs-only RSS quiescence probes before opening one independent authoritative RSS window.
- Fail closed on non-finite evidence, missing samples, incomplete windows, or a process that never becomes quiescent.
- Keep RSS sampling on a dedicated worker and record each probe, sample path, duration, range, slope, and decision.
- Configure and verify symmetric Linux UDP receive/send maxima, then validate the effective 8 MiB buffers using `getsockopt`.
- Record Linux-native `/proc` UDP, socket, softnet, loopback-drop, pressure, swap, CPU, and file-limit evidence; release candidates fail on new drop/error counters.
- Require the configured N2 CPU platform for release workers and allow a named preflight-only diagnostic.
- Preserve per-worker diagnostics under shard-specific controller paths while retaining fail-closed duplicate detection for real gate evidence.

No test load, soak duration, RSS threshold, or public Rust API is reduced or changed.

## GCP evidence

- Exact original #150 candidate, original access-edge workload, 7,400 calls, and full 600-second RSS window with THP disabled: **PASS**. Both processes drained to zero retained calls; receiver slope was -0.07 MB/hour and `AnonHugePages`/THP collapse count remained zero.
- Exact compiled-fix candidate `62486790`: access-edge burst **PASS** in 902 seconds and high-density burst **PASS** in 982 seconds, concurrently on separate `n2-standard-4` workers. Immutable archive SHA-256 values are `8f8a9146cf6a060d09a1b2abfca9c9a7d1d1f51e57125bd026abd8802df1da99` and `d4c19d666b45b8f28e508c2771c1f51f0b63ff2583546d26401ba8445b467f3d` ([run](https://github.com/eisenzopf/rvoip/actions/runs/30779479292)). The workflow's only failure was the now-fixed cache-sidecar merge collision; replaying both exact archives through the corrected verifier passes with both shards trusted.
- Hardened `n2-standard-8` infrastructure preflight: **PASS**. Effective receive/send buffers were 16 MiB for an 8 MiB request, no file/socket/drop limit failed, and all native Linux error/drop deltas were zero ([run](https://github.com/eisenzopf/rvoip/actions/runs/30780660020)).

## Local verification

- 43 release gate/fanout tests pass, including real duplicate-gate rejection and reserved-controller-path protection.
- 86 CI policy/planner tests pass.
- Python compilation and diff hygiene pass.
- Both immutable GCP shard archives replay through the corrected full fanout verifier with status `PASS` and two trusted shards.

## Risk and follow-up

Disabling THP for mimalloc trades opportunistic huge pages for stable release behavior; the exact before/after GCP evidence shows the previous RSS growth disappears. The added host checks are diagnostic for PR work and fail closed for exact release candidates.

The report's RTP-range overlap with Linux's default ephemeral range remains a topology concern. It is deliberately not hidden by reserving the broad RTP range globally; a separate topology-aware port allocator/validator is required before colocating overlapping roles on one host.

Closes #150 after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production mimalloc configuration and release qualification gates that can block publishes; changes are well-tested but alter fail-closed behavior on RSS and Linux network evidence.
> 
> **Overview**
> Addresses false burst RSS failures and flaky Linux release evidence by changing how memory is measured and how GCP workers are provisioned—not by relaxing load or acceptance thresholds.
> 
> **Burst RSS qualification** enables mimalloc `no_thp` so post-drain RSS is not inflated by transparent huge pages. Burst caller/receiver tests must pass bounded **RSS quiescence** probes before the authoritative settled window; gates fail closed if quiescence is not achieved, the window is incomplete, or growth exceeds the limit. Resource sampling runs on a **dedicated blocking thread** so the observer does not add mimalloc cross-worker RSS noise.
> 
> **Linux release runners** pin N2 workers to **Intel Cascade Lake**, bump the release environment id, set symmetric UDP buffer sysctl ceilings, and extend preflight with CPU model, limits, pressure/swap, procfs UDP/softnet/loopback counters, and an 8 MiB socket-buffer `getsockopt` probe. Burst matrix scripts use `linux_performance_host.py` for snapshots/deltas; release candidates can require **zero drop deltas**. `remote-diagnostic` may target preflight gates, enables optional external memory/THP diagnostics on workers, and accepts content-addressed prebuilt bundles from GCS cache.
> 
> **Evidence merge** routes per-worker sidecars (e.g. sccache stats, external memory TSV) under shard-specific paths while keeping fail-closed duplicate detection for shared gate evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa202b28358fb16ea068e62428ea2c2bf6b83e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->