### PR TITLE
fix(vapi): tolerate inbound audio bursts instead of killing the session

### DIFF
--- a/crates/extensions/rvoip-vapi/src/adapter.rs
+++ b/crates/extensions/rvoip-vapi/src/adapter.rs
@@ -863,6 +863,8 @@ async fn run_websocket_session(
     let mut incoming_frames = VecDeque::<Bytes>::new();
     let mut outgoing_frames = VecDeque::<Bytes>::new();
     let mut timestamp_rtp = 0u32;
+    let mut inbound_dropped: u64 = 0;
+    let mut inbound_drop_reported = false;
     let mut incoming_tick = tokio::time::interval(std::time::Duration::from_millis(20));
     incoming_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     incoming_tick.tick().await;
@@ -983,18 +985,35 @@ async fn run_websocket_session(
                 }
                 match message {
                     Some(Ok(WebSocketMessage::Binary(payload))) => {
-                        let max_queued = config
-                            .startup_audio_frames
-                            .saturating_sub(route.stream.incoming_pending_frames());
-                        if append_bounded_frames(
-                            &mut incoming_framer,
-                            &payload,
-                            &mut incoming_frames,
-                            max_queued,
-                            config.max_message_bytes,
-                        ).is_err() {
-                            metrics::counter!("rvoip_vapi_queue_overflow_total", "direction" => "in").increment(1);
-                            break SessionOutcome::Failed("Vapi inbound media buffer overflow");
+                        if payload.len() > config.max_message_bytes {
+                            break SessionOutcome::Failed("Vapi audio message exceeded size limit");
+                        }
+                        // Vapi's transport is a raw byte stream with no framing
+                        // or pacing guarantee, and it delivers coalesced bursts.
+                        // A transient backlog must degrade the jitter buffer, not
+                        // terminate the session: dropping the oldest frame costs
+                        // 20 ms of audio, whereas failing here silently ends the
+                        // call for its remaining duration.
+                        incoming_framer.push(&payload);
+                        while let Some(frame) = incoming_framer.next_frame() {
+                            if incoming_frames.len() >= config.inbound_queue_capacity {
+                                incoming_frames.pop_front();
+                                inbound_dropped = inbound_dropped.saturating_add(1);
+                                metrics::counter!(
+                                    "rvoip_vapi_inbound_frames_dropped_total"
+                                ).increment(1);
+                            }
+                            incoming_frames.push_back(frame);
+                        }
+                        // Report once per contiguous episode rather than per
+                        // frame, so a burst does not flood the log.
+                        if inbound_dropped > 0 && !inbound_drop_reported {
+                            inbound_drop_reported = true;
+                            tracing::warn!(
+                                capacity = config.inbound_queue_capacity,
+                                "inbound Vapi audio is arriving faster than it drains; \
+                                 dropping the oldest frames"
+                            );
                         }
                     }
                     Some(Ok(WebSocketMessage::Text(text))) => {
@@ -1041,6 +1060,12 @@ async fn run_websocket_session(
         }
     };
 
+    if inbound_dropped > 0 {
+        tracing::warn!(
+            dropped_frames = inbound_dropped,
+            "Vapi session dropped inbound audio frames to keep the jitter buffer bounded"
+        );
+    }
     match &outcome {
         SessionOutcome::Local(_) => {
             wait_for_vapi_shutdown(config, global_events, route, &mut socket).await;
@@ -1162,7 +1187,11 @@ async fn finish_route(
         SessionOutcome::RemoteClosed => {
             metrics::counter!("rvoip_vapi_disconnects_total", "outcome" => "abnormal").increment(1);
         }
-        SessionOutcome::Failed(_) => {
+        SessionOutcome::Failed(detail) => {
+            // Previously this incremented a counter and discarded `detail`,
+            // so a terminated media session was invisible to anyone not
+            // scraping metrics mid-call.
+            tracing::warn!(detail, "Vapi session failed");
             metrics::counter!("rvoip_vapi_disconnects_total", "outcome" => "failed").increment(1);
         }
         SessionOutcome::Local(_) => {}

--- a/crates/extensions/rvoip-vapi/src/config.rs
+++ b/crates/extensions/rvoip-vapi/src/config.rs
@@ -61,7 +61,24 @@ pub struct VapiConfig {
     pub control_queue_capacity: usize,
     pub event_queue_capacity: usize,
     pub max_message_bytes: usize,
+    /// Frames buffered before the first is handed downstream.
+    ///
+    /// Historically this also served as the inbound queue bound. It no longer
+    /// does: see [`VapiConfig::inbound_queue_capacity`].
     pub startup_audio_frames: usize,
+    /// Inbound jitter buffer depth, in frames.
+    ///
+    /// Vapi's WebSocket transport is a *raw byte stream*: the documentation
+    /// specifies the sample encoding and `"container": "raw"`, but no frame
+    /// size, no chunk size, and no pacing guarantee. Measured against a live
+    /// assistant, chunks are 170-743 bytes with a p50 inter-arrival of 50 ms
+    /// and a **minimum of 0 ms** — i.e. coalesced bursts carrying ~90 ms of
+    /// audio at once, against a drain that emits one 20 ms frame per tick.
+    ///
+    /// This must therefore absorb a burst. It is deliberately not capped the
+    /// way `startup_audio_frames` is, because the appropriate depth depends on
+    /// the peer's burst behaviour rather than on startup latency.
+    pub inbound_queue_capacity: usize,
     pub(crate) allow_insecure_transport: bool,
 }
 
@@ -84,6 +101,7 @@ impl VapiConfig {
             event_queue_capacity: 100,
             max_message_bytes: 1024 * 1024,
             startup_audio_frames: 100,
+            inbound_queue_capacity: 200,
             allow_insecure_transport: false,
         }
     }
@@ -124,6 +142,7 @@ impl VapiConfig {
             || self.control_queue_capacity == 0
             || self.event_queue_capacity == 0
             || self.startup_audio_frames == 0
+            || self.inbound_queue_capacity == 0
         {
             return Err(VapiError::InvalidConfiguration(
                 "queue capacities must be non-zero",
@@ -164,6 +183,7 @@ impl fmt::Debug for VapiConfig {
             .field("event_queue_capacity", &self.event_queue_capacity)
             .field("max_message_bytes", &self.max_message_bytes)
             .field("startup_audio_frames", &self.startup_audio_frames)
+            .field("inbound_queue_capacity", &self.inbound_queue_capacity)
             .field("insecure_transport", &self.allow_insecure_transport)
             .finish()
     }

--- a/crates/extensions/rvoip-vapi/src/media.rs
+++ b/crates/extensions/rvoip-vapi/src/media.rs
@@ -112,12 +112,6 @@ impl VapiMediaStream {
             .map_err(|_| VapiError::MediaQueueOverflow)
     }
 
-    pub(crate) fn incoming_pending_frames(&self) -> usize {
-        self.incoming_tx
-            .max_capacity()
-            .saturating_sub(self.incoming_tx.capacity())
-    }
-
     pub(crate) fn incoming_has_capacity(&self) -> bool {
         self.incoming_tx.capacity() > 0 && !self.incoming_tx.is_closed()
     }

--- a/crates/extensions/rvoip-vapi/tests/mock_transport.rs
+++ b/crates/extensions/rvoip-vapi/tests/mock_transport.rs
@@ -875,12 +875,22 @@ async fn missing_heartbeat_response_is_terminal() {
 }
 
 #[tokio::test]
-async fn startup_audio_overflow_fails_closed() {
+async fn inbound_audio_burst_degrades_instead_of_terminating_the_session() {
+    // Vapi's WebSocket transport is a raw byte stream: its documentation
+    // specifies `"container": "raw"` and the sample encoding, but no frame
+    // size, no chunk size, and no pacing guarantee. Measured against a live
+    // assistant, chunks are 170-743 bytes with a p50 inter-arrival of 50 ms
+    // and a minimum of 0 ms, i.e. coalesced bursts.
+    //
+    // A burst that outruns the 20 ms-per-frame drain must cost audio, not the
+    // call. Before this behaviour changed, a transient backlog terminated the
+    // media session permanently and silently.
     let (api_base, _state, _observed, server) = start_mock(Duration::ZERO).await;
     let mut config = VapiConfig::new(VapiApiKey::new("mock-api-key").expect("mock key"))
         .with_api_base(api_base)
         .with_loopback_test_transport();
-    config.startup_audio_frames = 1;
+    // A jitter buffer far too small for the mock's burst.
+    config.inbound_queue_capacity = 1;
     config.heartbeat_interval = Duration::from_secs(60);
     let adapter = VapiAdapter::new(config).expect("adapter");
     let mut events = adapter.subscribe_events();
@@ -908,13 +918,15 @@ async fn startup_audio_overflow_fails_closed() {
         events.recv().await.expect("connected event"),
         AdapterEvent::Connected { .. }
     ));
-    assert!(matches!(
-        tokio::time::timeout(Duration::from_secs(1), events.recv())
-            .await
-            .expect("overflow terminal timeout")
-            .expect("overflow terminal"),
-        AdapterEvent::Failed { .. }
-    ));
+
+    // The session must stay up despite the overflowing burst.
+    if let Ok(Some(event)) = tokio::time::timeout(Duration::from_secs(1), events.recv()).await {
+        assert!(
+            !matches!(event, AdapterEvent::Failed { .. }),
+            "an inbound burst terminated the session; it should have dropped \
+             frames and continued"
+        );
+    }
     server.abort();
 }
 


### PR DESCRIPTION
Fixes one root-caused defect behind #163. **It is a partial fix** — measured live, it moves the failure rate from ~20–25% to ~13%, and evidence now points to a second, separate defect downstream of this crate. Details below.

## Root cause

Vapi's WebSocket transport is a **raw byte stream**. The documentation specifies `"container": "raw"` and the sample encoding, but no frame size, no chunk size, and no pacing guarantee. Measured directly against a live assistant with rvoip out of the path:

```
chunk sizes:   170, 185, 186, 371, 372, 557, 558, 743 bytes   (never 160)
inter-arrival: min=0ms  p50=50ms  p95=52ms  max=103ms
```

`min=0` means coalesced bursts — commonly 371+372 back to back, ~90 ms of audio in one instant — against a drain that emits one 20 ms frame per tick.

The inbound path bounded its queue with `startup_audio_frames` and treated exceeding it as terminal:

```rust
let max_queued = config.startup_audio_frames
    .saturating_sub(route.stream.incoming_pending_frames());
if append_bounded_frames(...).is_err() {
    break SessionOutcome::Failed("Vapi inbound media buffer overflow");
}
```

Once the downstream stream held `startup_audio_frames` pending frames, `max_queued` reached zero and the next inbound message — however small — ended the media session for the remainder of the call. `VapiConfig::validate` also caps `startup_audio_frames` at 100, so an application could not raise the bound from outside the crate.

## Changes

- **`inbound_queue_capacity`** (default 200, uncapped) as the inbound jitter-buffer depth, separate from startup buffering.
- **Overflow drops the oldest frame and continues.** Losing 20 ms of audio is strictly better than silently ending the call.
- **Failed sessions now say why.** `SessionOutcome::Failed(detail)` incremented a counter and discarded `detail`, so a terminated media session was invisible to anyone not scraping metrics mid-call.
- **Frame drops are logged** once per episode plus a total at session end.

`startup_audio_frames` is retained for API compatibility and still governs startup buffering.

## Test changes

`startup_audio_overflow_fails_closed` encoded the old contract and is replaced by `inbound_audio_burst_degrades_instead_of_terminating_the_session`, which asserts a burst overflowing a deliberately tiny jitter buffer does **not** produce `AdapterEvent::Failed`. All 27 crate tests pass.

## Verification

Against live Vapi through a SIP caller, before and after:

| | result |
|---|---|
| before | ~75–80% of calls delivered assistant audio |
| after (45 runs) | **39/45 ≈ 87%** |

A mock server emitting steady 160-byte frames every 20 ms passed 5/5 both before and after, which is what originally masked this.

## What this does not fix

The residual ~13% is a **different** failure, and the logging added here is what rules this crate out for it:

```
DIAG: subscribes=1 sub_errors=0 closes=0 timeouts=83 frames=0 first_frame_at=None
```

No frame drops, no session failure, no adapter log of any kind — audio simply never reaches the SIP caller. Two signatures appear: audio never arriving at all, and audio starting (~680 ms) then stopping. Neither trips the inbound path this PR touches, so the remaining defect looks to be downstream in the media/bridge layer. I'll open a separate issue with that evidence rather than widen this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-call media behavior (drop vs fail) in the Vapi adapter; mis-tuned `inbound_queue_capacity` could add audible glitches but should improve reliability versus silent call death.
> 
> **Overview**
> Inbound Vapi WebSocket audio no longer ends the call when the jitter buffer fills. **`inbound_queue_capacity`** (default 200, separate from capped `startup_audio_frames`) bounds the pre-drain frame queue; overflow **drops the oldest frame** and keeps the session, with `rvoip_vapi_inbound_frames_dropped_total` and throttled warnings.
> 
> **`SessionOutcome::Failed`** now logs the failure detail at teardown instead of only incrementing metrics. **`incoming_pending_frames`** is removed from the media stream because inbound bounds no longer depend on downstream queue depth.
> 
> The integration test **`inbound_audio_burst_degrades_instead_of_terminating_the_session`** replaces the old fail-closed overflow test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf2e5581ac9fd9f9e3f692fc5e5762c5b19d408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->