### PR TITLE
Cache exact performance build bundles

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -425,60 +425,86 @@ jobs:
             exit 0
           fi
 
+          cache_started="$(date +%s)"
+          cache_key="$(python3 scripts/release/prebuilt_performance.py cache-key \
+            --candidate "$CANDIDATE" \
+            --environment-id "$ENVIRONMENT_ID" \
+            --gates "$gates_csv")"
+          cache_prefix="release-cache/performance-prebuilt-v1/${cache_key}"
+          cache_result_uri="gs://${BUCKET}/${cache_prefix}/prebuild-result.json"
+          cache_hit=false
+          if gcloud storage cp "$cache_result_uri" \
+            target/gcp-controller/prebuild/cached-result.json 2>/dev/null \
+            && python3 scripts/release/prebuilt_performance.py verify-result \
+              --result target/gcp-controller/prebuild/cached-result.json \
+              --candidate "$CANDIDATE" \
+              --environment-id "$ENVIRONMENT_ID" \
+              --gates "$gates_csv" \
+              --cache-key "$cache_key"; then
+            mv target/gcp-controller/prebuild/cached-result.json \
+              target/gcp-controller/prebuild/prebuild-result.json
+            cache_hit=true
+          else
+            rm -f target/gcp-controller/prebuild/cached-result.json
+          fi
+
           builder="rvoip-rel-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-prebuild"
           prefix="release/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/prebuild"
-          gates_b64="$(printf '%s' "$gates_csv" | base64 -w0)"
-          environment_b64="$(printf '%s' "$ENVIRONMENT_ID" | base64 -w0)"
-          cleanup_builder() {
-            gcloud compute instances delete "$builder" \
-              --project "$PROJECT" --zone "$ZONE" --quiet >/dev/null 2>&1 || true
-          }
-          trap cleanup_builder EXIT
+          if [[ "$cache_hit" != true ]]; then
+            gates_b64="$(printf '%s' "$gates_csv" | base64 -w0)"
+            environment_b64="$(printf '%s' "$ENVIRONMENT_ID" | base64 -w0)"
+            cleanup_builder() {
+              gcloud compute instances delete "$builder" \
+                --project "$PROJECT" --zone "$ZONE" --quiet >/dev/null 2>&1 || true
+            }
+            trap cleanup_builder EXIT
 
-          gcloud compute instances create "$builder" \
-            --project "$PROJECT" \
-            --zone "$ZONE" \
-            --machine-type n2-standard-32 \
-            --network "$NETWORK" \
-            --subnet "$SUBNET" \
-            --image-family ubuntu-2404-lts-amd64 \
-            --image-project ubuntu-os-cloud \
-            --boot-disk-type pd-balanced \
-            --boot-disk-size 200GB \
-            --boot-disk-auto-delete \
-            --service-account "$RUNNER_SERVICE_ACCOUNT" \
-            --scopes cloud-platform \
-            --shielded-secure-boot \
-            --shielded-vtpm \
-            --shielded-integrity-monitoring \
-            --labels rvoip-role=release-prebuild,managed-by=github-actions \
-            --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-evidence-bucket=${BUCKET},rvoip-cache-bucket=${CACHE_BUCKET},rvoip-prefix=${prefix},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
-            --metadata-from-file startup-script=infra/release-runners/gcp-performance-prebuild-startup.sh \
-            > target/gcp-controller/prebuild/create.log
+            gcloud compute instances create "$builder" \
+              --project "$PROJECT" \
+              --zone "$ZONE" \
+              --machine-type n2-standard-32 \
+              --network "$NETWORK" \
+              --subnet "$SUBNET" \
+              --image-family ubuntu-2404-lts-amd64 \
+              --image-project ubuntu-os-cloud \
+              --boot-disk-type pd-balanced \
+              --boot-disk-size 200GB \
+              --boot-disk-auto-delete \
+              --service-account "$RUNNER_SERVICE_ACCOUNT" \
+              --scopes cloud-platform \
+              --shielded-secure-boot \
+              --shielded-vtpm \
+              --shielded-integrity-monitoring \
+              --labels rvoip-role=release-prebuild,managed-by=github-actions \
+              --metadata "rvoip-candidate=${CANDIDATE},rvoip-run-id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT},rvoip-evidence-bucket=${BUCKET},rvoip-cache-bucket=${CACHE_BUCKET},rvoip-prefix=${prefix},rvoip-prebuild-cache-key=${cache_key},rvoip-gates-b64=${gates_b64},rvoip-environment-b64=${environment_b64}" \
+              --metadata-from-file startup-script=infra/release-runners/gcp-performance-prebuild-startup.sh \
+              > target/gcp-controller/prebuild/create.log
 
-          result_uri="gs://${BUCKET}/${prefix}/prebuild-result.json"
-          for attempt in $(seq 1 120); do
-            if gcloud storage cp "$result_uri" \
-              target/gcp-controller/prebuild/prebuild-result.json 2>/dev/null; then
-              break
-            fi
-            state="$(gcloud compute instances describe "$builder" \
-              --project "$PROJECT" --zone "$ZONE" --format='value(status)' || true)"
-            if [[ "$state" == TERMINATED ]]; then
-              echo "performance prebuilder stopped without an immutable result" >&2
-              break
-            fi
-            echo "Waiting for exact-candidate performance bundle (poll ${attempt}/120)"
-            sleep 20
-          done
-          gcloud storage cp "gs://${BUCKET}/${prefix}/prebuild.log" \
-            target/gcp-controller/prebuild/prebuild.log 2>/dev/null || true
+            result_uri="gs://${BUCKET}/${prefix}/prebuild-result.json"
+            for attempt in $(seq 1 120); do
+              if gcloud storage cp "$result_uri" \
+                target/gcp-controller/prebuild/prebuild-result.json 2>/dev/null; then
+                break
+              fi
+              state="$(gcloud compute instances describe "$builder" \
+                --project "$PROJECT" --zone "$ZONE" --format='value(status)' || true)"
+              if [[ "$state" == TERMINATED ]]; then
+                echo "performance prebuilder stopped without an immutable result" >&2
+                break
+              fi
+              echo "Waiting for exact-candidate performance bundle (poll ${attempt}/120)"
+              sleep 20
+            done
+            gcloud storage cp "gs://${BUCKET}/${prefix}/prebuild.log" \
+              target/gcp-controller/prebuild/prebuild.log 2>/dev/null || true
+          fi
           test -f target/gcp-controller/prebuild/prebuild-result.json
           python3 scripts/release/prebuilt_performance.py verify-result \
             --result target/gcp-controller/prebuild/prebuild-result.json \
             --candidate "$CANDIDATE" \
             --environment-id "$ENVIRONMENT_ID" \
             --gates "$gates_csv" \
+            --cache-key "$cache_key" \
             --github-output "$GITHUB_OUTPUT"
           manifest_uri="$(jq -r .manifest_uri target/gcp-controller/prebuild/prebuild-result.json)"
           manifest_sha="$(jq -r .manifest_sha256 target/gcp-controller/prebuild/prebuild-result.json)"
@@ -493,8 +519,14 @@ jobs:
             echo "### Shared exact-candidate performance build"
             echo
             echo "- Selected gates: ${count}"
-            echo "- Builder: ephemeral n2-standard-32"
-            echo "- Build and package duration: ${duration}s"
+            if [[ "$cache_hit" == true ]]; then
+              echo "- Bundle source: verified exact-candidate GCS cache"
+              echo "- Cache lookup and verification: $(( $(date +%s) - cache_started ))s"
+              echo "- Original build and package duration avoided: ${duration}s"
+            else
+              echo "- Bundle source: ephemeral n2-standard-32 builder"
+              echo "- Build and package duration: ${duration}s"
+            fi
             echo "- Builder retained after this step: no"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -127,6 +127,8 @@ dividing the continuous soak requirement. Any missing object or cache-key,
 manifest, bundle, or executable digest mismatch fails closed. Gates
 whose exact source, dependency, definition, environment, and threshold digests
 remain unchanged may reuse successful prior evidence on a later candidate.
+The GCS lifecycle expires only `release-cache/` objects after 14 days; it does
+not apply to the durable run-scoped qualification receipts and logs.
 Each proxy row has its own stable gate ID, so a later diagnostic can rerun only
 the failed combination without rerunning the other eleven rows.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -119,9 +119,12 @@ all 18 concurrent VM creations, but its short probes never substitute for the
 real performance, interoperability, and soak commands in `remote-release`.
 The one-hour soak establishes a physical lower bound of one hour for a fresh
 qualification, plus short provisioning and evidence overhead. The shared build
-stage is intentionally outside the measured workloads and can be reused only
-within its exact workflow run; it removes duplicate compilation but does not
-shorten or divide the continuous soak requirement. Gates
+stage is intentionally outside the measured workloads. Its finished bundle is
+reused across workflow reruns only when the exact candidate SHA, release
+environment, and selected performance gate set produce the same cache key. A
+hit avoids the approximately full-LTO build delay without shortening or
+dividing the continuous soak requirement. Any missing object or cache-key,
+manifest, bundle, or executable digest mismatch fails closed. Gates
 whose exact source, dependency, definition, environment, and threshold digests
 remain unchanged may reuse successful prior evidence on a later candidate.
 Each proxy row has its own stable gate ID, so a later diagnostic can rerun only

--- a/infra/release-runners/README.md
+++ b/infra/release-runners/README.md
@@ -55,6 +55,10 @@ workloads, durations, and thresholds; they verify the bundle and executable
 hashes instead of recompiling the same graph. This makes compilation a shared
 setup phase without contaminating performance or soak measurements.
 
+The evidence bucket lifecycle deletes only the `release-cache/` prefix after
+14 days. Run-scoped receipts, logs, and release evidence use different prefixes
+and are not covered by that transient-build-cache rule.
+
 The release-runner service account requires both
 `roles/storage.objectCreator` and `roles/storage.objectViewer` on the evidence
 bucket. Creator access stores immutable receipts and logs; viewer access lets

--- a/infra/release-runners/README.md
+++ b/infra/release-runners/README.md
@@ -46,7 +46,11 @@ For diagnostics and `remote-release` runs that select executable performance
 gates, the controller first creates one ephemeral `n2-standard-32` builder. It
 compiles the exact candidate once, packages only the selected test executables,
 uploads a SHA-256-bound bundle, and is deleted before the measurement fleet is
-created. Runtime workers still use their catalogued real GCP machine types,
+created. A rerun of the identical candidate, environment, and selected gate set
+reuses that finished bundle from GCS and does not create the builder. Cache
+objects are content-addressed; the controller and workers recheck the cache
+key, result, manifest, bundle, and executable hashes before use. Runtime workers
+still use their catalogued real GCP machine types,
 workloads, durations, and thresholds; they verify the bundle and executable
 hashes instead of recompiling the same graph. This makes compilation a shared
 setup phase without contaminating performance or soak measurements.

--- a/infra/release-runners/gcp-performance-prebuild-startup.sh
+++ b/infra/release-runners/gcp-performance-prebuild-startup.sh
@@ -15,6 +15,7 @@ RUN_ID="$(metadata rvoip-run-id)"
 BUCKET="$(metadata rvoip-evidence-bucket)"
 CACHE_BUCKET="$(metadata rvoip-cache-bucket)"
 PREFIX="$(metadata rvoip-prefix)"
+CACHE_KEY="$(metadata rvoip-prebuild-cache-key)"
 GATES="$(metadata rvoip-gates-b64 | base64 --decode)"
 ENVIRONMENT_ID="$(metadata rvoip-environment-b64 | base64 --decode)"
 WORKSPACE=/opt/rvoip
@@ -25,8 +26,9 @@ STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 START_SECONDS="$(date +%s)"
 BUNDLE_SHA=""
 MANIFEST_SHA=""
-BUNDLE_URI="gs://${BUCKET}/${PREFIX}/performance-prebuilt.tar.gz"
-MANIFEST_URI="gs://${BUCKET}/${PREFIX}/performance-manifest.json"
+CACHE_PREFIX="release-cache/performance-prebuilt-v1/${CACHE_KEY}"
+BUNDLE_URI=""
+MANIFEST_URI=""
 
 token() {
   curl --fail --silent --show-error \
@@ -79,6 +81,7 @@ finish() {
     upload /tmp/prebuild-sccache-stats.txt "${PREFIX}/prebuild-sccache-stats.txt" || true
   fi
   python3 - "$RESULT" "$CANDIDATE" "$RUN_ID" "$ENVIRONMENT_ID" "$GATES" \
+    "$CACHE_KEY" \
     "$STARTED_AT" "$ended_at" "$duration" "$exit_code" "$status" \
     "$BUNDLE_URI" "$BUNDLE_SHA" "$MANIFEST_URI" "$MANIFEST_SHA" <<'PY'
 import json
@@ -90,6 +93,7 @@ import sys
     run_id,
     environment_id,
     gates,
+    cache_key,
     started,
     ended,
     duration,
@@ -106,6 +110,7 @@ payload = {
     "github_run_id": run_id,
     "environment_id": environment_id,
     "selected_gate_ids": sorted({value for value in gates.split(",") if value}),
+    "cache_key_sha256": cache_key,
     "started_at": started,
     "ended_at": ended,
     "duration_seconds": int(duration),
@@ -123,6 +128,12 @@ with open(path, "w", encoding="utf-8") as handle:
 PY
   upload "$LOG" "${PREFIX}/prebuild.log" || true
   upload "$RESULT" "${PREFIX}/prebuild-result.json" || true
+  # The run-scoped result remains authoritative for this invocation. Publish
+  # the cache pointer only after every content-addressed object exists and the
+  # build has passed, so interrupted builders can never create a false hit.
+  if (( exit_code == 0 )); then
+    upload "$RESULT" "${CACHE_PREFIX}/prebuild-result.json" || true
+  fi
   sync
   shutdown -h now || true
   exit "$exit_code"
@@ -201,12 +212,16 @@ python3 scripts/release/prebuilt_performance.py build \
 MANIFEST_SHA="$(sha256sum "$BUNDLE_ROOT/manifest.json" | awk '{print $1}')"
 tar -C /tmp -I 'pigz -3' -cf "$BUNDLE" performance-prebuilt
 BUNDLE_SHA="$(sha256sum "$BUNDLE" | awk '{print $1}')"
-upload "$BUNDLE_ROOT/manifest.json" "${PREFIX}/performance-manifest.json"
-upload "$BUNDLE" "${PREFIX}/performance-prebuilt.tar.gz"
+BUNDLE_OBJECT="${CACHE_PREFIX}/bundles/${BUNDLE_SHA}.tar.gz"
+MANIFEST_OBJECT="${CACHE_PREFIX}/manifests/${MANIFEST_SHA}.json"
+BUNDLE_URI="gs://${BUCKET}/${BUNDLE_OBJECT}"
+MANIFEST_URI="gs://${BUCKET}/${MANIFEST_OBJECT}"
+upload "$BUNDLE_ROOT/manifest.json" "$MANIFEST_OBJECT"
+upload "$BUNDLE" "$BUNDLE_OBJECT"
 
 # Prove that the runtime service account can read evidence before deleting the
 # builder and creating the measurement fleet. Upload-only IAM otherwise fails
 # one VM later and obscures an infrastructure defect as a gate failure.
-download "${PREFIX}/performance-manifest.json" /tmp/performance-manifest-readback.json
+download "$MANIFEST_OBJECT" /tmp/performance-manifest-readback.json
 echo "${MANIFEST_SHA}  /tmp/performance-manifest-readback.json" \
   | sha256sum --check --status

--- a/infra/release-runners/gcp-performance-prebuild-startup.sh
+++ b/infra/release-runners/gcp-performance-prebuild-startup.sh
@@ -63,6 +63,43 @@ download() {
     -o "$destination"
 }
 
+ensure_content_addressed() {
+  local source="$1"
+  local object="$2"
+  local expected_sha="$3"
+  local readback
+  readback="$(mktemp /tmp/rvoip-prebuilt-object.XXXXXX)"
+
+  # ObjectCreator deliberately cannot overwrite. An interrupted or concurrent
+  # builder may already have created this digest path, so verify those bytes
+  # instead of requiring broader storage permissions.
+  if download "$object" "$readback" >/dev/null 2>&1; then
+    if echo "${expected_sha}  ${readback}" | sha256sum --check --status; then
+      rm -f "$readback"
+      return 0
+    fi
+    rm -f "$readback"
+    echo "content-addressed object digest mismatch: ${object}" >&2
+    return 1
+  fi
+  rm -f "$readback"
+
+  if upload "$source" "$object"; then
+    return 0
+  fi
+
+  # A second builder can win after the first read and before this upload.
+  readback="$(mktemp /tmp/rvoip-prebuilt-object.XXXXXX)"
+  if download "$object" "$readback" >/dev/null 2>&1 \
+    && echo "${expected_sha}  ${readback}" | sha256sum --check --status; then
+    rm -f "$readback"
+    return 0
+  fi
+  rm -f "$readback"
+  echo "unable to create or verify content-addressed object: ${object}" >&2
+  return 1
+}
+
 finish() {
   local exit_code=$?
   local ended_at duration status
@@ -216,8 +253,8 @@ BUNDLE_OBJECT="${CACHE_PREFIX}/bundles/${BUNDLE_SHA}.tar.gz"
 MANIFEST_OBJECT="${CACHE_PREFIX}/manifests/${MANIFEST_SHA}.json"
 BUNDLE_URI="gs://${BUCKET}/${BUNDLE_OBJECT}"
 MANIFEST_URI="gs://${BUCKET}/${MANIFEST_OBJECT}"
-upload "$BUNDLE_ROOT/manifest.json" "$MANIFEST_OBJECT"
-upload "$BUNDLE" "$BUNDLE_OBJECT"
+ensure_content_addressed "$BUNDLE_ROOT/manifest.json" "$MANIFEST_OBJECT" "$MANIFEST_SHA"
+ensure_content_addressed "$BUNDLE" "$BUNDLE_OBJECT" "$BUNDLE_SHA"
 
 # Prove that the runtime service account can read evidence before deleting the
 # builder and creating the measurement fleet. Upload-only IAM otherwise fails

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -258,11 +258,34 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("install-bundle", startup)
         self.assertIn("RVOIP_PERF_PREBUILT_MANIFEST", startup)
         self.assertIn("performance-prebuilt.tar.gz", builder)
-        self.assertIn('download "${PREFIX}/performance-manifest.json"', builder)
+        self.assertIn('download "$MANIFEST_OBJECT"', builder)
         self.assertIn("performance-manifest-readback.json", builder)
         self.assertIn("publishing_attempted", builder)
         self.assertIn("bundle digest mismatch", helper)
         self.assertIn("exact candidate", helper)
+
+    def test_exact_candidate_performance_bundle_is_reused_fail_closed(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        builder = (
+            ROOT / "infra/release-runners/gcp-performance-prebuild-startup.sh"
+        ).read_text()
+        helper = (ROOT / "scripts/release/prebuilt_performance.py").read_text()
+
+        self.assertIn("release-cache/performance-prebuilt-v1", workflow)
+        self.assertIn("cache-key", workflow)
+        self.assertIn("--cache-key", workflow)
+        self.assertLess(
+            workflow.index("cached-result.json"),
+            workflow.index("gcloud compute instances create \"$builder\""),
+        )
+        self.assertIn("rvoip-prebuild-cache-key=${cache_key}", workflow)
+        self.assertIn('CACHE_KEY="$(metadata rvoip-prebuild-cache-key)"', builder)
+        self.assertIn("bundles/${BUNDLE_SHA}.tar.gz", builder)
+        self.assertIn("manifests/${MANIFEST_SHA}.json", builder)
+        self.assertIn('if (( exit_code == 0 )); then', builder)
+        self.assertIn('upload "$RESULT" "${CACHE_PREFIX}/prebuild-result.json"', builder)
+        self.assertIn("cache_key_sha256", helper)
+        self.assertIn("outside the expected cache namespace", helper)
 
     def test_gcp_release_builds_use_the_versioned_lld_environment(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -282,6 +282,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('CACHE_KEY="$(metadata rvoip-prebuild-cache-key)"', builder)
         self.assertIn("bundles/${BUNDLE_SHA}.tar.gz", builder)
         self.assertIn("manifests/${MANIFEST_SHA}.json", builder)
+        self.assertIn("ensure_content_addressed", builder)
+        self.assertIn("content-addressed object digest mismatch", builder)
         self.assertIn('if (( exit_code == 0 )); then', builder)
         self.assertIn('upload "$RESULT" "${CACHE_PREFIX}/prebuild-result.json"', builder)
         self.assertIn("cache_key_sha256", helper)

--- a/scripts/release/prebuilt_performance.py
+++ b/scripts/release/prebuilt_performance.py
@@ -28,6 +28,7 @@ from typing import Any
 
 MANIFEST_SCHEMA = "rvoip-performance-prebuilt-v1"
 RESULT_SCHEMA = "rvoip-gcp-performance-prebuild-result-v1"
+CACHE_KEY_SCHEMA = "rvoip-performance-prebuilt-cache-key-v1"
 COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
 ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$", re.DOTALL)
@@ -46,12 +47,43 @@ def canonical_bytes(value: Any) -> bytes:
     return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
 
 
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for block in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(block)
     return digest.hexdigest()
+
+
+def cache_key(*, candidate: str, environment_id: str, gate_ids: list[str]) -> str:
+    """Bind a reusable bundle to one exact build request.
+
+    Candidate identity remains part of the key even when two commits have the
+    same Git tree. A future build script may legitimately consume commit
+    metadata, so cross-commit reuse would not be fail-closed.
+    """
+
+    if not COMMIT_SHA.fullmatch(candidate):
+        raise PrebuiltError("cache candidate must be a full lowercase commit SHA")
+    if not environment_id:
+        raise PrebuiltError("cache environment ID must be non-empty")
+    selected = sorted({gate_id for gate_id in gate_ids if gate_id})
+    if not selected:
+        raise PrebuiltError("cache gate set must be non-empty")
+    return sha256_bytes(
+        canonical_bytes(
+            {
+                "schema": CACHE_KEY_SCHEMA,
+                "candidate_sha": candidate,
+                "environment_id": environment_id,
+                "selected_gate_ids": selected,
+            }
+        )
+    )
 
 
 def load_json(path: Path, description: str) -> dict[str, Any]:
@@ -727,6 +759,7 @@ def validate_result(
     candidate: str,
     environment_id: str,
     gate_ids: list[str],
+    expected_cache_key: str | None = None,
 ) -> dict[str, Any]:
     result = load_json(result_path, "GCP prebuild result")
     expected = {
@@ -743,6 +776,14 @@ def validate_result(
         for key, value in expected.items()
         if result.get(key) != value
     ]
+    if expected_cache_key is not None:
+        if not HEX_SHA256.fullmatch(expected_cache_key):
+            raise PrebuiltError("expected performance cache key is invalid")
+        if result.get("cache_key_sha256") != expected_cache_key:
+            failures.append(
+                "cache_key_sha256: expected "
+                f"{expected_cache_key!r}, got {result.get('cache_key_sha256')!r}"
+            )
     if not HEX_SHA256.fullmatch(str(result.get("bundle_sha256", ""))):
         failures.append("bundle_sha256 is missing or invalid")
     if not HEX_SHA256.fullmatch(str(result.get("manifest_sha256", ""))):
@@ -750,9 +791,20 @@ def validate_result(
     uri = result.get("bundle_uri")
     if not isinstance(uri, str) or not uri.startswith("gs://"):
         failures.append("bundle_uri is missing or invalid")
+    elif not uri.endswith(f"/bundles/{result.get('bundle_sha256')}.tar.gz"):
+        failures.append("bundle_uri is not content-addressed by bundle_sha256")
     manifest_uri = result.get("manifest_uri")
     if not isinstance(manifest_uri, str) or not manifest_uri.startswith("gs://"):
         failures.append("manifest_uri is missing or invalid")
+    elif not manifest_uri.endswith(
+        f"/manifests/{result.get('manifest_sha256')}.json"
+    ):
+        failures.append("manifest_uri is not content-addressed by manifest_sha256")
+    if expected_cache_key is not None:
+        required_fragment = f"/performance-prebuilt-v1/{expected_cache_key}/"
+        for label, value in (("bundle_uri", uri), ("manifest_uri", manifest_uri)):
+            if isinstance(value, str) and required_fragment not in value:
+                failures.append(f"{label} is outside the expected cache namespace")
     if failures:
         raise PrebuiltError(
             "GCP prebuild result verification failed:\n- " + "\n- ".join(failures)
@@ -767,6 +819,11 @@ def parser() -> argparse.ArgumentParser:
     select = commands.add_parser("select-gates")
     select.add_argument("--catalog", type=Path, required=True)
     select.add_argument("--gates", required=True)
+
+    cache = commands.add_parser("cache-key")
+    cache.add_argument("--candidate", required=True)
+    cache.add_argument("--environment-id", required=True)
+    cache.add_argument("--gates", required=True)
 
     build = commands.add_parser("build")
     build.add_argument("--workspace", type=Path, required=True)
@@ -809,6 +866,7 @@ def parser() -> argparse.ArgumentParser:
     verify.add_argument("--candidate", required=True)
     verify.add_argument("--environment-id", required=True)
     verify.add_argument("--gates", required=True)
+    verify.add_argument("--cache-key")
     verify.add_argument("--github-output", type=Path)
     return result
 
@@ -832,6 +890,14 @@ def main(argv: list[str] | None = None) -> int:
                     gate_id
                     for gate_id in selected
                     if gate_definition(by_id[gate_id]) is not None
+                )
+            )
+        elif args.command == "cache-key":
+            print(
+                cache_key(
+                    candidate=args.candidate,
+                    environment_id=args.environment_id,
+                    gate_ids=csv_values(args.gates),
                 )
             )
         elif args.command == "build":
@@ -899,6 +965,7 @@ def main(argv: list[str] | None = None) -> int:
                 candidate=args.candidate,
                 environment_id=args.environment_id,
                 gate_ids=csv_values(args.gates),
+                expected_cache_key=args.cache_key,
             )
             if args.github_output:
                 with args.github_output.open("a", encoding="utf-8") as handle:

--- a/scripts/test_release_prebuilt_performance.py
+++ b/scripts/test_release_prebuilt_performance.py
@@ -88,16 +88,25 @@ class PrebuiltPerformanceTests(unittest.TestCase):
 
     def test_result_is_bound_to_candidate_environment_and_gate_set(self) -> None:
         candidate = "a" * 40
+        cache_key = prebuilt.cache_key(
+            candidate=candidate,
+            environment_id="environment-v1",
+            gate_ids=["perf.two", "perf.one"],
+        )
+        cache_root = (
+            "gs://bucket/release-cache/performance-prebuilt-v1/" + cache_key
+        )
         payload = {
             "schema": prebuilt.RESULT_SCHEMA,
             "candidate_sha": candidate,
             "environment_id": "environment-v1",
             "selected_gate_ids": ["perf.one", "perf.two"],
+            "cache_key_sha256": cache_key,
             "status": "PASS",
             "exit_code": 0,
-            "bundle_uri": "gs://bucket/release/1/prebuild/performance-prebuilt.tar.gz",
+            "bundle_uri": f"{cache_root}/bundles/{'b' * 64}.tar.gz",
             "bundle_sha256": "b" * 64,
-            "manifest_uri": "gs://bucket/release/1/prebuild/performance-manifest.json",
+            "manifest_uri": f"{cache_root}/manifests/{'d' * 64}.json",
             "manifest_sha256": "d" * 64,
             "publishing_attempted": False,
         }
@@ -109,6 +118,7 @@ class PrebuiltPerformanceTests(unittest.TestCase):
                 candidate=candidate,
                 environment_id="environment-v1",
                 gate_ids=["perf.two", "perf.one"],
+                expected_cache_key=cache_key,
             )
             self.assertEqual(verified["bundle_sha256"], "b" * 64)
             payload["candidate_sha"] = "c" * 40
@@ -119,6 +129,72 @@ class PrebuiltPerformanceTests(unittest.TestCase):
                     candidate=candidate,
                     environment_id="environment-v1",
                     gate_ids=["perf.one", "perf.two"],
+                    expected_cache_key=cache_key,
+                )
+
+    def test_cache_key_is_order_independent_and_exact_candidate_bound(self) -> None:
+        first = prebuilt.cache_key(
+            candidate="a" * 40,
+            environment_id="environment-v1",
+            gate_ids=["perf.two", "perf.one", "perf.two"],
+        )
+        reordered = prebuilt.cache_key(
+            candidate="a" * 40,
+            environment_id="environment-v1",
+            gate_ids=["perf.one", "perf.two"],
+        )
+        other_candidate = prebuilt.cache_key(
+            candidate="b" * 40,
+            environment_id="environment-v1",
+            gate_ids=["perf.one", "perf.two"],
+        )
+        other_environment = prebuilt.cache_key(
+            candidate="a" * 40,
+            environment_id="environment-v2",
+            gate_ids=["perf.one", "perf.two"],
+        )
+        other_gates = prebuilt.cache_key(
+            candidate="a" * 40,
+            environment_id="environment-v1",
+            gate_ids=["perf.one"],
+        )
+        self.assertEqual(first, reordered)
+        self.assertEqual(len(first), 64)
+        self.assertEqual(
+            len({first, other_candidate, other_environment, other_gates}), 4
+        )
+
+    def test_cached_result_rejects_non_content_addressed_objects(self) -> None:
+        candidate = "a" * 40
+        key = prebuilt.cache_key(
+            candidate=candidate,
+            environment_id="environment-v1",
+            gate_ids=["perf.one"],
+        )
+        payload = {
+            "schema": prebuilt.RESULT_SCHEMA,
+            "candidate_sha": candidate,
+            "environment_id": "environment-v1",
+            "selected_gate_ids": ["perf.one"],
+            "cache_key_sha256": key,
+            "status": "PASS",
+            "exit_code": 0,
+            "bundle_uri": "gs://bucket/mutable/performance-prebuilt.tar.gz",
+            "bundle_sha256": "b" * 64,
+            "manifest_uri": "gs://bucket/mutable/performance-manifest.json",
+            "manifest_sha256": "d" * 64,
+            "publishing_attempted": False,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            result = Path(directory) / "result.json"
+            result.write_text(json.dumps(payload))
+            with self.assertRaisesRegex(prebuilt.PrebuiltError, "content-addressed"):
+                prebuilt.validate_result(
+                    result,
+                    candidate=candidate,
+                    environment_id="environment-v1",
+                    gate_ids=["perf.one"],
+                    expected_cache_key=key,
                 )
 
     def test_bundle_rejects_path_traversal_before_extraction(self) -> None:


### PR DESCRIPTION
## What changed

- Cache the finished exact-candidate performance bundle in GCS, keyed by candidate SHA, release environment, and selected gate set.
- Resolve and verify that cache before provisioning the 32-vCPU prebuilder.
- Store the bundle and manifest under content-addressed object names.
- Validate the cache key, result, bundle, manifest, and executable hashes before use.
- Preserve all existing GCP worker types, workloads, durations, and acceptance thresholds.

## Why

Compiler-object caching still leaves roughly 17 minutes of full-LTO code generation and linking on every repeated diagnostic run. An identical workflow rerun can safely reuse the already-finished exact binary bundle and begin provisioning measurement workers in seconds.

A cache miss, stale entry, changed candidate, changed environment, changed gate set, or digest mismatch cannot be attested into passing. The workflow falls back to a clean ephemeral build when no verified hit exists.

## Impact

Repeated tests of the same exact candidate avoid the full release-binary rebuild. Fresh candidates still build normally, and all performance and soak measurements continue on the catalogued real GCP machines.

## Validation

- `python3 -m unittest scripts.test_release_prebuilt_performance scripts.ci.test_workflow_policy`
- `bash -n infra/release-runners/gcp-performance-prebuild-startup.sh`
- workflow YAML parse
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release qualification prebuild orchestration and GCS object layout; incorrect cache validation could skip a needed rebuild, but verification is fail-closed on key, namespace, and digest mismatches.
> 
> **Overview**
> Adds a **GCS-backed reuse path** for the shared exact-candidate performance prebuild so identical reruns can skip the ephemeral `n2-standard-32` builder when a verified bundle already exists.
> 
> The release-qualify controller now derives a **cache key** from candidate SHA, release environment, and selected performance gates, then tries `release-cache/performance-prebuilt-v1/{key}/prebuild-result.json` **before** creating the builder. On a verified hit it reuses that result; on miss or any verification failure it builds as before. Step summaries distinguish cache hits from fresh builds.
> 
> `prebuilt_performance.py` gains a `cache-key` command and stricter `verify-result` checks: `cache_key_sha256`, content-addressed `bundle_uri` / `manifest_uri`, and namespace validation. The prebuild startup script uploads bundles and manifests under digest-based paths via `ensure_content_addressed` (handles concurrent builders without overwrite), records the cache key in results, and publishes the cache pointer only after a successful PASS.
> 
> Docs note cross-run reuse semantics and that **`release-cache/`** is lifecycle-managed (14 days), separate from durable run evidence. Tests cover cache-key stability and fail-closed verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b737d34167996e8e9544d67a20d5c8b7cf424ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->