### PR TITLE
Keep qualified release checkout on main

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -98,7 +98,7 @@ jobs:
             exit 1
           }
           qualification="$(realpath "$aggregate")"
-          git checkout --detach "$candidate"
+          git checkout -B main "$candidate"
           test "$(git rev-parse HEAD)" = "$candidate"
           echo "QUALIFIED_CANDIDATE=$candidate" >> "$GITHUB_ENV"
           echo "REMOTE_QUALIFICATION=$qualification" >> "$GITHUB_ENV"

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -421,11 +421,11 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('gh attestation verify "$aggregate"', preflight)
         self.assertIn('candidate="$(jq -r .candidate_sha "$aggregate")"', preflight)
         self.assertIn('git merge-base --is-ancestor "$candidate" origin/main', preflight)
-        self.assertIn('git checkout --detach "$candidate"', preflight)
+        self.assertIn('git checkout -B main "$candidate"', preflight)
         self.assertIn('test "$(git rev-parse HEAD)" = "$candidate"', preflight)
         self.assertLess(
             preflight.index('gh attestation verify "$aggregate"'),
-            preflight.index('git checkout --detach "$candidate"'),
+            preflight.index('git checkout -B main "$candidate"'),
         )
 
     def test_release_gcp_workers_do_not_consume_one_github_job_each(self) -> None:


### PR DESCRIPTION
## Summary
- check out the signed release candidate on the runner local main branch
- preserve the exact candidate SHA assertion and attestation-before-checkout ordering
- update the workflow-policy regression test

## Testing
- python3 -m unittest scripts.ci.test_workflow_policy
- git diff --check

## Context
The protected v0.3.6 dry run verified and selected ff7ed5ae correctly, then release.py refused detached HEAD because release commands require branch main. This changes only the runner local branch; origin/main is not moved and no release gates need to rerun.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner-local git checkout only; remote `main` and qualification gates are unchanged, with the same SHA and attestation checks.
> 
> **Overview**
> Fixes protected release publish failing after qualification when **`release.py`** refuses a **detached HEAD** (it requires the current branch to be **`main`**).
> 
> In **`release-publish.yml`**, the qualified candidate checkout changes from **`git checkout --detach`** to **`git checkout -B main "$candidate"`**, so the runner’s **local** `main` points at the attested SHA while **`origin/main`** is unchanged. **Attestation-before-checkout** ordering and the **`git rev-parse HEAD`** equality check stay the same.
> 
> The workflow-policy test is updated to lock in the new checkout command and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de638cc88c44c0907925ddf63956ef729ba1ce1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->