### PR TITLE
Publish the exact qualified release candidate

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - name: Check out current main
+      - name: Check out publication workflow revision
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: main
@@ -71,23 +71,37 @@ jobs:
           --name release-gate-evidence
           --dir target/downloaded-qualification
 
-      - name: Resolve and preflight aggregate
+      - name: Resolve, verify, and check out qualified candidate
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          set -euo pipefail
           aggregate="$(find target/downloaded-qualification -name aggregate.json -type f -print -quit)"
           test -n "$aggregate" || {
             echo "qualification aggregate is missing" >&2
             exit 1
           }
+          gh attestation verify "$aggregate" --repo "$REPOSITORY"
           test "$(jq -r .schema "$aggregate")" = rvoip-release-qualification-v1
           test "$(jq -r .status "$aggregate")" = PASS
           test "$(jq -r .profile "$aggregate")" = remote-release
-          test "$(jq -r .candidate_sha "$aggregate")" = "$(git rev-parse HEAD)"
-          gh attestation verify "$aggregate" --repo "$REPOSITORY"
-          echo "REMOTE_QUALIFICATION=$aggregate" >> "$GITHUB_ENV"
+          candidate="$(jq -r .candidate_sha "$aggregate")"
+          [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "qualification candidate is not a full commit SHA" >&2
+            exit 1
+          }
+          git cat-file -e "$candidate^{commit}"
+          git merge-base --is-ancestor "$candidate" origin/main || {
+            echo "qualified candidate is not an ancestor of origin/main" >&2
+            exit 1
+          }
+          qualification="$(realpath "$aggregate")"
+          git checkout --detach "$candidate"
+          test "$(git rev-parse HEAD)" = "$candidate"
+          echo "QUALIFIED_CANDIDATE=$candidate" >> "$GITHUB_ENV"
+          echo "REMOTE_QUALIFICATION=$qualification" >> "$GITHUB_ENV"
 
       - name: Fresh package and source verification
         env:

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -410,14 +410,23 @@ class WorkflowPolicyTests(unittest.TestCase):
             publication,
         )
 
-    def test_release_publish_attestation_preflight_receives_github_token(self) -> None:
+    def test_release_publish_consumes_exact_attested_candidate(self) -> None:
         publication = (ROOT / ".github/workflows/release-publish.yml").read_text()
         preflight = publication.split(
-            "      - name: Resolve and preflight aggregate\n", maxsplit=1
+            "      - name: Resolve, verify, and check out qualified candidate\n",
+            maxsplit=1,
         )[1].split("      - name: Fresh package and source verification\n", maxsplit=1)[0]
 
         self.assertIn("GH_TOKEN: ${{ github.token }}", preflight)
         self.assertIn('gh attestation verify "$aggregate"', preflight)
+        self.assertIn('candidate="$(jq -r .candidate_sha "$aggregate")"', preflight)
+        self.assertIn('git merge-base --is-ancestor "$candidate" origin/main', preflight)
+        self.assertIn('git checkout --detach "$candidate"', preflight)
+        self.assertIn('test "$(git rev-parse HEAD)" = "$candidate"', preflight)
+        self.assertLess(
+            preflight.index('gh attestation verify "$aggregate"'),
+            preflight.index('git checkout --detach "$candidate"'),
+        )
 
     def test_release_gcp_workers_do_not_consume_one_github_job_each(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()


### PR DESCRIPTION
## Summary
- verify the signed qualification aggregate before trusting its candidate SHA
- require the candidate to be a full commit SHA and an ancestor of main
- check out that exact qualified commit for package verification, publication, tagging, and release creation
- keep release-orchestration fixes from forcing a redundant product qualification

## Testing
- python3 -m unittest scripts.ci.test_workflow_policy
- git diff --check

## Release impact
This allows the protected v0.3.6 publication workflow to consume the successful 189-gate qualification for ff7ed5ae while the workflow definition itself runs from updated main. It does not bypass or weaken exact-candidate validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens release supply-chain binding (attested SHA + main ancestry) but changes which tree is published when workflow and qualification commits differ—high impact if misconfigured, with stronger guards than before.
> 
> **Overview**
> **Release publish** can run workflow YAML from current `main` while still packaging and shipping the **exact commit** named in the signed remote-release qualification aggregate.
> 
> The preflight step now **verifies attestation first**, checks `candidate_sha` is a 40-char hex commit on `origin/main`, then **detached-checkouts that SHA** and exports `QUALIFIED_CANDIDATE` before `release.py verify` / publish / tagging. It no longer requires `candidate_sha` to equal the initial checkout HEAD.
> 
> Workflow policy tests were renamed and extended to require ancestor validation, detached checkout, HEAD equality, and attestation-before-checkout ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e07aeb6cde577f448fa4ca7492ac41f6f11d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->