### PR TITLE
Fix 0.3.7 release qualification blockers

### DIFF
--- a/crates/sip/rvoip-sip/scripts/beta_release_report.py
+++ b/crates/sip/rvoip-sip/scripts/beta_release_report.py
@@ -374,7 +374,7 @@ PROXY_INTEROP_OPENSIPS_TLS_DOCKERFILE = (
     "crates/sip/sip-proxy/tests/interop/images/opensips-tls/Dockerfile"
 )
 PROXY_INTEROP_OPENSIPS_TLS_DOCKERFILE_SHA256 = (
-    "0093ff1117307b11db1d3783b54f01ea63c3c016c3993e2bf4ec52100aebf312"
+    "2ad332bdbb48e707c3995e0e95500053857a908c178de025d8180f6133d4501c"
 )
 PROXY_INTEROP_OPENSIPS_TLS_PACKAGES = {
     "opensips": {"version": "3.6.7-1"},
@@ -393,7 +393,7 @@ PROXY_INTEROP_OPENSIPS_TLS_PACKAGES = {
     "opensips-tls-openssl-module": {
         "version": "3.6.7-1",
         "deb_sha256": (
-            "05e0c80de73b352390981352f08183f9acc3dd0187577688c4c174f94fd9bc68"
+            "690c52e06b9d0f8d76483900a4185f3a3d7cc3ec30a752ff762bdca254750209"
         ),
     },
 }
@@ -408,7 +408,7 @@ PROXY_INTEROP_OPENSIPS_TLS_MODULES = {
     },
     "tls_openssl.so": {
         "path": "/usr/lib/x86_64-linux-gnu/opensips/modules/tls_openssl.so",
-        "sha256": ("ec8dbf7164f48b8ae6298f4d014980f567ef4d7cc426ce39d83071b4a4ca956e"),
+        "sha256": ("77714d25e26933b4a18408b3ef65bad75400d5840d1bcf58efde99292e21ba6f"),
     },
 }
 

--- a/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
+++ b/crates/sip/rvoip-sip/tests/perf/perf_burst_caller.rs
@@ -1119,7 +1119,18 @@ async fn run_one_call(
         Err(err) => {
             counters.pending_setups.fetch_sub(1, Ordering::Relaxed);
             let is_timeout = matches!(&err, rvoip_sip::SessionError::Timeout(_));
-            let looks_like_overload = looks_like_overload(&err);
+            let hangup_started = Instant::now();
+            let hangup_result = handle.hangup_and_wait(Some(call_timeout)).await;
+            let lifecycle_after_hangup = handle.lifecycle().await.ok();
+            // The immediate wait error can lose the typed SIP response while
+            // the exact call lifecycle still retains it. Classify from both
+            // sources so a terminal 503 cannot be mistaken for an unrelated
+            // failure, but never use terminal evidence to mask a timeout.
+            let looks_like_overload = !is_timeout
+                && (looks_like_overload(&err)
+                    || lifecycle_after_hangup
+                        .as_ref()
+                        .is_some_and(lifecycle_reports_overload));
             if is_timeout {
                 counters.timeout.fetch_add(1, Ordering::Relaxed);
             } else {
@@ -1129,13 +1140,6 @@ async fn run_one_call(
                 }
             }
             phase.record_failed(in_stable_recovery, looks_like_overload, phase_elapsed);
-            let hangup_started = Instant::now();
-            let hangup_result = handle.hangup_and_wait(Some(call_timeout)).await;
-            let lifecycle_after_hangup = handle
-                .lifecycle()
-                .await
-                .ok()
-                .map(|snapshot| lifecycle_snapshot_json(&snapshot));
             call_failure_trace.record(json!({
                 "kind": if is_timeout { "answer_timeout" } else { "answer_failed" },
                 "call_seq": call_seq,
@@ -1154,7 +1158,9 @@ async fn run_one_call(
                     Ok(reason) => json!({"ok": true, "reason": reason}),
                     Err(err) => json!({"ok": false, "error": err.to_string()}),
                 },
-                "lifecycle_after_hangup": lifecycle_after_hangup,
+                "lifecycle_after_hangup": lifecycle_after_hangup
+                    .as_ref()
+                    .map(lifecycle_snapshot_json),
             }));
             return;
         }
@@ -1701,6 +1707,16 @@ fn looks_like_overload(err: &rvoip_sip::SessionError) -> bool {
     text.contains("503") || text.contains("service unavailable") || text.contains("overload")
 }
 
+fn lifecycle_reports_overload(snapshot: &rvoip_sip::CallLifecycleSnapshot) -> bool {
+    matches!(
+        snapshot.terminal.as_ref(),
+        Some(rvoip_sip::CallTerminalInfo::Failed {
+            status_code: 503,
+            ..
+        })
+    )
+}
+
 fn update_atomic_max(target: &AtomicU64, value: u64) {
     let mut current = target.load(Ordering::Relaxed);
     while value > current {
@@ -1729,7 +1745,7 @@ fn soak_like_settings(scenario: &BurstScenario) -> support::soak::SoakLoadSettin
 
 #[cfg(test)]
 mod tests {
-    use super::looks_like_overload;
+    use super::{lifecycle_reports_overload, looks_like_overload};
 
     #[test]
     fn overload_classifier_uses_typed_detail_without_unredacting_reports() {
@@ -1741,6 +1757,32 @@ mod tests {
         assert!(!error.to_string().contains("503"));
         assert!(!looks_like_overload(&rvoip_sip::SessionError::Other(
             "call failed before answer: 486 Busy Here".to_string(),
+        )));
+    }
+
+    #[test]
+    fn overload_classifier_uses_authoritative_terminal_status() {
+        let snapshot = |terminal| rvoip_sip::CallLifecycleSnapshot {
+            call_id: rvoip_sip::SessionId::new(),
+            state: None,
+            progress: Vec::new(),
+            answered: None,
+            media_security: None,
+            terminal: Some(terminal),
+            latest_transfer_outcome: None,
+        };
+
+        assert!(lifecycle_reports_overload(&snapshot(
+            rvoip_sip::CallTerminalInfo::Failed {
+                status_code: 503,
+                reason: "Service Unavailable".to_string(),
+            },
+        )));
+        assert!(!lifecycle_reports_overload(&snapshot(
+            rvoip_sip::CallTerminalInfo::Failed {
+                status_code: 486,
+                reason: "Busy Here".to_string(),
+            },
         )));
     }
 }

--- a/crates/sip/sip-proxy/tests/interop/images/opensips-tls/Dockerfile
+++ b/crates/sip/sip-proxy/tests/interop/images/opensips-tls/Dockerfile
@@ -4,7 +4,7 @@ ARG OPENSIPS_VERSION=3.6.7-1
 ARG OPENSIPS_POOL=https://apt.opensips.org/pool/bullseye/3.6-releases/o/opensips
 ARG PROTO_TLS_SHA256=685f704faf2ce6b9015a0c059a32333bf789cabd8a467c7068aa1cea363de799
 ARG TLS_MGM_SHA256=20d83193399a9ee02b8c3f1cc2fbe311231ec22c0b43656add63f77110a68545
-ARG TLS_OPENSSL_SHA256=05e0c80de73b352390981352f08183f9acc3dd0187577688c4c174f94fd9bc68
+ARG TLS_OPENSSL_SHA256=690c52e06b9d0f8d76483900a4185f3a3d7cc3ec30a752ff762bdca254750209
 
 LABEL org.opencontainers.image.title="rvoip OpenSIPS 3.6.7 TLS interop peer" \
       org.opencontainers.image.description="Pinned OpenSIPS beta-gate peer with only the reviewed TLS modules added" \

--- a/crates/sip/sip-proxy/tests/interop/scripts/opensips_tls_provenance.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/opensips_tls_provenance.py
@@ -36,7 +36,7 @@ REVIEWED_DEBS = {
         "20d83193399a9ee02b8c3f1cc2fbe311231ec22c0b43656add63f77110a68545"
     ),
     "opensips-tls-openssl-module_3.6.7-1_amd64.deb": (
-        "05e0c80de73b352390981352f08183f9acc3dd0187577688c4c174f94fd9bc68"
+        "690c52e06b9d0f8d76483900a4185f3a3d7cc3ec30a752ff762bdca254750209"
     ),
 }
 MODULES = {
@@ -47,7 +47,7 @@ MODULES = {
         "f2726bc731dbdf840bd40dbc7209eded8f16899034177b8dabed481da60662d2"
     ),
     "/usr/lib/x86_64-linux-gnu/opensips/modules/tls_openssl.so": (
-        "ec8dbf7164f48b8ae6298f4d014980f567ef4d7cc426ce39d83071b4a4ca956e"
+        "77714d25e26933b4a18408b3ef65bad75400d5840d1bcf58efde99292e21ba6f"
     ),
 }
 

--- a/crates/sip/sip-proxy/tests/interop/scripts/verify_tls_evidence.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/verify_tls_evidence.py
@@ -115,7 +115,7 @@ OPENSIPS_PACKAGES = {
     "opensips-tls-openssl-module": {
         "version": "3.6.7-1",
         "deb_sha256": (
-            "05e0c80de73b352390981352f08183f9acc3dd0187577688c4c174f94fd9bc68"
+            "690c52e06b9d0f8d76483900a4185f3a3d7cc3ec30a752ff762bdca254750209"
         ),
     },
 }
@@ -137,7 +137,7 @@ OPENSIPS_MODULES = {
             "/usr/lib/x86_64-linux-gnu/opensips/modules/tls_openssl.so"
         ),
         "sha256": (
-            "ec8dbf7164f48b8ae6298f4d014980f567ef4d7cc426ce39d83071b4a4ca956e"
+            "77714d25e26933b4a18408b3ef65bad75400d5840d1bcf58efde99292e21ba6f"
         ),
     },
 }


### PR DESCRIPTION
## Summary

- classify overload failures from the authoritative terminal SIP 503 when the immediate session error loses typed response detail
- refresh the reviewed OpenSIPS 3.6.7 TLS OpenSSL package and module digests across build, provenance, verification, and release reporting
- preserve strict timeout and non-overload failure rejection

## Root cause

Release qualification run 31145050423 rejected one terminal 503 as an unclassified overload failure. Both OpenSIPS TLS rows also failed because the upstream same-version package was rebuilt and no longer matched the reviewed digest.

## Validation

- `cargo fmt --all -- --check`
- focused `perf_burst_caller` classifier tests: 2 passed
- OpenSIPS provenance tests: 7 passed
- TLS evidence tests: 15 passed
- beta release report tests: 24 passed
- workflow policy tests: 29 passed
- real linux/amd64 OpenSIPS image build passed all package digest/version checks
- running-image provenance capture passed with the reviewed module hashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to perf test classification logic and pinned third-party artifact hashes for interop/release verification; no production SIP runtime behavior changes.
> 
> **Overview**
> Fixes two **0.3.7 release qualification** failures: one misclassified perf overload and stale **OpenSIPS 3.6.7 TLS** provenance after an upstream package rebuild.
> 
> In **`perf_burst_caller`**, answer failures now run **hangup** before classifying overload. Overload is true when the immediate `SessionError` looks like overload **or** the post-hangup lifecycle shows a terminal **503**, but **timeouts** never inherit overload from lifecycle. Adds `lifecycle_reports_overload` and unit tests.
> 
> **OpenSIPS TLS interop** pins are refreshed everywhere they are checked: the interop **Dockerfile** `TLS_OPENSSL` deb hash, **`opensips_tls_provenance.py`**, **`verify_tls_evidence.py`**, and **`beta_release_report.py`** (Dockerfile SHA, `opensips-tls-openssl-module` deb, and `tls_openssl.so` module hashes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f022220a4b154645593dde94eb3e3e6c6b539a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->