### PR TITLE
fix(examples): stabilize attended-transfer Main Gate smoke

### DIFF
--- a/examples/01-quickstart-p2p/run_demo.sh
+++ b/examples/01-quickstart-p2p/run_demo.sh
@@ -10,7 +10,12 @@ CALLER_PORT=5060
 CALLEE_PORT=5061
 
 PIDS=()
-cleanup() { for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done; }
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+  sleep 0.1
+  for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+  wait 2>/dev/null || true
+}
 trap cleanup EXIT
 
 mkdir -p logs

--- a/examples/06-attended-transfer/README.md
+++ b/examples/06-attended-transfer/README.md
@@ -25,17 +25,20 @@ new call to the consultation leg.
 
 ## Demo flow
 
-1. Alice (`:5060`) calls Bob (`:5061`); Bob answers (the *original* call).
-2. Bob calls Charlie (`:5062`) — the *consultation* call — and waits for answer.
+1. Alice (`:5080`) calls Bob (`:5081`); Bob answers (the *original* call).
+2. Bob calls Charlie (`:5082`) — the *consultation* call — and waits for answer.
 3. Bob reads the consultation's `dialog_identity`, formats `Replaces`, and calls
    `transfer_attended` on the Alice leg.
 4. Alice receives the REFER (with `Replaces`), hangs up with Bob, and calls the
    Refer-To target. Charlie answers the transferred call. ✅
 
+Ports default to `5080`–`5082` so the combined `examples-smoke` suite does not
+collide with quickstart-p2p / SRTP demos that use `5060`/`5061`.
+
 ## Architecture
 
 ```
-   Alice (:5060) ── INVITE ─▶ Bob (:5061) ── INVITE (consult) ─▶ Charlie (:5062)
+   Alice (:5080) ── INVITE ─▶ Bob (:5081) ── INVITE (consult) ─▶ Charlie (:5082)
         │  ◀── REFER (Refer-To: Charlie; Replaces=consult dialog) ──┘
         │ hangup Bob
         └──────────────── INVITE (completes transfer) ─▶ Charlie  ✅ connected
@@ -50,15 +53,15 @@ new call to the consultation leg.
 Or manually, in three terminals (defaults shown):
 
 ```sh
-CHARLIE_PORT=5062 cargo run --bin charlie
-BOB_PORT=5061 CHARLIE_PORT=5062 cargo run --bin bob
-ALICE_PORT=5060 BOB_PORT=5061 cargo run --bin alice
+CHARLIE_PORT=5082 cargo run --bin charlie
+BOB_PORT=5081 CHARLIE_PORT=5082 cargo run --bin bob
+ALICE_PORT=5080 BOB_PORT=5081 cargo run --bin alice
 ```
 
 ## Expected output
 
 ```text
-  [ALICE] Got REFER to sip:charlie@127.0.0.1:5062
+  [ALICE] Got REFER to sip:charlie@127.0.0.1:5082
   [ALICE] Replaces = Some("session-…@rvoip-sip;to-tag=…;from-tag=…")
   [ALICE] ✅ Connected to Charlie (attended transfer complete).
   [BOB] Consultation with Charlie established.

--- a/examples/06-attended-transfer/run_demo.sh
+++ b/examples/06-attended-transfer/run_demo.sh
@@ -1,31 +1,73 @@
 #!/usr/bin/env bash
 # Attended transfer demo: Alice calls Bob; Bob consults Charlie, then attended-
 # transfers Alice to Charlie (REFER + Replaces). Exits 0 on success.
+#
+# Ports are deliberately outside the 5060/5061 range used by the combined
+# examples-smoke suite (quickstart-p2p, secure-call-srtp) so a slow cleanup
+# from a prior demo cannot leave Alice dialing a stale peer.
 set -euo pipefail
 cd "$(dirname "$0")"
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-../target}"
 
 GREEN='\033[0;32m'; RED='\033[0;31m'; CYAN='\033[0;36m'; NC='\033[0m'
-export ALICE_PORT=5060 BOB_PORT=5061 CHARLIE_PORT=5062
-PIDS=(); cleanup() { for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null || true; done; }
-trap cleanup EXIT
+export ALICE_PORT=5080 BOB_PORT=5081 CHARLIE_PORT=5082
+PIDS=()
+
+cleanup() {
+  for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null || true; done
+  sleep 0.1
+  for p in "${PIDS[@]:-}"; do kill -9 "$p" 2>/dev/null || true; done
+  wait 2>/dev/null || true
+}
+
+dump_logs() {
+  echo ""
+  for f in alice bob charlie; do
+    if [ -f "logs/$f.log" ]; then
+      echo "--- $f.log ---"
+      sed "s/^/  /" "logs/$f.log" || true
+    fi
+  done
+}
+
+finish() {
+  local rc=$?
+  dump_logs
+  cleanup
+  exit "$rc"
+}
+trap finish EXIT
 
 mkdir -p logs
+rm -f logs/alice.log logs/bob.log logs/charlie.log
 echo -e "${GREEN}Building…${NC}"; cargo build --release --quiet
 
 echo -e "${CYAN}[charlie]${NC} :$CHARLIE_PORT  ${CYAN}[bob]${NC} :$BOB_PORT"
 "$CARGO_TARGET_DIR/release/charlie" > logs/charlie.log 2>&1 & PIDS+=($!)
 "$CARGO_TARGET_DIR/release/bob"     > logs/bob.log     2>&1 & PIDS+=($!)
-for _ in {1..20}; do lsof -iUDP:$BOB_PORT -n >/dev/null 2>&1 && lsof -iUDP:$CHARLIE_PORT -n >/dev/null 2>&1 && break; sleep 0.25; done
+
+ready=0
+for _ in {1..40}; do
+  if lsof -iUDP:"$BOB_PORT" -n >/dev/null 2>&1 \
+    && lsof -iUDP:"$CHARLIE_PORT" -n >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [ "$ready" -ne 1 ]; then
+  echo -e "${RED}❌ Bob/Charlie failed to bind UDP :$BOB_PORT / :$CHARLIE_PORT${NC}"
+  exit 1
+fi
 
 echo -e "${CYAN}[alice]${NC} :$ALICE_PORT calling Bob"
 "$CARGO_TARGET_DIR/release/alice" > logs/alice.log 2>&1 & DRIVER=$!; PIDS+=($DRIVER)
 wait "$DRIVER"; RC=$?
-sleep 1
 
-echo ""; for f in alice bob charlie; do sed "s/^/  /" logs/$f.log; done
 if [ "$RC" -eq 0 ] && grep -q "attended transfer complete" logs/alice.log; then
-  echo -e "\n${GREEN}✅ DEMO SUCCESSFUL — Alice was attended-transferred to Charlie${NC}"; exit 0
+  echo -e "\n${GREEN}✅ DEMO SUCCESSFUL — Alice was attended-transferred to Charlie${NC}"
+  exit 0
 else
-  echo -e "\n${RED}❌ DEMO FAILED (alice exit $RC) — see logs/${NC}"; exit 1
+  echo -e "\n${RED}❌ DEMO FAILED (alice exit $RC) — see logs/${NC}"
+  exit 1
 fi

--- a/examples/06-attended-transfer/src/alice.rs
+++ b/examples/06-attended-transfer/src/alice.rs
@@ -6,7 +6,7 @@
 //! Refer-To target — which replaces that consultation leg.
 
 use rvoip_sip::{Config, Event, StreamPeer};
-use tokio::time::{sleep, Duration};
+use tokio::time::{timeout, Duration};
 
 fn env_port(key: &str, default: u16) -> u16 {
     std::env::var(key)
@@ -23,8 +23,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    let alice_port = env_port("ALICE_PORT", 5060);
-    let bob_port = env_port("BOB_PORT", 5061);
+    // Defaults avoid the combined examples-smoke ports used by quickstart-p2p
+    // (5060/5061) and secure-call-srtp (5060).
+    let alice_port = env_port("ALICE_PORT", 5080);
+    let bob_port = env_port("BOB_PORT", 5081);
 
     let mut alice = StreamPeer::with_config(Config::local("alice", alice_port)).await?;
 
@@ -33,42 +35,56 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .invite(format!("sip:bob@127.0.0.1:{bob_port}"))
         .send()
         .await?;
-    let handle = alice.coordinator().session(&call_id);
-    alice.wait_for_answered(handle.id()).await?;
+    // Prefer SessionHandle::wait_for_answered: it observes authoritative
+    // lifecycle evidence and does not miss CallAnswered if the event already
+    // fired. StreamPeer::wait_for_answered only watches the event stream.
+    let bob_leg = alice.coordinator().session(&call_id);
+    bob_leg
+        .wait_for_answered(Some(Duration::from_secs(20)))
+        .await?;
     println!("[ALICE] Connected to Bob.");
 
+    // Bound the REFER wait: the combined examples-smoke hang was Alice waiting
+    // here forever after dialing a stale peer on recycled 5060/5061 ports.
     println!("[ALICE] Waiting for attended transfer...");
     let mut events = alice.control().subscribe_events().await?;
-    loop {
-        match events.next().await {
-            Some(Event::ReferReceived {
-                refer_to, replaces, ..
-            }) => {
-                println!("[ALICE] Got REFER to {refer_to}");
-                println!("[ALICE] Replaces = {replaces:?}");
-                handle.hangup().await?;
-                alice.wait_for_ended(handle.id()).await?;
-
-                println!("[ALICE] Completing transfer — calling the Refer-To target...");
-                let charlie_id = alice.invite(refer_to.clone()).send().await?;
-                let charlie = alice.coordinator().session(&charlie_id);
-                alice.wait_for_answered(charlie.id()).await?;
-                println!("[ALICE] ✅ Connected to Charlie (attended transfer complete).");
-
-                sleep(Duration::from_secs(1)).await;
-                charlie.hangup().await?;
-                alice.wait_for_ended(charlie.id()).await?;
-                break;
+    let (refer_to, replaces) = timeout(Duration::from_secs(45), async {
+        loop {
+            match events.next().await {
+                Some(Event::ReferReceived {
+                    refer_to, replaces, ..
+                }) => return Ok::<_, String>((refer_to, replaces)),
+                Some(Event::CallEnded { .. }) => {
+                    return Err("call ended before attended-transfer REFER".into());
+                }
+                None => return Err("event stream closed before attended-transfer REFER".into()),
+                _ => {}
             }
-            Some(Event::CallEnded { .. }) => {
-                println!("[ALICE] Call ended before transfer");
-                break;
-            }
-            None => break,
-            _ => {}
         }
-    }
+    })
+    .await
+    .map_err(|_| "timed out waiting for attended-transfer REFER".to_string())??;
+    println!("[ALICE] Got REFER to {refer_to}");
+    println!("[ALICE] Replaces = {replaces:?}");
+
+    // Place the replacing INVITE while the original Bob leg is still up. Hanging
+    // up first races Bob's consultation teardown and can leave Charlie answered
+    // without Alice observing lifecycle answer evidence.
+    println!("[ALICE] Completing transfer — calling the Refer-To target...");
+    let charlie_id = alice.invite(refer_to.clone()).send().await?;
+    let charlie = alice.coordinator().session(&charlie_id);
+    charlie
+        .wait_for_answered(Some(Duration::from_secs(30)))
+        .await?;
+    println!("[ALICE] ✅ Connected to Charlie (attended transfer complete).");
+
+    let _ = bob_leg.hangup().await;
+    let _ = bob_leg.wait_for_end(Some(Duration::from_secs(5))).await;
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let _ = charlie.hangup().await;
+    let _ = charlie.wait_for_end(Some(Duration::from_secs(10))).await;
 
     println!("[ALICE] Done.");
-    std::process::exit(0);
+    Ok(())
 }

--- a/examples/06-attended-transfer/src/bob.rs
+++ b/examples/06-attended-transfer/src/bob.rs
@@ -24,8 +24,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    let bob_port = env_port("BOB_PORT", 5061);
-    let charlie_port = env_port("CHARLIE_PORT", 5062);
+    // Defaults avoid the combined examples-smoke ports used by quickstart-p2p
+    // (5060/5061) and secure-call-srtp (5060).
+    let bob_port = env_port("BOB_PORT", 5081);
+    let charlie_port = env_port("CHARLIE_PORT", 5082);
 
     let mut bob = StreamPeer::with_config(Config::local("bob", bob_port)).await?;
     println!("[BOB] Waiting for call...");
@@ -55,10 +57,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .transfer_attended(&format!("sip:charlie@127.0.0.1:{charlie_port}"), &replaces)
         .await?;
 
-    // Give Alice time to place the replacing INVITE, then drop both legs.
-    sleep(Duration::from_secs(3)).await;
-    let _ = alice_leg.hangup_and_wait(Some(Duration::from_secs(5))).await;
-    let _ = consult.hangup_and_wait(Some(Duration::from_secs(5))).await;
+    // Give Alice time to place the replacing INVITE and observe answer before
+    // tearing down the consultation/original legs.
+    sleep(Duration::from_secs(12)).await;
+    let _ = alice_leg.hangup_and_wait(Some(Duration::from_secs(3))).await;
+    let _ = consult.hangup_and_wait(Some(Duration::from_secs(3))).await;
     println!("[BOB] Done.");
-    std::process::exit(0);
+    Ok(())
 }

--- a/examples/06-attended-transfer/src/charlie.rs
+++ b/examples/06-attended-transfer/src/charlie.rs
@@ -21,7 +21,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    let charlie_port = env_port("CHARLIE_PORT", 5062);
+    // Defaults avoid the combined examples-smoke ports used by quickstart-p2p
+    // (5060/5061) and secure-call-srtp (5060).
+    let charlie_port = env_port("CHARLIE_PORT", 5082);
 
     let mut charlie = StreamPeer::with_config(Config::local("charlie", charlie_port)).await?;
     println!("[CHARLIE] Waiting for consultation call from Bob...");


### PR DESCRIPTION
## Summary
- Main Gate `examples-smoke` was failing with exit 124 on `06-attended-transfer` after `01-quickstart-p2p` recycled ports `5060`/`5061` (also seen on PR #155).
- Move attended-transfer defaults to `5080`–`5082`, fail closed if Bob/Charlie do not bind, dump logs on exit, and bound Alice's REFER wait.
- Use `SessionHandle::wait_for_answered` and complete the replacing INVITE before tearing down Bob so Charlie's answer is observed reliably.

## Test plan
- [x] `./examples/06-attended-transfer/run_demo.sh` ×10 locally (10/10)
- [x] Sequential `01-quickstart-p2p` → `02-softphone-audio` → `06-attended-transfer` locally
- [ ] Main Gate / PR Gate `examples-smoke` (or `example-smoke--06-attended-transfer`) green


Made with [Cursor](https://cursor.com)