### PR TITLE
Fix selective release evidence reuse

### DIFF
--- a/scripts/release/build_gate_catalog.py
+++ b/scripts/release/build_gate_catalog.py
@@ -408,7 +408,7 @@ def core_gate(package: dict[str, Any], root: Path, weights: dict[str, int]) -> d
         "retry_on_exit_codes": [75],
         "max_infrastructure_retries": 1,
         "affected_crates": [name],
-        "affected_paths": [f"{crate_root}/**"],
+        "affected_paths": [f"{crate_root}/**", "scripts/ci/run_checks.py"],
         "expected_outputs": ["receipt.json", "command.log", "nested-ci-receipt.json"],
         "estimated_seconds": int(weights.get(name, 2)) * 60,
         "always_fresh": False,

--- a/scripts/release/gates.json
+++ b/scripts/release/gates.json
@@ -6993,7 +6993,8 @@
         "rvoip"
       ],
       "affected_paths": [
-        "crates/rvoip/**"
+        "crates/rvoip/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7036,7 +7037,8 @@
         "rvoip-amazon-connect"
       ],
       "affected_paths": [
-        "crates/webrtc/rvoip-amazon-connect/**"
+        "crates/webrtc/rvoip-amazon-connect/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7079,7 +7081,8 @@
         "rvoip-audio-device"
       ],
       "affected_paths": [
-        "crates/media/rvoip-audio-device/**"
+        "crates/media/rvoip-audio-device/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7122,7 +7125,8 @@
         "rvoip-audit"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-audit/**"
+        "crates/extensions/rvoip-audit/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7165,7 +7169,8 @@
         "rvoip-auth-core"
       ],
       "affected_paths": [
-        "crates/identity/auth-core/**"
+        "crates/identity/auth-core/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7208,7 +7213,8 @@
         "rvoip-client"
       ],
       "affected_paths": [
-        "crates/rvoip-client/**"
+        "crates/rvoip-client/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7251,7 +7257,8 @@
         "rvoip-codec-core"
       ],
       "affected_paths": [
-        "crates/media/codec-core/**"
+        "crates/media/codec-core/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7294,7 +7301,8 @@
         "rvoip-core"
       ],
       "affected_paths": [
-        "crates/foundation/rvoip-core/**"
+        "crates/foundation/rvoip-core/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7337,7 +7345,8 @@
         "rvoip-core-traits"
       ],
       "affected_paths": [
-        "crates/foundation/rvoip-core-traits/**"
+        "crates/foundation/rvoip-core-traits/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7380,7 +7389,8 @@
         "rvoip-harness"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-harness/**"
+        "crates/extensions/rvoip-harness/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7423,7 +7433,8 @@
         "rvoip-identity"
       ],
       "affected_paths": [
-        "crates/identity/rvoip-identity/**"
+        "crates/identity/rvoip-identity/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7466,7 +7477,8 @@
         "rvoip-ims-aka"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-ims-aka/**"
+        "crates/extensions/rvoip-ims-aka/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7509,7 +7521,8 @@
         "rvoip-infra-common"
       ],
       "affected_paths": [
-        "crates/foundation/infra-common/**"
+        "crates/foundation/infra-common/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7552,7 +7565,8 @@
         "rvoip-keycloak"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-keycloak/**"
+        "crates/extensions/rvoip-keycloak/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7595,7 +7609,8 @@
         "rvoip-ldap"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-ldap/**"
+        "crates/extensions/rvoip-ldap/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7638,7 +7653,8 @@
         "rvoip-media-core"
       ],
       "affected_paths": [
-        "crates/media/media-core/**"
+        "crates/media/media-core/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7681,7 +7697,8 @@
         "rvoip-moq"
       ],
       "affected_paths": [
-        "crates/moq/rvoip-moq/**"
+        "crates/moq/rvoip-moq/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7724,7 +7741,8 @@
         "rvoip-moq-native"
       ],
       "affected_paths": [
-        "crates/moq/rvoip-moq-native/**"
+        "crates/moq/rvoip-moq-native/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7767,7 +7785,8 @@
         "rvoip-moq-relay"
       ],
       "affected_paths": [
-        "crates/moq/rvoip-moq-relay/**"
+        "crates/moq/rvoip-moq-relay/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7810,7 +7829,8 @@
         "rvoip-moq-transport"
       ],
       "affected_paths": [
-        "crates/moq/rvoip-moq-transport/**"
+        "crates/moq/rvoip-moq-transport/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7853,7 +7873,8 @@
         "rvoip-oidc"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-oidc/**"
+        "crates/extensions/rvoip-oidc/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7896,7 +7917,8 @@
         "rvoip-quic"
       ],
       "affected_paths": [
-        "crates/uctp/rvoip-quic/**"
+        "crates/uctp/rvoip-quic/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7939,7 +7961,8 @@
         "rvoip-redis"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-redis/**"
+        "crates/extensions/rvoip-redis/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -7982,7 +8005,8 @@
         "rvoip-rtc"
       ],
       "affected_paths": [
-        "crates/webrtc/rvoip-rtc/**"
+        "crates/webrtc/rvoip-rtc/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8025,7 +8049,8 @@
         "rvoip-rtp-core"
       ],
       "affected_paths": [
-        "crates/media/rtp-core/**"
+        "crates/media/rtp-core/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8068,7 +8093,8 @@
         "rvoip-saml"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-saml/**"
+        "crates/extensions/rvoip-saml/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8111,7 +8137,8 @@
         "rvoip-scim"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-scim/**"
+        "crates/extensions/rvoip-scim/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8154,7 +8181,8 @@
         "rvoip-sip"
       ],
       "affected_paths": [
-        "crates/sip/rvoip-sip/**"
+        "crates/sip/rvoip-sip/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8197,7 +8225,8 @@
         "rvoip-sip-core"
       ],
       "affected_paths": [
-        "crates/sip/sip-core/**"
+        "crates/sip/sip-core/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8240,7 +8269,8 @@
         "rvoip-sip-dialog"
       ],
       "affected_paths": [
-        "crates/sip/sip-dialog/**"
+        "crates/sip/sip-dialog/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8283,7 +8313,8 @@
         "rvoip-sip-proxy"
       ],
       "affected_paths": [
-        "crates/sip/sip-proxy/**"
+        "crates/sip/sip-proxy/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8326,7 +8357,8 @@
         "rvoip-sip-registrar"
       ],
       "affected_paths": [
-        "crates/sip/sip-registrar/**"
+        "crates/sip/sip-registrar/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8369,7 +8401,8 @@
         "rvoip-sip-transport"
       ],
       "affected_paths": [
-        "crates/sip/sip-transport/**"
+        "crates/sip/sip-transport/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8412,7 +8445,8 @@
         "rvoip-stir-shaken"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-stir-shaken/**"
+        "crates/extensions/rvoip-stir-shaken/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8455,7 +8489,8 @@
         "rvoip-uctp"
       ],
       "affected_paths": [
-        "crates/uctp/rvoip-uctp/**"
+        "crates/uctp/rvoip-uctp/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8498,7 +8533,8 @@
         "rvoip-users-core"
       ],
       "affected_paths": [
-        "crates/identity/users-core/**"
+        "crates/identity/users-core/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8541,7 +8577,8 @@
         "rvoip-vapi"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-vapi/**"
+        "crates/extensions/rvoip-vapi/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8584,7 +8621,8 @@
         "rvoip-vcon"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-vcon/**"
+        "crates/extensions/rvoip-vcon/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8627,7 +8665,8 @@
         "rvoip-vcon-postgres"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-vcon-postgres/**"
+        "crates/extensions/rvoip-vcon-postgres/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8670,7 +8709,8 @@
         "rvoip-webauthn"
       ],
       "affected_paths": [
-        "crates/extensions/rvoip-webauthn/**"
+        "crates/extensions/rvoip-webauthn/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8713,7 +8753,8 @@
         "rvoip-webrtc"
       ],
       "affected_paths": [
-        "crates/webrtc/rvoip-webrtc/**"
+        "crates/webrtc/rvoip-webrtc/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8756,7 +8797,8 @@
         "rvoip-webrtc-stack"
       ],
       "affected_paths": [
-        "crates/webrtc/rvoip-webrtc-stack/**"
+        "crates/webrtc/rvoip-webrtc-stack/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8799,7 +8841,8 @@
         "rvoip-websocket"
       ],
       "affected_paths": [
-        "crates/uctp/rvoip-websocket/**"
+        "crates/uctp/rvoip-websocket/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",
@@ -8842,7 +8885,8 @@
         "rvoip-webtransport"
       ],
       "affected_paths": [
-        "crates/uctp/rvoip-webtransport/**"
+        "crates/uctp/rvoip-webtransport/**",
+        "scripts/ci/run_checks.py"
       ],
       "always_fresh": false,
       "category": "Parallel 44-crate core",

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -27,6 +27,11 @@ AGGREGATE_SCHEMA = "rvoip-release-qualification-v1"
 DEFAULT_CATALOG = Path("scripts/release/gates.json")
 MAX_DIAGNOSTIC_GATES = 20
 COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+RUNTIME_EVIDENCE_NEUTRAL_PATHS = (
+    "docs/**",
+    "scripts/ci/test_*.py",
+    "scripts/test_release*.py",
+)
 
 
 class GateError(RuntimeError):
@@ -278,7 +283,6 @@ def input_record(
             "Cargo.lock",
             "rust-toolchain.toml",
             "scripts/release/gates.py",
-            "scripts/ci/**",
             ".config/**",
             ".github/workflows/**",
             "deny.toml",
@@ -359,9 +363,38 @@ def exact_reusable(
     return None
 
 
+def parse_name_status_z(output: str) -> list[str]:
+    """Return both sides of rename/copy records from ``git diff -z`` output."""
+
+    fields = output.split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+    paths: set[str] = set()
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        index += 1
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        if not status or index + path_count > len(fields):
+            raise GateError("malformed NUL-delimited git name-status output")
+        paths.update(fields[index : index + path_count])
+        index += path_count
+    return sorted(paths)
+
+
 def changed_files(root: Path, base: str, candidate: str) -> list[str]:
-    output = git(root, "diff", "--name-only", "--find-renames", f"{base}...{candidate}")
-    return sorted(set(filter(None, output.splitlines())))
+    output = run(
+        [
+            "git",
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            f"{base}...{candidate}",
+        ],
+        root=root,
+    ).stdout
+    return parse_name_status_z(output)
 
 
 def unknown_change(
@@ -375,8 +408,27 @@ def unknown_change(
     return [
         path
         for path in paths
-        if not any(matches(path, gate.get("affected_paths", [])) for gate in meaningful)
+        if not matches(path, RUNTIME_EVIDENCE_NEUTRAL_PATHS)
+        and not any(matches(path, gate.get("affected_paths", [])) for gate in meaningful)
     ]
+
+
+def directly_changed_gate_ids(
+    paths: list[str], selected_gates: list[dict[str, Any]]
+) -> set[str]:
+    """Return runtime gates whose declared inputs intersect the candidate diff.
+
+    Always-fresh source and reporting gates regenerate their own receipts for
+    every candidate.  Their broad ``**`` mappings must not invalidate every
+    runtime gate that depends on those bookkeeping receipts.
+    """
+
+    return {
+        gate["id"]
+        for gate in selected_gates
+        if not gate.get("always_fresh")
+        and any(matches(path, gate.get("affected_paths", [])) for path in paths)
+    }
 
 
 def reverse_gate_dependencies(selected: list[str], by_id: dict[str, dict[str, Any]]) -> dict[str, set[str]]:
@@ -581,11 +633,9 @@ def create_plan(
     }
     reverse_dependencies = reverse_gate_dependencies(selected, by_id)
     invalidated_by_failure = dependent_closure(previous_failures, reverse_dependencies)
-    changed_gate_ids = {
-        gate_id
-        for gate_id in selected
-        if any(matches(path, by_id[gate_id].get("affected_paths", [])) for path in changed)
-    }
+    changed_gate_ids = directly_changed_gate_ids(
+        changed, [by_id[gate_id] for gate_id in selected]
+    )
     invalidated_by_change = dependent_closure(changed_gate_ids, reverse_dependencies)
     reusable_receipts = {
         gate_id: exact_reusable(

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -45,6 +45,12 @@ class GateFrameworkTests(unittest.TestCase):
             self.catalog["remote_release_legacy_coverage"]["required_legacy_count"],
             108,
         )
+        core_gates = [
+            gate for gate in self.catalog["gates"] if gate["id"].startswith("core.")
+        ]
+        self.assertTrue(
+            all("scripts/ci/run_checks.py" in gate["affected_paths"] for gate in core_gates)
+        )
 
     def test_checked_in_catalog_is_reproducible(self) -> None:
         generated = builder.build_catalog(
@@ -581,6 +587,50 @@ class GateFrameworkTests(unittest.TestCase):
             {"changed", "consumer", "consumer-of-consumer"},
         )
 
+    def test_always_fresh_bookkeeping_does_not_invalidate_runtime_gates(self) -> None:
+        selected = [
+            {
+                "id": "source.clean",
+                "always_fresh": True,
+                "affected_paths": ["**"],
+            },
+            {
+                "id": "interop.freeswitch",
+                "always_fresh": False,
+                "affected_paths": ["infra/release-runners/interop-lifecycle.sh"],
+            },
+            {
+                "id": "core.unrelated",
+                "always_fresh": False,
+                "affected_paths": ["crates/core/**"],
+            },
+        ]
+        self.assertEqual(
+            gates.directly_changed_gate_ids(
+                ["infra/release-runners/interop-lifecycle.sh"], selected
+            ),
+            {"interop.freeswitch"},
+        )
+
+    def test_changed_path_parser_keeps_rename_copy_and_delete_sources(self) -> None:
+        self.assertEqual(
+            gates.parse_name_status_z(
+                "R100\0crates/old.rs\0docs/new.md\0"
+                "C090\0crates/source.rs\0crates/copy.rs\0"
+                "D\0crates/deleted.rs\0M\0crates/modified.rs\0"
+            ),
+            [
+                "crates/copy.rs",
+                "crates/deleted.rs",
+                "crates/modified.rs",
+                "crates/old.rs",
+                "crates/source.rs",
+                "docs/new.md",
+            ],
+        )
+        with self.assertRaises(gates.GateError):
+            gates.parse_name_status_z("R100\0only-old-path\0")
+
     def test_shard_runs_gate_dependencies_before_dependents(self) -> None:
         by_id = {
             "c": {"dependencies": ["b"]},
@@ -610,6 +660,54 @@ class GateFrameworkTests(unittest.TestCase):
             gates.unknown_change(["crates/unknown/lib.rs"], selected),
             ["crates/unknown/lib.rs"],
         )
+        self.assertEqual(
+            gates.unknown_change(
+                [
+                    "docs/release-notes.md",
+                    "scripts/ci/test_workflow_policy.py",
+                    "scripts/test_release_gates.py",
+                ],
+                selected,
+            ),
+            [],
+        )
+
+    def test_ci_policy_tests_do_not_change_unrelated_gate_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            runner = root / "scripts/release/gates.py"
+            policy_test = root / "scripts/ci/test_workflow_policy.py"
+            runner.parent.mkdir(parents=True)
+            policy_test.parent.mkdir(parents=True)
+            runner.write_text("runner-v1\n")
+            policy_test.write_text("test-v1\n")
+            gate = {
+                "id": "gate-a",
+                "resource_class": "github-standard",
+                "affected_paths": ["crates/a/**"],
+                "affected_crates": [],
+                "dependencies": [],
+                "command": ["true"],
+            }
+            definitions = {"gate-a": gate}
+
+            def record() -> dict:
+                return gates.input_record(
+                    root=root,
+                    gate=gate,
+                    environment_id="environment-v1",
+                    files=[
+                        "scripts/release/gates.py",
+                        "scripts/ci/test_workflow_policy.py",
+                    ],
+                    package_roots={},
+                    package_dependencies={},
+                    gate_definitions=definitions,
+                )
+
+            first = record()
+            policy_test.write_text("test-v2\n")
+            self.assertEqual(first, record())
 
     def test_collector_rejects_tampered_log_and_accepts_exact_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Problem

The release planner was intended to rerun only changed gates and their dependents, but every ordinary change also matched always-fresh source/report gates whose broad path mapping is **. Their reverse dependency closure therefore invalidated all 189 gates. In addition, every scripts/ci test file was included in every gate input digest.

## Fix

- Exclude always-fresh bookkeeping gates from change-propagated runtime invalidation; their own receipts still regenerate for every candidate.
- Treat explicit docs and release/CI test-only files as runtime-evidence-neutral while preserving fail-closed behavior for unknown runtime paths.
- Bind each 44-crate core gate to the shared scripts/ci/run_checks.py runner instead of binding every release gate to all scripts/ci files.
- Parse NUL-delimited git name-status output and retain both sides of renames/copies plus deleted paths.
- Regenerate the checked-in gate catalog.

The planner itself remains a global release input, so this change correctly requires one fresh full qualification. After that run, unrelated future fixes can reuse exact matching evidence.

## Verification

- 100 release automation tests passed.
- 86 CI policy/planner tests passed.
- Catalog regeneration is deterministic.
- Diff hygiene passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release qualification planning and input hashing; incorrect reuse logic could skip required gates, but behavior is heavily covered by new tests and catalog invariants.
> 
> **Overview**
> **Release planning** no longer treats every diff as touching all runtime gates. Change-driven invalidation uses only non–always-fresh gates whose `affected_paths` match the candidate diff, so broad `**` on source/report bookkeeping gates does not cascade invalidation across the full profile.
> 
> **Input digests and unknown-path policy** stop folding all of `scripts/ci/**` into every gate: each of the 44 `core.*` gates now declares `scripts/ci/run_checks.py` in catalog `affected_paths` (via `build_gate_catalog.py` and regenerated `gates.json`). Docs and selected release/CI test paths are treated as runtime-evidence-neutral for unknown-change detection while unknown runtime paths still fail closed.
> 
> **Diff parsing** switches to NUL-delimited `git diff --name-status` with `parse_name_status_z`, keeping both sides of renames/copies and deleted paths. Tests cover the new invalidation rules, neutral paths, rename parsing, and core gate path binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8705d6a319e36d73b1886a691e1b5eadf52fdbce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->