### PR TITLE
Require FreeSWITCH registrar readiness

### DIFF
--- a/crates/sip/rvoip-sip/examples/pbx/run.sh
+++ b/crates/sip/rvoip-sip/examples/pbx/run.sh
@@ -814,15 +814,24 @@ wait_for_pbx_tls_ready() {
   while [ "$i" -le "$attempts" ]; do
     nc_rc=1
     openssl_rc=1
+    fs_cli_rc=0
     {
       echo
       echo "## attempt $i"
       if [ "$provider" = "freeswitch" ] && command -v docker >/dev/null 2>&1; then
-        # fs_cli is useful diagnostic evidence, but the profile may still be
-        # starting. Under `set -e` that expected probe failure must not abort
-        # the readiness loop before the authoritative socket checks below.
-        docker exec rvoip-freeswitch fs_cli -x "sofia status profile rvoip_tls_srtp" 2>&1 \
-          | sed -n '1,80p' || true
+        fs_cli_rc=1
+        if fs_cli_output=$(docker exec rvoip-freeswitch \
+          fs_cli -p "${FREESWITCH_EVENT_SOCKET_PASSWORD:-ClueCon}" \
+          -x "sofia status" 2>&1); then
+          printf '%s\n' "$fs_cli_output" | sed -n '1,80p'
+          if printf '%s\n' "$fs_cli_output" \
+            | grep -Eq 'rvoip_tls_srtp[[:space:]].*RUNNING'; then
+            fs_cli_rc=0
+          fi
+        else
+          printf '%s\n' "$fs_cli_output" | sed -n '1,80p'
+        fi
+        echo "fs_cli_rc=$fs_cli_rc"
       fi
       if command -v nc >/dev/null 2>&1; then
         if nc -z -w 2 "$host" "$port"; then
@@ -832,31 +841,33 @@ wait_for_pbx_tls_ready() {
         fi
         echo "nc_rc=$nc_rc"
       else
-        nc_rc=0
-        echo "nc not found; skipping TCP socket probe"
+        echo "nc not found; TLS readiness requires the TCP socket probe"
       fi
       if command -v openssl >/dev/null 2>&1; then
-        if printf '' \
-          | openssl s_client -connect "$host:$port" -servername "$host" -brief 2>&1 \
-          | sed -n '1,80p'; then
+        if openssl_output=$(printf '' \
+          | openssl s_client -connect "$host:$port" -servername "$host" -brief 2>&1); then
           openssl_rc=0
         else
           openssl_rc=$?
         fi
+        printf '%s\n' "$openssl_output" | sed -n '1,80p'
         echo "openssl_rc=$openssl_rc"
       else
-        openssl_rc=0
-        echo "openssl not found; skipping TLS handshake probe"
+        echo "openssl not found; TLS readiness requires the handshake probe"
       fi
     } >>"$ready_log" 2>&1
-    if [ "$nc_rc" -eq 0 ]; then
+    if [ "$nc_rc" -eq 0 ] && [ "$openssl_rc" -eq 0 ] && [ "$fs_cli_rc" -eq 0 ]; then
       echo "ready_at_attempt=$i" >>"$ready_log"
       return 0
     fi
     sleep "$sleep_secs"
     i=$((i + 1))
   done
-  echo "PBX TLS socket was not ready at $host:$port after $attempts attempts; see $ready_log" >&2
+  if [ "$provider" = "freeswitch" ] && command -v docker >/dev/null 2>&1; then
+    capture_command "$out_dir/freeswitch-container.log" \
+      docker logs rvoip-freeswitch
+  fi
+  echo "PBX TLS service was not ready at $host:$port after $attempts attempts; see $ready_log" >&2
   return 1
 }
 
@@ -895,6 +906,12 @@ run_prewarm_one() {
   ) >>"$log" 2>&1
   rc=$?
   set -e
+
+  if [ "$rc" -ne 0 ] && [ "$provider" = "freeswitch" ] \
+    && command -v docker >/dev/null 2>&1; then
+    capture_command "$out_dir/freeswitch-container.log" \
+      docker logs rvoip-freeswitch
+  fi
 
   ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   duration=$(( $(date +%s) - start_epoch ))

--- a/infra/release-runners/interop-lifecycle.sh
+++ b/infra/release-runners/interop-lifecycle.sh
@@ -38,6 +38,42 @@ wait_udp_port() {
   return 1
 }
 
+wait_freeswitch_control_plane() {
+  local container="$1"
+  local password="$2"
+  local attempts="${RVOIP_FREESWITCH_READY_ATTEMPTS:-180}"
+  local consecutive_ready=0
+  local sofia_status=""
+
+  for _ in $(seq 1 "$attempts"); do
+    if sofia_status="$(
+      docker exec "$container" fs_cli -p "$password" \
+        -x "sofia status" 2>&1
+    )" && grep -Eq 'rvoip_udp[[:space:]].*RUNNING' <<<"$sofia_status" \
+      && grep -Eq 'rvoip_tls_srtp[[:space:]].*RUNNING' <<<"$sofia_status"; then
+      consecutive_ready="$((consecutive_ready + 1))"
+      if [[ "$consecutive_ready" -ge 2 ]]; then
+        return 0
+      fi
+    else
+      consecutive_ready=0
+    fi
+
+    if ! docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null \
+      | grep -qx true; then
+      echo "$container exited before the FreeSWITCH control plane became ready" >&2
+      docker logs "$container" >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+
+  echo "FreeSWITCH control plane did not become ready in $container" >&2
+  printf 'sofia status:\n%s\n' "$sofia_status" >&2
+  docker logs "$container" >&2 || true
+  return 1
+}
+
 down() {
   docker rm -f "$1" >/dev/null 2>&1 || true
 }
@@ -134,6 +170,7 @@ PY
     -e FS_EXTERNAL_RTP_IP=127.0.0.1 \
     rvoip-release-freeswitch >/dev/null
   wait_udp_port rvoip-freeswitch 5062
+  wait_freeswitch_control_plane rvoip-freeswitch ClueCon
   cat > "$LOCAL_ENV_ROOT/freeswitch/freeswitch-local.env" <<'EOF'
 FREESWITCH_ADDR=127.0.0.1:5060
 FREESWITCH_IP=127.0.0.1

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -439,6 +439,14 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn("nc -z 127.0.0.1", lifecycle)
         self.assertIn("--name rvoip-freeswitch", lifecycle)
         self.assertIn("wait_udp_port rvoip-freeswitch 5062", lifecycle)
+        self.assertIn("wait_freeswitch_control_plane", lifecycle)
+        self.assertIn(
+            "wait_freeswitch_control_plane rvoip-freeswitch ClueCon", lifecycle
+        )
+        self.assertIn('fs_cli -p "$password"', lifecycle)
+        self.assertIn('-x "sofia status"', lifecycle)
+        self.assertIn('rvoip_udp[[:space:]].*RUNNING', lifecycle)
+        self.assertIn('rvoip_tls_srtp[[:space:]].*RUNNING', lifecycle)
         self.assertNotIn("--name rvoip-release-freeswitch", lifecycle)
         self.assertNotIn("down rvoip-release-freeswitch", lifecycle)
         for path in (
@@ -449,6 +457,22 @@ class WorkflowPolicyTests(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 self.assertTrue((ROOT / path).is_file())
+
+        pbx_runner = (
+            ROOT / "crates/sip/rvoip-sip/examples/pbx/run.sh"
+        ).read_text()
+        self.assertIn('fs_cli_rc=0', pbx_runner)
+        self.assertIn('FREESWITCH_EVENT_SOCKET_PASSWORD:-ClueCon', pbx_runner)
+        self.assertIn('[ "$openssl_rc" -eq 0 ]', pbx_runner)
+        self.assertIn('[ "$fs_cli_rc" -eq 0 ]', pbx_runner)
+        self.assertIn(
+            "nc not found; TLS readiness requires the TCP socket probe", pbx_runner
+        )
+        self.assertIn(
+            "openssl not found; TLS readiness requires the handshake probe",
+            pbx_runner,
+        )
+        self.assertIn('freeswitch-container.log', pbx_runner)
 
     def test_linux_proxy_helpers_share_the_reviewed_host_network(self) -> None:
         common = (


### PR DESCRIPTION
## Problem

Full non-publishing release qualification run 30781786498 passed all hosted, performance, burst, and proxy shards, but interop.freeswitch-matrix failed before running any matrix cells. UDP 5062 was open while the FreeSWITCH event socket and SIP registrar profiles were still starting; the first endpoint registration received 503.

## Fix

- Require the FreeSWITCH event socket to answer and both rvoip_udp and rvoip_tls_srtp profiles to report RUNNING twice consecutively before the lifecycle step succeeds.
- Require TCP, TLS handshake, and FreeSWITCH control-plane probes in the PBX prewarm path.
- Capture container logs when readiness or prewarm fails.
- Extend workflow policy coverage for these fail-closed checks.

No performance requirement, soak duration, test matrix, or threshold is reduced.

## Verification

- 97 release-script tests passed.
- 86 CI policy/planner tests passed.
- Bash and POSIX shell syntax checks passed.
- Modified shell paths passed static analysis with existing repository-wide legacy warning classes excluded.

After PR checks pass, a focused GCE diagnostic will rerun the real FreeSWITCH lifecycle and matrix before the next exact-candidate release qualification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell-only readiness and CI policy assertions; no production SIP/runtime logic changes, but interop may fail longer if FreeSWITCH starts slowly.
> 
> **Overview**
> Release and PBX interop no longer treat an open UDP port as “FreeSWITCH is up.” **Lifecycle** now waits for `fs_cli` and requires both `rvoip_udp` and `rvoip_tls_srtp` Sofia profiles to show **RUNNING** on two consecutive polls before `freeswitch-up` succeeds.
> 
> **PBX TLS prewarm** readiness is fail-closed: success needs TCP (`nc`), a TLS handshake (`openssl`), and—for FreeSWITCH—the `rvoip_tls_srtp` profile **RUNNING** via the event socket (with `FREESWITCH_EVENT_SOCKET_PASSWORD`). Missing `nc`/`openssl` no longer skips those checks. On readiness or prewarm failure, **`docker logs`** for `rvoip-freeswitch` are captured to `freeswitch-container.log`.
> 
> **Workflow policy tests** assert the new lifecycle waiter and the stricter PBX runner probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5adf5679aa1c1e0e3674b3e082f98db8678147d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->