### PR TITLE
Fix PBX readiness source test

### DIFF
--- a/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
+++ b/crates/sip/rvoip-sip/scripts/test_beta_gate_source.py
@@ -361,8 +361,10 @@ class BetaGateCompatibilitySourceTests(unittest.TestCase):
     def test_pbx_tls_readiness_tolerates_expected_startup_probe_failures(self) -> None:
         pbx = (CRATE_DIR / "examples/pbx/run.sh").read_text(encoding="utf-8")
         self.assertIn('if nc -z -w 2 "$host" "$port"; then', pbx)
-        self.assertIn("if printf '' \\\n", pbx)
+        self.assertIn("if openssl_output=$(printf '' \\\n", pbx)
         self.assertIn('openssl s_client -connect "$host:$port"', pbx)
+        self.assertIn("openssl_rc=$?", pbx)
+        self.assertIn("printf '%s\\n' \"$openssl_output\"", pbx)
 
     def test_all_thirteen_standalone_manifests_are_independent_gates(self) -> None:
         examples = shell_function("run_standalone_example_gates")


### PR DESCRIPTION
## What changed

- update the PBX TLS readiness source-policy assertion for the output-capturing OpenSSL probe introduced by #156
- retain checks that probe failures are captured through `openssl_rc=$?` and that diagnostic output is logged

## Root cause

Release qualification run 30787297828 failed `build.evidence-helper-tests` because the compatibility test still required the old literal `if printf ''` form. The runtime script now correctly uses `if openssl_output=$(printf '' | openssl ...)`; the production behavior and real GCP interop path are unchanged.

## Impact

Test-only change. No Rust public API or runtime behavior changes. Successful evidence from the current qualification remains reusable; only the failed/affected evidence-helper gate must rerun.

## Verification

- complete evidence-helper command: 129 tests passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only unittest string expectations in test_beta_gate_source.py change; no Rust or shell runtime behavior.
> 
> **Overview**
> Updates **`test_pbx_tls_readiness_tolerates_expected_startup_probe_failures`** so it matches the PBX **`run.sh`** TLS readiness probe from #156, instead of the old literal **`if printf ''`** check that broke **`build.evidence-helper-tests`**.
> 
> The test now requires command-substitution capture (**`if openssl_output=$(printf ''`**, **`openssl_rc=$?`**, and logging via **`printf '%s\n' "$openssl_output"`**), while keeping the existing **`nc`** and **`openssl s_client`** assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b996953b0d6fe5f9f7c98a85332aca2515af0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->