### PR TITLE
Fix release attestation preflight token

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Resolve and preflight aggregate
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: |
           aggregate="$(find target/downloaded-qualification -name aggregate.json -type f -print -quit)"

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -410,6 +410,15 @@ class WorkflowPolicyTests(unittest.TestCase):
             publication,
         )
 
+    def test_release_publish_attestation_preflight_receives_github_token(self) -> None:
+        publication = (ROOT / ".github/workflows/release-publish.yml").read_text()
+        preflight = publication.split(
+            "      - name: Resolve and preflight aggregate\n", maxsplit=1
+        )[1].split("      - name: Fresh package and source verification\n", maxsplit=1)[0]
+
+        self.assertIn("GH_TOKEN: ${{ github.token }}", preflight)
+        self.assertIn('gh attestation verify "$aggregate"', preflight)
+
     def test_release_gcp_workers_do_not_consume_one_github_job_each(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
         controller = workflow.split("\n  gate-gcp:\n", maxsplit=1)[1].split(


### PR DESCRIPTION
## Summary
- expose the GitHub Actions job token to the signed qualification preflight
- add a workflow-policy regression test for the attestation step

## Testing
- python3 -m unittest scripts.ci.test_workflow_policy
- git diff --check

## Context
The v0.3.6 publication dry run 30795955714 downloaded valid signed qualification evidence, then failed because gh attestation verify had no GH_TOKEN. No package publication was attempted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only env wiring and a policy regression test; no application or publish logic changes beyond unblocking attestation preflight.
> 
> **Overview**
> Fixes **release publish** failing during qualification preflight when `gh attestation verify` runs without credentials (e.g. v0.3.6 dry run after evidence download succeeded).
> 
> The **Resolve and preflight aggregate** step in `release-publish.yml` now sets `GH_TOKEN: ${{ github.token }}` in its `env`, matching the download step so attestation verification can call the GitHub API.
> 
> Adds a **workflow-policy** unittest that asserts that preflight block includes both the token and `gh attestation verify "$aggregate"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c699378e19bf56ad23a6b4733d2d3162b9a77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->