### PR TITLE
Add WebTransport origin allowlist

### DIFF
--- a/crates/uctp/rvoip-webtransport/src/adapter.rs
+++ b/crates/uctp/rvoip-webtransport/src/adapter.rs
@@ -3,6 +3,7 @@
 //! line-for-line; only `transport()` and the WT-upgrade in the accept
 //! path differ.
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -66,6 +67,12 @@ pub struct UctpWtConfig {
     pub max_concurrent_connections: usize,
     /// HTTP/3 `:path` to accept the WebTransport upgrade on.
     pub mount_path: String,
+    /// Exact browser origins permitted to establish a WebTransport session.
+    ///
+    /// `None` preserves the pre-policy behavior for non-browser and legacy
+    /// deployments. `Some` requires exactly one `Origin` header whose value is
+    /// present in the set; an empty set therefore denies every request.
+    pub allowed_origins: Option<Arc<HashSet<String>>>,
     pub quinn_stats_interval: std::time::Duration,
     pub client_endpoint: Option<Arc<quinn::Endpoint>>,
     pub client_tls: Option<Arc<rustls::ClientConfig>>,
@@ -102,6 +109,7 @@ impl UctpWtConfig {
             bearer_validator,
             max_concurrent_connections: 1024,
             mount_path: "/uctp".into(),
+            allowed_origins: None,
             quinn_stats_interval: std::time::Duration::from_secs(5),
             client_endpoint: None,
             client_tls: None,
@@ -141,6 +149,15 @@ impl UctpWtConfig {
 
     pub fn with_orchestrator(mut self, orch: Arc<rvoip_core::Orchestrator>) -> Self {
         self.orchestrator = Some(orch);
+        self
+    }
+
+    /// Require an exact `Origin` match before accepting WebTransport CONNECT.
+    pub fn with_allowed_origins(
+        mut self,
+        allowed_origins: impl IntoIterator<Item = String>,
+    ) -> Self {
+        self.allowed_origins = Some(Arc::new(allowed_origins.into_iter().collect()));
         self
     }
 
@@ -202,6 +219,7 @@ impl UctpWtAdapter {
             Arc::clone(&routes),
             config.max_concurrent_connections,
             config.mount_path,
+            config.allowed_origins,
             config.quinn_stats_interval,
             config.subscription_handler,
             config.session_binding_resolver,

--- a/crates/uctp/rvoip-webtransport/src/server.rs
+++ b/crates/uctp/rvoip-webtransport/src/server.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashMap, num::NonZeroU16};
+use std::{collections::HashMap, collections::HashSet, num::NonZeroU16};
 
 use chrono::Utc;
 use dashmap::DashMap;
@@ -42,6 +42,7 @@ impl UctpWtServer {
         routes: Arc<DashMap<ConnectionId, Route>>,
         max_concurrent: usize,
         mount_path: String,
+        allowed_origins: Option<Arc<HashSet<String>>>,
         quinn_stats_interval: Duration,
         subscription_handler: Option<Arc<dyn rvoip_uctp::state::SubscriptionHandler>>,
         session_binding_resolver: Option<Arc<dyn rvoip_uctp::state::SessionBindingResolver>>,
@@ -72,6 +73,7 @@ impl UctpWtServer {
                 let events_tx = events_tx.clone();
                 let lifecycle_sink = lifecycle_sink.clone();
                 let mount_path = mount_path.clone();
+                let allowed_origins = allowed_origins.clone();
                 let by_connection = Arc::clone(&by_connection);
                 let by_uctp_sid = Arc::clone(&by_uctp_sid);
                 let routes = Arc::clone(&routes);
@@ -93,6 +95,7 @@ impl UctpWtServer {
                         by_uctp_sid,
                         routes,
                         mount_path,
+                        allowed_origins,
                         quinn_stats_interval,
                         subscription_handler,
                         session_binding_resolver,
@@ -323,6 +326,7 @@ async fn spawn_peer_session(
     by_uctp_sid: Arc<DashMap<String, ConnectionId>>,
     routes: Arc<DashMap<ConnectionId, Route>>,
     mount_path: String,
+    allowed_origins: Option<Arc<HashSet<String>>>,
     quinn_stats_interval: Duration,
     subscription_handler: Option<Arc<dyn rvoip_uctp::state::SubscriptionHandler>>,
     session_binding_resolver: Option<Arc<dyn rvoip_uctp::state::SessionBindingResolver>>,
@@ -357,15 +361,20 @@ async fn spawn_peer_session(
     };
 
     // web-transport-quinn 0.11+: `url` is a field, not a method.
-    // The graceful `close(StatusCode)` API was removed; for now we
-    // drop the request on path mismatch, which manifests as a
-    // closed CONNECT stream on the client side.
     if !request.url.path().eq(&mount_path) {
         warn!(
             requested = %request.url.path(),
             expected = %mount_path,
             "rvoip-webtransport: mount path mismatch; closing"
         );
+        return;
+    }
+
+    if !request_origin_allowed(&request.headers, allowed_origins.as_deref()) {
+        warn!(%peer_addr, "rvoip-webtransport: origin rejected");
+        if let Err(error) = request.reject(http::StatusCode::FORBIDDEN).await {
+            warn!(%peer_addr, %error, "rvoip-webtransport: failed to reject origin");
+        }
         return;
     }
 
@@ -1083,4 +1092,56 @@ async fn spawn_peer_session(
     stats_pump.abort();
 
     info!(%peer_addr, "rvoip-webtransport: connection closed");
+}
+
+fn request_origin_allowed(
+    headers: &http::HeaderMap,
+    allowed_origins: Option<&HashSet<String>>,
+) -> bool {
+    let Some(allowed_origins) = allowed_origins else {
+        return true;
+    };
+    let mut origins = headers.get_all(http::header::ORIGIN).iter();
+    let Some(origin) = origins.next() else {
+        return false;
+    };
+    if origins.next().is_some() {
+        return false;
+    }
+    origin
+        .to_str()
+        .ok()
+        .is_some_and(|origin| allowed_origins.contains(origin))
+}
+
+#[cfg(test)]
+mod origin_tests {
+    use super::*;
+
+    fn allowed() -> HashSet<String> {
+        HashSet::from(["https://app.example.com".to_owned()])
+    }
+
+    #[test]
+    fn configured_origin_policy_requires_one_exact_match() {
+        let mut headers = http::HeaderMap::new();
+        assert!(!request_origin_allowed(&headers, Some(&allowed())));
+
+        headers.insert(
+            http::header::ORIGIN,
+            http::HeaderValue::from_static("https://app.example.com"),
+        );
+        assert!(request_origin_allowed(&headers, Some(&allowed())));
+
+        headers.insert(
+            http::header::ORIGIN,
+            http::HeaderValue::from_static("https://other.example.com"),
+        );
+        assert!(!request_origin_allowed(&headers, Some(&allowed())));
+    }
+
+    #[test]
+    fn absent_policy_preserves_legacy_clients() {
+        assert!(request_origin_allowed(&http::HeaderMap::new(), None));
+    }
 }


### PR DESCRIPTION
## Summary

- add an opt-in exact Origin allowlist to UctpWtConfig
- reject missing, duplicate, and unlisted browser origins before accepting WebTransport CONNECT
- preserve existing non-browser behavior when no policy is configured

## Verification

- cargo test -p rvoip-webtransport

Thelve's dedicated browser WebTransport deployment uses this public seam to enforce its configured UI origins.