### PR TITLE
Allow publication from an exact signed ancestor

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -98,17 +98,21 @@ jobs:
             exit 1
           }
           qualification="$(realpath "$aggregate")"
+          cp scripts/release.py target/release-tool.py
+          release_tool="$(realpath target/release-tool.py)"
           git checkout -B main "$candidate"
           test "$(git rev-parse HEAD)" = "$candidate"
           echo "QUALIFIED_CANDIDATE=$candidate" >> "$GITHUB_ENV"
+          echo "RELEASE_TOOL=$release_tool" >> "$GITHUB_ENV"
           echo "REMOTE_QUALIFICATION=$qualification" >> "$GITHUB_ENV"
 
       - name: Fresh package and source verification
         env:
           VERSION: ${{ inputs.version }}
         run: >-
-          python3 scripts/release.py verify
+          python3 "$RELEASE_TOOL" verify
           --version "$VERSION"
+          --qualified-head "$QUALIFIED_CANDIDATE"
           --remote-qualification "$REMOTE_QUALIFICATION"
 
       - name: Dry-run or execute resumable topological publication
@@ -117,11 +121,15 @@ jobs:
           EXECUTE: ${{ inputs.execute }}
           VERSION: ${{ inputs.version }}
         run: |
-          args=(publish --version "$VERSION")
+          args=(
+            publish
+            --version "$VERSION"
+            --qualified-head "$QUALIFIED_CANDIDATE"
+          )
           if test "$EXECUTE" = true; then
             args+=(--execute)
           fi
-          python3 scripts/release.py "${args[@]}"
+          python3 "$RELEASE_TOOL" "${args[@]}"
 
       - name: Attest published package archives
         if: inputs.execute

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -239,11 +239,16 @@ non-publishing dry run:
 scripts/release.sh publish --version X.Y.Z
 ```
 
-The workflow resolves and verifies the signed aggregate, checks that it binds
-the current `main` commit and current gate catalog, and runs the complete
-topological package preflight. The crates.io token exists only in the
-approval-protected `release-publish` environment and is never available to PR,
-nightly, or performance runners.
+The workflow resolves and verifies the signed aggregate before trusting its
+candidate SHA. The candidate must be the current `main` commit or an ancestor
+of it, and the aggregate must bind that exact commit and its gate catalog. The
+workflow then checks out the qualified product commit on its local `main`
+branch and runs the complete topological package preflight with reviewed
+release tooling captured from the protected workflow revision. This allows a
+publishing-only workflow fix without relabeling a newer product commit as
+qualified. The crates.io token exists only in the approval-protected
+`release-publish` environment and is never available to PR, nightly, or
+performance runners.
 
 After environment approval, set `execute=true` in the workflow to publish:
 
@@ -251,12 +256,14 @@ After environment approval, set `execute=true` in the workflow to publish:
 scripts/release.sh publish --version X.Y.Z --execute
 ```
 
-Publication requires a clean `main` equal to `origin/main`, the matching
-verification receipt, and an unused `vX.Y.Z` tag. Each crate is packaged and
-dry-run immediately before publication, and its file manifest must match the
-verified receipt. The tool records the final archive hash, waits for each
-version to become visible on crates.io, and only then packages and publishes
-dependents.
+Publication normally requires a clean `main` equal to `origin/main`. The
+protected workflow may instead supply the exact signed qualification SHA; in
+that mode the clean local `main` must equal that full SHA and it must be an
+ancestor of live `origin/main`. Both modes require the matching verification
+receipt and an unused `vX.Y.Z` tag. Each crate is packaged and dry-run
+immediately before publication, and its file manifest must match the verified
+receipt. The tool records the final archive hash, waits for each version to
+become visible on crates.io, and only then packages and publishes dependents.
 
 An interrupted run is resumable. A version already on crates.io is skipped
 only when its registry checksum matches the locally verified `.crate` artifact;

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -421,12 +421,16 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('gh attestation verify "$aggregate"', preflight)
         self.assertIn('candidate="$(jq -r .candidate_sha "$aggregate")"', preflight)
         self.assertIn('git merge-base --is-ancestor "$candidate" origin/main', preflight)
+        self.assertIn("cp scripts/release.py target/release-tool.py", preflight)
         self.assertIn('git checkout -B main "$candidate"', preflight)
         self.assertIn('test "$(git rev-parse HEAD)" = "$candidate"', preflight)
         self.assertLess(
             preflight.index('gh attestation verify "$aggregate"'),
             preflight.index('git checkout -B main "$candidate"'),
         )
+        self.assertIn('python3 "$RELEASE_TOOL" verify', publication)
+        self.assertIn('--qualified-head "$QUALIFIED_CANDIDATE"', publication)
+        self.assertIn('python3 "$RELEASE_TOOL" "${args[@]}"', publication)
 
     def test_release_gcp_workers_do_not_consume_one_github_job_each(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -215,17 +215,42 @@ def ensure_clean(root: Path) -> None:
         raise ReleaseError(f"working tree must be clean:\n{status}")
 
 
-def ensure_release_state(root: Path, version: str, *, require_no_tag: bool) -> str:
+def ensure_release_state(
+    root: Path,
+    version: str,
+    *,
+    require_no_tag: bool,
+    qualified_head: str | None = None,
+) -> str:
     ensure_clean(root)
     branch = git_output(root, "branch", "--show-current")
     if branch != "main":
         raise ReleaseError(f"release commands require branch main, found {branch!r}")
     head = git_output(root, "rev-parse", "HEAD")
+    if qualified_head is not None:
+        if not COMMIT_SHA.fullmatch(qualified_head):
+            raise ReleaseError("qualified release HEAD must be a full commit SHA")
+        if qualified_head != head:
+            raise ReleaseError("qualified release HEAD does not match the checkout")
     remote = run(
         ["git", "ls-remote", "origin", "refs/heads/main"], cwd=root
     ).stdout.split()
-    if not remote or remote[0] != head:
+    if not remote:
+        raise ReleaseError("current origin/main could not be resolved")
+    remote_head = remote[0]
+    if remote_head != head and qualified_head != head:
         raise ReleaseError("HEAD must exactly match the current origin/main")
+    if remote_head != head:
+        run(["git", "fetch", "--no-tags", "origin", remote_head], cwd=root)
+        ancestor = run(
+            ["git", "merge-base", "--is-ancestor", head, remote_head],
+            cwd=root,
+            check=False,
+        )
+        if ancestor.returncode:
+            raise ReleaseError(
+                "qualified release HEAD must be an ancestor of current origin/main"
+            )
     tag = f"v{version}"
     if require_no_tag:
         local_tag = run(
@@ -1366,8 +1391,18 @@ def verify(
     beta_carry_forward_attestation: str | None,
     targeted_delta_attestation: str | None,
     remote_qualification: str | None,
+    qualified_head: str | None = None,
 ) -> None:
-    head = ensure_release_state(root, version, require_no_tag=True)
+    if qualified_head is not None and remote_qualification is None:
+        raise ReleaseError(
+            "--qualified-head requires an exact --remote-qualification aggregate"
+        )
+    head = ensure_release_state(
+        root,
+        version,
+        require_no_tag=True,
+        qualified_head=qualified_head,
+    )
     packages, ordered = validate_workspace(root, version, locked=True)
     log = ReleaseLog(root, version, "verify")
     log.event("start", operation="verify", version=version, git_commit=head)
@@ -1798,10 +1833,26 @@ def publish(
     version: str,
     *,
     execute: bool,
+    qualified_head: str | None = None,
 ) -> None:
-    head = ensure_release_state(root, version, require_no_tag=True)
+    head = ensure_release_state(
+        root,
+        version,
+        require_no_tag=True,
+        qualified_head=qualified_head,
+    )
     packages, ordered = validate_workspace(root, version, locked=True)
     receipt = read_verification_receipt(root, version, head, ordered)
+    if qualified_head is not None:
+        qualification = receipt.get("beta_qualification")
+        if (
+            not isinstance(qualification, dict)
+            or qualification.get("mode") != "remote-release"
+            or qualification.get("git_commit") != qualified_head
+        ):
+            raise ReleaseError(
+                "qualified ancestor publication requires matching remote-release evidence"
+            )
     verified_hashes = receipt.get("package_sha256")
     verified_file_hashes = receipt.get("package_file_manifest_sha256")
     if (
@@ -1937,6 +1988,15 @@ def parser() -> argparse.ArgumentParser:
     for name in ("prepare", "verify", "publish"):
         command = commands.add_parser(name)
         command.add_argument("--version", required=True)
+        if name in ("verify", "publish"):
+            command.add_argument(
+                "--qualified-head",
+                default=os.environ.get("RVOIP_RELEASE_QUALIFIED_HEAD"),
+                help=(
+                    "allow an attested ancestor of origin/main as the exact "
+                    "release checkout"
+                ),
+            )
         if name == "verify":
             report_group = command.add_mutually_exclusive_group()
             report_group.add_argument(
@@ -1987,9 +2047,15 @@ def main(argv: list[str] | None = None) -> int:
                     args.beta_carry_forward_attestation,
                     args.targeted_delta_attestation,
                     args.remote_qualification,
+                    args.qualified_head,
                 )
             elif args.command == "publish":
-                publish(root, version, execute=args.execute)
+                publish(
+                    root,
+                    version,
+                    execute=args.execute,
+                    qualified_head=args.qualified_head,
+                )
     except ReleaseError as error:
         print(f"release: FAIL: {error}", file=sys.stderr)
         return 1

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -1079,6 +1079,46 @@ rvoip-rtc = { path = "../rvoip-rtc" }
                 ]
             )
 
+    def test_qualified_head_requires_remote_qualification(self) -> None:
+        with self.assertRaisesRegex(
+            release.ReleaseError, "requires an exact --remote-qualification"
+        ):
+            release.verify(
+                Path("/repo"),
+                "0.3.6",
+                None,
+                None,
+                None,
+                None,
+                None,
+                "a" * 40,
+            )
+
+    def test_qualified_publish_requires_remote_release_receipt(self) -> None:
+        head = "a" * 40
+        receipt = {
+            "beta_qualification": {
+                "mode": "strict",
+                "git_commit": head,
+            }
+        }
+        with (
+            mock.patch.object(release, "ensure_release_state", return_value=head),
+            mock.patch.object(release, "validate_workspace", return_value=({}, [])),
+            mock.patch.object(
+                release, "read_verification_receipt", return_value=receipt
+            ),
+            self.assertRaisesRegex(
+                release.ReleaseError, "matching remote-release evidence"
+            ),
+        ):
+            release.publish(
+                Path("/repo"),
+                "0.3.6",
+                execute=False,
+                qualified_head=head,
+            )
+
     def test_visibility_timeout_fails(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             log = release.ReleaseLog(Path(directory), "0.3.0", "test")
@@ -1129,6 +1169,75 @@ rvoip-rtc = { path = "../rvoip-rtc" }
         ):
             release.ensure_release_state(
                 Path("/repo"), "0.3.0", require_no_tag=True
+            )
+
+    def test_qualified_ancestor_release_state_succeeds(self) -> None:
+        head = "a" * 40
+        remote_head = "b" * 40
+        remote = release.subprocess.CompletedProcess(
+            ["git", "ls-remote"],
+            0,
+            stdout=f"{remote_head}\trefs/heads/main\n",
+            stderr="",
+        )
+        ancestor = release.subprocess.CompletedProcess(
+            ["git", "merge-base"], 0, stdout="", stderr=""
+        )
+        fetched = release.subprocess.CompletedProcess(
+            ["git", "fetch"], 0, stdout="", stderr=""
+        )
+        with (
+            mock.patch.object(
+                release,
+                "git_output",
+                side_effect=["", "main", head],
+            ),
+            mock.patch.object(
+                release, "run", side_effect=[remote, fetched, ancestor]
+            ),
+        ):
+            actual = release.ensure_release_state(
+                Path("/repo"),
+                "0.3.6",
+                require_no_tag=False,
+                qualified_head=head,
+            )
+
+        self.assertEqual(actual, head)
+
+    def test_qualified_non_ancestor_release_state_fails_closed(self) -> None:
+        head = "a" * 40
+        remote_head = "b" * 40
+        remote = release.subprocess.CompletedProcess(
+            ["git", "ls-remote"],
+            0,
+            stdout=f"{remote_head}\trefs/heads/main\n",
+            stderr="",
+        )
+        not_ancestor = release.subprocess.CompletedProcess(
+            ["git", "merge-base"], 1, stdout="", stderr=""
+        )
+        fetched = release.subprocess.CompletedProcess(
+            ["git", "fetch"], 0, stdout="", stderr=""
+        )
+        with (
+            mock.patch.object(
+                release,
+                "git_output",
+                side_effect=["", "main", head],
+            ),
+            mock.patch.object(
+                release,
+                "run",
+                side_effect=[remote, fetched, not_ancestor],
+            ),
+            self.assertRaises(release.ReleaseError),
+        ):
+            release.ensure_release_state(
+                Path("/repo"),
+                "0.3.6",
+                require_no_tag=False,
+                qualified_head=head,
             )
 
     def test_current_workspace_has_all_44_unique_publishable_packages(self) -> None:


### PR DESCRIPTION
## Summary
- retain the default clean-main-equals-origin/main release rule
- add an explicit qualified-head mode limited to a full SHA matching the checkout and ancestral to live origin/main
- require remote-release qualification evidence for both verification and publication in that mode
- execute reviewed publisher tooling from the protected workflow revision while packaging the exact signed product candidate
- document the workflow-only-fix case

## Testing
- python3 -m unittest scripts.test_release scripts.ci.test_workflow_policy (69 tests passed)
- python3 -m py_compile scripts/release.py scripts/test_release.py scripts/ci/test_workflow_policy.py
- git diff --check

## Release impact
This permits v0.3.6 to publish the already-qualified ff7ed5ae product tree after publishing-only workflow fixes. It does not relabel the newer main commit as qualified and does not rerun or bypass the 189 release gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protected publication and git HEAD rules for crates.io releases, but only through fail-closed checks (attested aggregate, ancestor of `origin/main`, matching remote-release receipt).
> 
> **Overview**
> **Enables publication from an exact signed qualification SHA** when live `origin/main` has moved ahead (e.g. publishing-only workflow fixes), without treating the newer tip as qualified.
> 
> `scripts/release.py` gains optional **`--qualified-head`** on `verify` and `publish`. In that mode the checkout must match the full SHA, it may differ from `origin/main` only if it is an **ancestor** of live `origin/main`, and **`--remote-qualification` is mandatory**; publish additionally requires verification receipt **`remote-release`** evidence bound to that same commit. Default behavior still requires clean `main` equal to `origin/main`.
> 
> The **Publish protected release** workflow copies `scripts/release.py` to `target/release-tool.py` **before** checking out the aggregate’s `candidate_sha`, then runs verify/publish via **`$RELEASE_TOOL`** with **`--qualified-head`**, so packaging uses the qualified product tree while release logic comes from the reviewed workflow revision on `main`.
> 
> `docs/RELEASING.md` and workflow-policy/unit tests document and lock in the new ordering and flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf647e08b35b0f4174469833bd4179ecb4765a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->