### PR TITLE
Prepare the 0.3.8 release

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Stable SemVer without a leading v (for example 0.3.7)
+        description: Stable SemVer without a leading v (for example 0.3.8)
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,13 @@ repairs SIPS dialog and opus-bridge edge cases found on the way.
 - Expose the profiled egress registration's coordinator for
   observation-only event subscriptions; the composite adapter remains the
   sole signaling and lifecycle owner.
-- `Config` gains `amr_dtx`, `amr_auto_cmr`, and `amr_mode_set`. The 0.3.x
-  line accepts additive `Config` fields; construct through the documented
-  constructors rather than struct literals.
+- `Config` gains `with_amr_dtx`, `with_amr_auto_cmr`, and
+  `with_amr_mode_set` builders (private fields — `Config`'s constructible
+  shape stays frozen). DTX and auto-CMR are local media policy; only the
+  RFC 4867 `mode-set` is negotiated.
+- `CodecInfo` carries the payload type a transport negotiated
+  (`payload_type: Option<u8>`). Code constructing `CodecInfo` literals adds
+  one field on upgrade; `None` preserves the name-table behavior.
 
 ### Media graph and bridges
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 ## Unreleased
 
+## 0.3.8 — 2026-08-14
+
+This coordinated 44-crate patch release brings AMR-NB and AMR-WB into the
+codec set end to end — negotiation, transport, transcoding, and release
+evidence — adds record-routed proxy interop to the qualification matrix, and
+repairs SIPS dialog and opus-bridge edge cases found on the way.
+
+### AMR codecs
+
+- Add AMR-NB and AMR-WB with IF1 and IF2 interface formats, VAD1/VAD2 and DTX
+  reaching the wire, receive-side interleaving reassembly, max-red redundancy
+  scheduling with dedup, and CMR damping — bit-exact against the fetched
+  TS 26.073/26.101/26.201 material, with no 3GPP sources in the repository.
+- Negotiate and obey the SDP mode-set, prove every mode in a live call, and
+  attest each rate in the release evidence; long-run soaks cover both
+  variants.
+- Admit dynamic codecs into the media graph by their negotiated payload type
+  (`CodecInfo` now carries it), re-frame packet times AMR cannot accept
+  (10 ms joins and 30 ms splits), and label emitted frames so the UCTP pumps
+  stop stamping Opus's number on everything else.
+- Prove AMR crosses SRTP in process and a QUIC datagram in both directions.
+
+### SIP, proxies, and interop
+
+- Generate a secure fallback Contact for every RFC 3261 §12.1.1 trigger, so
+  secure dialogs answer with `sips:` at the TLS-advertised address while
+  explicit Contact and plain-SIP behavior are preserved (issue #176). This
+  also repairs rvoip-to-rvoip SIPS setup: `Dialog::from_2xx_response` refuses
+  a secure dialog whose Contact is not `sips:`, which the old plain fallback
+  tripped.
+- Learn the UAC route set from the dialog-forming 2xx's Record-Route
+  (reversed per §12.1.2), so in-dialog requests stop bypassing
+  record-routing proxies; the UAS side reads it from the request.
+- Add Kamailio and OpenSIPS registrar-proxy labs with TLS and SRTP through
+  rtpengine, opt-in AMR-NB transcoding (the AMR-WB transcode failure is
+  attributed to rtpengine), and a per-rate sweep bound to the gate catalog.
+- Expose the profiled egress registration's coordinator for
+  observation-only event subscriptions; the composite adapter remains the
+  sole signaling and lifecycle owner.
+- `Config` gains `amr_dtx`, `amr_auto_cmr`, and `amr_mode_set`. The 0.3.x
+  line accepts additive `Config` fields; construct through the documented
+  constructors rather than struct literals.
+
+### Media graph and bridges
+
+- Keep opus↔opus bridges passthrough when the two legs numbered opus
+  differently: the payload type is a per-leg SDP artifact, so the bypass
+  compares name, rate, and channels, and passthrough restamps the sink's
+  payload type on egress.
+- Make a barge-in flush empty the re-framing accumulator as well as the sink
+  queues, so no pre-interruption audio or dead-timeline timestamp survives
+  into the first post-flush frame.
+- Reach the opus and all-codecs feature sets from the rvoip facade.
+
+### Qualification
+
+`0.3.8` requires a fresh `remote-release` qualification bound to the updated
+gate catalog, which adds the AMR per-rate sweep, the proxy-PBX media family,
+and the AMR fuzz targets. Because the aggregate is bound to the catalog hash,
+no `0.3.7` evidence qualifies this release.
+
 ## 0.3.7 — 2026-08-06
 
 This coordinated 44-crate patch release hardens voice-AI and WebRTC media under

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6787,7 +6787,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -6816,7 +6816,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-amazon-connect"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-audio-device"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "cpal",
@@ -6860,7 +6860,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-audit"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -6874,7 +6874,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-auth-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-client"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-codec-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "criterion",
  "opus",
@@ -6939,7 +6939,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6972,7 +6972,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core-traits"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6988,7 +6988,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-harness"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-identity"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "rvoip-core",
@@ -7007,7 +7007,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-ims-aka"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aes",
  "async-trait",
@@ -7026,7 +7026,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-infra-common"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7054,7 +7054,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-keycloak"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-ldap"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "ldap3",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-media-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "apodize",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-native"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-relay"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7200,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-moq-transport"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "bytes",
  "futures",
@@ -7218,7 +7218,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-oidc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-quic"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7257,7 +7257,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-redis"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7312,7 +7312,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtp-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -7349,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-saml"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7364,7 +7364,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-scim"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7469,7 +7469,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-dialog"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-proxy"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -7513,7 +7513,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-registrar"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7534,7 +7534,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-transport"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7566,7 +7566,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-stir-shaken"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7591,7 +7591,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-uctp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7630,7 +7630,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-users-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7672,7 +7672,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vapi"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -7697,7 +7697,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7718,7 +7718,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon-postgres"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7735,7 +7735,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webauthn"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -7806,7 +7806,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc-stack"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7827,7 +7827,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-websocket"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7856,7 +7856,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webtransport"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ default-members = [
 [workspace.package]
 # Every publishable workspace crate ships at this one version. Feature-level
 # maturity and non-claims remain documented independently of package SemVer.
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/eisenzopf/rvoip"
@@ -213,55 +213,55 @@ collapsible_else_if = "allow"
 # the in-repo directory changed. See the grouped [workspace] members above.
 # All publishable workspace crates and internal registry requirements move
 # together in one dependency-ordered release.
-rvoip-sip-core      = { path = "crates/sip/sip-core", version = "0.3.7" }
-rvoip-sip-transport = { path = "crates/sip/sip-transport", version = "0.3.7" }
-rvoip-sip-dialog    = { path = "crates/sip/sip-dialog", version = "0.3.7" }
-rvoip-sip-proxy     = { path = "crates/sip/sip-proxy", version = "0.3.7" }
-rvoip-sip-registrar = { path = "crates/sip/sip-registrar", version = "0.3.7" }
-rvoip-rtp-core      = { path = "crates/media/rtp-core", version = "0.3.7" }
-rvoip-media-core    = { path = "crates/media/media-core", version = "0.3.7" }
-rvoip-sip           = { path = "crates/sip/rvoip-sip", version = "0.3.7" }
-rvoip-core          = { path = "crates/foundation/rvoip-core", version = "0.3.7" }
-rvoip-codec-core    = { path = "crates/media/codec-core", version = "0.3.7" }
-rvoip-infra-common  = { path = "crates/foundation/infra-common", version = "0.3.7" }
-rvoip-auth-core     = { path = "crates/identity/auth-core", version = "0.3.7" }
-rvoip-core-traits   = { path = "crates/foundation/rvoip-core-traits", version = "0.3.7" }
-rvoip-users-core    = { path = "crates/identity/users-core", version = "0.3.7" }
+rvoip-sip-core      = { path = "crates/sip/sip-core", version = "0.3.8" }
+rvoip-sip-transport = { path = "crates/sip/sip-transport", version = "0.3.8" }
+rvoip-sip-dialog    = { path = "crates/sip/sip-dialog", version = "0.3.8" }
+rvoip-sip-proxy     = { path = "crates/sip/sip-proxy", version = "0.3.8" }
+rvoip-sip-registrar = { path = "crates/sip/sip-registrar", version = "0.3.8" }
+rvoip-rtp-core      = { path = "crates/media/rtp-core", version = "0.3.8" }
+rvoip-media-core    = { path = "crates/media/media-core", version = "0.3.8" }
+rvoip-sip           = { path = "crates/sip/rvoip-sip", version = "0.3.8" }
+rvoip-core          = { path = "crates/foundation/rvoip-core", version = "0.3.8" }
+rvoip-codec-core    = { path = "crates/media/codec-core", version = "0.3.8" }
+rvoip-infra-common  = { path = "crates/foundation/infra-common", version = "0.3.8" }
+rvoip-auth-core     = { path = "crates/identity/auth-core", version = "0.3.8" }
+rvoip-core-traits   = { path = "crates/foundation/rvoip-core-traits", version = "0.3.8" }
+rvoip-users-core    = { path = "crates/identity/users-core", version = "0.3.8" }
 
 # Optional and top-of-stack crates are part of the same release. Facade and
 # core packages list extension crates such as rvoip-vcon, rvoip-harness, and
 # rvoip-vapi as optional runtime dependencies, so their versions must resolve
 # on crates.io regardless of feature activation.
-rvoip-vcon          = { path = "crates/extensions/rvoip-vcon", version = "0.3.7" }
-rvoip-vcon-postgres = { path = "crates/extensions/rvoip-vcon-postgres", version = "0.3.7" }
-rvoip-harness       = { path = "crates/extensions/rvoip-harness", version = "0.3.7" }
-rvoip-vapi          = { path = "crates/extensions/rvoip-vapi", version = "0.3.7" }
-rvoip               = { path = "crates/rvoip", version = "0.3.7" }
-rvoip-uctp          = { path = "crates/uctp/rvoip-uctp", version = "0.3.7" }
-rvoip-quic          = { path = "crates/uctp/rvoip-quic", version = "0.3.7" }
-rvoip-webtransport  = { path = "crates/uctp/rvoip-webtransport", version = "0.3.7" }
-rvoip-websocket     = { path = "crates/uctp/rvoip-websocket", version = "0.3.7" }
-rvoip-moq-transport = { path = "crates/moq/rvoip-moq-transport", version = "0.3.7" }
-rvoip-moq-native    = { path = "crates/moq/rvoip-moq-native", version = "0.3.7" }
-rvoip-moq-relay     = { path = "crates/moq/rvoip-moq-relay", version = "0.3.7", default-features = false }
-rvoip-moq           = { path = "crates/moq/rvoip-moq", version = "0.3.7" }
-rvoip-rtc           = { path = "crates/webrtc/rvoip-rtc", version = "0.3.7" }
-rvoip-webrtc-stack  = { path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.7" }
-rvoip-webrtc        = { path = "crates/webrtc/rvoip-webrtc", version = "0.3.7" }
-rvoip-identity      = { path = "crates/identity/rvoip-identity", version = "0.3.7" }
-rvoip-client        = { path = "crates/rvoip-client", version = "0.3.7" }
-rvoip-audio-device  = { path = "crates/media/rvoip-audio-device", version = "0.3.7" }
-rvoip-stir-shaken   = { path = "crates/extensions/rvoip-stir-shaken", version = "0.3.7" }
-rvoip-keycloak      = { path = "crates/extensions/rvoip-keycloak", version = "0.3.7" }
-rvoip-redis         = { path = "crates/extensions/rvoip-redis", version = "0.3.7" }
-rvoip-audit         = { path = "crates/extensions/rvoip-audit", version = "0.3.7" }
-rvoip-oidc          = { path = "crates/extensions/rvoip-oidc", version = "0.3.7" }
-rvoip-ldap          = { path = "crates/extensions/rvoip-ldap", version = "0.3.7" }
-rvoip-scim          = { path = "crates/extensions/rvoip-scim", version = "0.3.7" }
-rvoip-saml          = { path = "crates/extensions/rvoip-saml", version = "0.3.7" }
-rvoip-webauthn      = { path = "crates/extensions/rvoip-webauthn", version = "0.3.7" }
-rvoip-ims-aka       = { path = "crates/extensions/rvoip-ims-aka", version = "0.3.7" }
-rtc = { package = "rvoip-rtc", path = "crates/webrtc/rvoip-rtc", version = "0.3.7" }
+rvoip-vcon          = { path = "crates/extensions/rvoip-vcon", version = "0.3.8" }
+rvoip-vcon-postgres = { path = "crates/extensions/rvoip-vcon-postgres", version = "0.3.8" }
+rvoip-harness       = { path = "crates/extensions/rvoip-harness", version = "0.3.8" }
+rvoip-vapi          = { path = "crates/extensions/rvoip-vapi", version = "0.3.8" }
+rvoip               = { path = "crates/rvoip", version = "0.3.8" }
+rvoip-uctp          = { path = "crates/uctp/rvoip-uctp", version = "0.3.8" }
+rvoip-quic          = { path = "crates/uctp/rvoip-quic", version = "0.3.8" }
+rvoip-webtransport  = { path = "crates/uctp/rvoip-webtransport", version = "0.3.8" }
+rvoip-websocket     = { path = "crates/uctp/rvoip-websocket", version = "0.3.8" }
+rvoip-moq-transport = { path = "crates/moq/rvoip-moq-transport", version = "0.3.8" }
+rvoip-moq-native    = { path = "crates/moq/rvoip-moq-native", version = "0.3.8" }
+rvoip-moq-relay     = { path = "crates/moq/rvoip-moq-relay", version = "0.3.8", default-features = false }
+rvoip-moq           = { path = "crates/moq/rvoip-moq", version = "0.3.8" }
+rvoip-rtc           = { path = "crates/webrtc/rvoip-rtc", version = "0.3.8" }
+rvoip-webrtc-stack  = { path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.8" }
+rvoip-webrtc        = { path = "crates/webrtc/rvoip-webrtc", version = "0.3.8" }
+rvoip-identity      = { path = "crates/identity/rvoip-identity", version = "0.3.8" }
+rvoip-client        = { path = "crates/rvoip-client", version = "0.3.8" }
+rvoip-audio-device  = { path = "crates/media/rvoip-audio-device", version = "0.3.8" }
+rvoip-stir-shaken   = { path = "crates/extensions/rvoip-stir-shaken", version = "0.3.8" }
+rvoip-keycloak      = { path = "crates/extensions/rvoip-keycloak", version = "0.3.8" }
+rvoip-redis         = { path = "crates/extensions/rvoip-redis", version = "0.3.8" }
+rvoip-audit         = { path = "crates/extensions/rvoip-audit", version = "0.3.8" }
+rvoip-oidc          = { path = "crates/extensions/rvoip-oidc", version = "0.3.8" }
+rvoip-ldap          = { path = "crates/extensions/rvoip-ldap", version = "0.3.8" }
+rvoip-scim          = { path = "crates/extensions/rvoip-scim", version = "0.3.8" }
+rvoip-saml          = { path = "crates/extensions/rvoip-saml", version = "0.3.8" }
+rvoip-webauthn      = { path = "crates/extensions/rvoip-webauthn", version = "0.3.8" }
+rvoip-ims-aka       = { path = "crates/extensions/rvoip-ims-aka", version = "0.3.8" }
+rtc = { package = "rvoip-rtc", path = "crates/webrtc/rvoip-rtc", version = "0.3.8" }
 
 # External dependencies
 tokio = { version = "1.36", features = ["full"] }
@@ -334,15 +334,15 @@ tokio-util = { version = "0.7", features = ["codec", "compat"] }
 metrics = "0.23"
 # Qualified, attributed MOQT draft-19 forks. Package aliases retain the
 # upstream Rust crate names while the registry identities remain rvoip-owned.
-moq-transport = { package = "rvoip-moq-transport", path = "crates/moq/rvoip-moq-transport", version = "0.3.7" }
-moq-native-ietf = { package = "rvoip-moq-native", path = "crates/moq/rvoip-moq-native", version = "0.3.7" }
-moq-relay-ietf = { package = "rvoip-moq-relay", path = "crates/moq/rvoip-moq-relay", version = "0.3.7", default-features = false }
+moq-transport = { package = "rvoip-moq-transport", path = "crates/moq/rvoip-moq-transport", version = "0.3.8" }
+moq-native-ietf = { package = "rvoip-moq-native", path = "crates/moq/rvoip-moq-native", version = "0.3.8" }
+moq-relay-ietf = { package = "rvoip-moq-relay", path = "crates/moq/rvoip-moq-relay", version = "0.3.8", default-features = false }
 # rvoip-websocket signaling + media. tokio-tungstenite for the WebSocket
 # transport, webrtc for the co-located PeerConnection media plane.
 # webrtc is pre-1.0 and API-volatile — pinned strictly. Bumping requires
 # verifying the WebRtcMediaBridge still compiles.
 tokio-tungstenite = "0.29"
-webrtc = { package = "rvoip-webrtc-stack", path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.7" }
+webrtc = { package = "rvoip-webrtc-stack", path = "crates/webrtc/rvoip-webrtc-stack", version = "0.3.8" }
 hickory-resolver = { version = "0.26.1", default-features = false, features = ["tokio", "system-config"] }
 tracing-appender = "0.2"
 env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ---
 
 > [!IMPORTANT]
-> **Unified `0.3.7` release train.** All 44 publishable workspace crates ship on
+> **Unified `0.3.8` release train.** All 44 publishable workspace crates ship on
 > the same version. Publication requires a fresh, strict full-beta run bound to
 > the exact release source: no skipped gates, no carry-forward qualification,
 > and passing workspace, security, four-peer interoperability, performance,
@@ -120,7 +120,7 @@ Add the SIP product:
 
 ```toml
 [dependencies]
-rvoip-sip = "0.3.7"
+rvoip-sip = "0.3.8"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -226,7 +226,7 @@ RTP-over-QUIC has shipped.
 
 ## Extensions
 
-All 14 extension crates ship at `0.3.7`. They are first-class workspace
+All 14 extension crates ship at `0.3.8`. They are first-class workspace
 capabilities, but remain optional so protocol crates depend on provider
 contracts rather than deployment-specific services.
 
@@ -248,22 +248,22 @@ The supporting contracts live in
 The facade exposes the conversation-model extensions together:
 
 ```toml
-rvoip = { version = "0.3.7", features = ["voip-3"] }
+rvoip = { version = "0.3.8", features = ["voip-3"] }
 ```
 
 `voip-3` enables SIP, WebRTC, UCTP, vCon, the identity provider surface, and
 the AI harness. Vapi and STIR/SHAKEN have separate facade features:
 
 ```toml
-rvoip = { version = "0.3.7", features = ["sip", "vapi", "sip-stir-shaken"] }
+rvoip = { version = "0.3.8", features = ["sip", "vapi", "sip-stir-shaken"] }
 ```
 
 Deployment-specific extensions are direct dependencies:
 
 ```toml
-rvoip-keycloak = "0.3.7"
-rvoip-redis = "0.3.7"
-rvoip-audit = "0.3.7"
+rvoip-keycloak = "0.3.8"
+rvoip-redis = "0.3.8"
+rvoip-audit = "0.3.8"
 ```
 
 The facade's `full` feature does **not** enable every workspace extension,
@@ -340,12 +340,12 @@ product's implementation:
   unified release identity, source compatibility notes, and attestation
   provenance.
 
-The `0.3.7` release requires a fresh strict full-beta report bound to one clean,
+The `0.3.8` release requires a fresh strict full-beta report bound to one clean,
 unchanged release source fingerprint. The gate admits no skipped checks and
 includes the workspace, SIP/media, public API, security, PBX, SIPp, strict-UA,
 proxy interoperability, performance, resiliency, and long-soak scopes. The
 historical `0.3.4` carry-forward receipt remains immutable release history; it
-does not qualify `0.3.7`.
+does not qualify `0.3.8`.
 
 ### SIP interoperability attestation
 
@@ -354,7 +354,7 @@ independently managed peers below. The report generator binds every row to the
 tested source tree, exact peer identity and configuration, selected matrix,
 and hashed evidence; it refuses to produce a strict release-candidate report
 if a required peer is missing, skipped, ambiguous, unpinned, or failing. This
-four-peer matrix is mandatory for the `0.3.7` strict release gate.
+four-peer matrix is mandatory for the `0.3.8` strict release gate.
 
 | Peer | Attested boundary | Required release evidence |
 | --- | --- | --- |

--- a/crates/extensions/rvoip-vcon/README.md
+++ b/crates/extensions/rvoip-vcon/README.md
@@ -5,7 +5,7 @@
 vCon (Virtualized Conversation) document model, builder, signer, validator, and
 store, pinned to `draft-ietf-vcon-vcon-core` working-group commit `2342aba`.
 Core Session finalization exposes persisted documents through `VconReady`.
-`RecordingComplete.vcon_ref` wiring remains outside the current 0.3.7 scope.
+`RecordingComplete.vcon_ref` wiring remains outside the current 0.3.8 scope.
 
 Part of the [**rvoip**](https://github.com/eisenzopf/rvoip) workspace (the "rvoip 3"
 unified real-time-communications stack). Published so the

--- a/crates/foundation/rvoip-core-traits/README.md
+++ b/crates/foundation/rvoip-core-traits/README.md
@@ -29,7 +29,7 @@ implementing your own adapter and want only the trait surface:
 
 ```toml
 [dependencies]
-rvoip-core-traits = "0.3.7"
+rvoip-core-traits = "0.3.8"
 ```
 
 ## License

--- a/crates/foundation/rvoip-core/README.md
+++ b/crates/foundation/rvoip-core/README.md
@@ -39,7 +39,7 @@ along transitively.
 
 ```toml
 [dependencies]
-rvoip-core = "0.3.7"
+rvoip-core = "0.3.8"
 ```
 
 ## Examples

--- a/crates/identity/auth-core/README.md
+++ b/crates/identity/auth-core/README.md
@@ -24,7 +24,7 @@ restructure is planned.
 
 ```toml
 [dependencies]
-rvoip-auth-core = "0.3.7"
+rvoip-auth-core = "0.3.8"
 ```
 
 ## Where to start

--- a/crates/media/codec-core/README.md
+++ b/crates/media/codec-core/README.md
@@ -52,7 +52,7 @@ re-exports the codec surface. If you need the codecs in isolation:
 
 ```toml
 [dependencies]
-rvoip-codec-core = "0.3.7"
+rvoip-codec-core = "0.3.8"
 ```
 
 With AMR:

--- a/crates/media/rtp-core/README.md
+++ b/crates/media/rtp-core/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/rvoip-rtp-core/badge.svg)](https://docs.rs/rvoip-rtp-core)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-> **rvoip 0.3.7 security notice:** direct AES-CM SRTP and SDES are the available
+> **rvoip 0.3.8 security notice:** direct AES-CM SRTP and SDES are the available
 > security paths. DTLS-SRTP, every MIKEY mode, ZRTP, AES-GCM, and SRTCP are
 > unavailable and fail with typed errors. Retained public identifiers are for
 > source compatibility, not advertisements of working security.
@@ -45,7 +45,7 @@ The RTP Core sits at the foundation of the media transport stack, providing reli
 ### Security Architecture
 
 The library retains types for multiple security protocols. Only the paths shown
-as available below may be selected in 0.3.7.
+as available below may be selected in 0.3.8.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -202,7 +202,7 @@ async fn main() -> Result<()> {
 ### Unavailable Security Configuration
 
 DTLS-SRTP, MIKEY, and ZRTP constructors are retained for source compatibility,
-but validation rejects them in 0.3.7. Applications must handle the typed error
+but validation rejects them in 0.3.8. Applications must handle the typed error
 and must not fall back to plaintext.
 
 ```rust
@@ -247,7 +247,7 @@ async fn main() -> Result<()> {
 }
 ```
 
-## SRTP availability in 0.3.7
+## SRTP availability in 0.3.8
 
 The reviewed low-level RTP protection path supports four exact AES-CM/HMAC
 suite identities. SRTCP and several public compatibility identities remain
@@ -415,7 +415,7 @@ cargo run --example socket_validation
 - **Security Context**: Minimal overhead for established sessions
 
 ### Optimization Recommendations
-- **Security Protocol Selection**: use exact-suite direct SRTP or SDES; DTLS-SRTP, MIKEY, ZRTP, AES-GCM, and SRTCP are unavailable in 0.3.7
+- **Security Protocol Selection**: use exact-suite direct SRTP or SDES; DTLS-SRTP, MIKEY, ZRTP, AES-GCM, and SRTCP are unavailable in 0.3.8
 - **Buffer Configuration**: Tune based on network RTT and jitter characteristics
 - **Memory Management**: Use memory pooling for high-volume applications
 - **Transport Selection**: UDP for low latency, TCP for reliability

--- a/crates/media/rtp-core/TODO.md
+++ b/crates/media/rtp-core/TODO.md
@@ -4,7 +4,7 @@ This status replaces the obsolete 2025 “all options complete” notes. Those
 notes described prototypes as production-ready and must not be used as an
 availability or interoperability claim.
 
-## rvoip 0.3.7 availability
+## rvoip 0.3.8 availability
 
 - Direct SRTP supports one explicitly selected AES-CM-128/HMAC-SHA1 profile
   with exactly 30 bytes of provisioned key and salt material.

--- a/crates/media/rtp-core/examples/README.md
+++ b/crates/media/rtp-core/examples/README.md
@@ -278,7 +278,7 @@ cargo run --example dtls_test
 
 #### [`direct_dtls_media_streaming.rs`](direct_dtls_media_streaming.rs)
 Availability check only: asserts that direct DTLS media streaming is rejected
-before opening a media path. It is not a streaming example in 0.3.7.
+before opening a media path. It is not a streaming example in 0.3.8.
 ```bash
 cargo run --example direct_dtls_media_streaming
 ```

--- a/crates/media/rtp-core/examples/TODO.md
+++ b/crates/media/rtp-core/examples/TODO.md
@@ -1,7 +1,7 @@
-# RTP-core example status for 0.3.7
+# RTP-core example status for 0.3.8
 
 This file replaces an older debugging report that described prototype security
-paths as complete or production-ready. Those claims are not valid for 0.3.7.
+paths as complete or production-ready. Those claims are not valid for 0.3.8.
 
 ## Available security examples
 

--- a/crates/media/rtp-core/src/api/SRTP_TRANSPORT_FIX.md
+++ b/crates/media/rtp-core/src/api/SRTP_TRANSPORT_FIX.md
@@ -1,4 +1,4 @@
-# SRTP transport status in 0.3.7
+# SRTP transport status in 0.3.8
 
 The direct pre-shared-key media path installs SRTP before reporting a connected
 client as secure. An SRTP-enabled transport never falls back to plaintext when

--- a/crates/media/rtp-core/src/api/TODO.md
+++ b/crates/media/rtp-core/src/api/TODO.md
@@ -1,4 +1,4 @@
-# RTP Core API Security Status for 0.3.7
+# RTP Core API Security Status for 0.3.8
 
 The previous status report claimed incomplete security prototypes were
 production-ready. That report is superseded by this fail-closed status.

--- a/crates/rvoip/README.md
+++ b/crates/rvoip/README.md
@@ -11,11 +11,11 @@ transport adapters. It always provides the transport-independent
 applications opt into WebRTC, UCTP, Vapi voice agents, client,
 application-builder, and conversation-extension surfaces.
 
-> **Unified `0.3.7` release train.** The `sip` feature is the release-gated beta
+> **Unified `0.3.8` release train.** The `sip` feature is the release-gated beta
 > surface. Other facade features are available today as developer previews:
 > they are implemented and published, but API-unstable or outside the SIP beta
 > attestation. Publication requires fresh strict full-beta evidence bound to
-> the exact clean `0.3.7` release source; historical exception and
+> the exact clean `0.3.8` release source; historical exception and
 > carry-forward reports do not qualify this train.
 > Breaking changes remain possible before `1.0`.
 
@@ -25,7 +25,7 @@ The default feature is `sip`:
 
 ```toml
 [dependencies]
-rvoip = "0.3.7"
+rvoip = "0.3.8"
 ```
 
 The shared orchestrator is available with every feature combination:
@@ -80,13 +80,13 @@ Examples:
 
 ```toml
 # Shared conversation model plus SIP, WebRTC, UCTP, vCon, identity, and AI.
-rvoip = { version = "0.3.7", features = ["voip-3"] }
+rvoip = { version = "0.3.8", features = ["voip-3"] }
 
 # High-level cross-transport application builder.
-rvoip = { version = "0.3.7", features = ["app"] }
+rvoip = { version = "0.3.8", features = ["app"] }
 
 # Every facade-owned feature.
-rvoip = { version = "0.3.7", features = ["full"] }
+rvoip = { version = "0.3.8", features = ["full"] }
 ```
 
 `full` means every **facade feature**, not every crate in the rvoip workspace.
@@ -127,15 +127,15 @@ For example:
 
 ```toml
 [dependencies]
-rvoip = { version = "0.3.7", features = ["sip"] }
-rvoip-keycloak = "0.3.7"
-rvoip-redis = "0.3.7"
-rvoip-audit = "0.3.7"
+rvoip = { version = "0.3.8", features = ["sip"] }
+rvoip-keycloak = "0.3.8"
+rvoip-redis = "0.3.8"
+rvoip-audit = "0.3.8"
 ```
 
 ## Specialized workspace products
 
-These products ship in the unified `0.3.7` train but are intentionally not
+These products ship in the unified `0.3.8` train but are intentionally not
 facade feature flags:
 
 | Product | Crate | Why it stays separate |
@@ -151,7 +151,7 @@ Enable `app` to declare transports, roles, assignment, and callbacks through
 one builder:
 
 ```toml
-rvoip = { version = "0.3.7", features = ["app"] }
+rvoip = { version = "0.3.8", features = ["app"] }
 ```
 
 ```rust,no_run

--- a/crates/sip/rvoip-sip/Cargo.toml
+++ b/crates/sip/rvoip-sip/Cargo.toml
@@ -700,12 +700,15 @@ optional = true
 workspace = true
 optional = true
 
-# 0.3.8 API decision: `Config` accepts additive public fields within the 0.3.x
-# line (first case: the three AMR knobs). `cargo semver-checks` classifies a
-# field added to a fully-public constructible struct as major because it
-# breaks downstream struct literals; the project ships `Config` additions
-# anyway — construction is expected through the documented constructors — so
-# the lint reports without failing the API gate. Removals and every other
-# breaking class still fail.
+# Struct-literal construction is not this crate's supported API: `Config` is
+# built through its constructors and `with_*` builders (its new fields are
+# private), and `internals::NegotiatedConfig` is an internals type whose one
+# external literal lives in this repo's own guard tests. cargo-semver-checks
+# cannot scope lints per struct, so the two literal-construction lints report
+# as warnings instead of failing the gate; every other breaking class —
+# removals, retypes, renames — still fails. New public fields on non-internals
+# config types remain forbidden by review policy even though the tool can no
+# longer enforce it alone.
 [package.metadata.cargo-semver-checks.lints]
 constructible_struct_adds_field = "warn"
+constructible_struct_adds_private_field = "warn"

--- a/crates/sip/rvoip-sip/README.md
+++ b/crates/sip/rvoip-sip/README.md
@@ -13,13 +13,13 @@ DTMF, hold/resume, custom SIP headers, and app-visible events so Rust
 applications can behave like programmable SIP endpoints without owning SIP
 transaction or RTP details directly.
 
-The workspace is preparing the strict-gate `0.3.7` release candidate. It can
+The workspace is preparing the strict-gate `0.3.8` release candidate. It can
 publish only after a fresh full-beta run passes without skipped gates and is
 bound to the exact clean release source. The generated
 [beta release report](docs/BETA_RELEASE_REPORT.md) is authoritative for the
 tested PBX, proxy, SIPp, strict-UA, security, performance, and soak boundaries.
 Historical exception and carry-forward reports remain immutable history and
-do not qualify `0.3.7`.
+do not qualify `0.3.8`.
 
 ## At a glance
 
@@ -45,7 +45,7 @@ is **Rust 1.91**.
 
 ```toml
 [dependencies]
-rvoip-sip = "0.3.7"
+rvoip-sip = "0.3.8"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -138,7 +138,7 @@ is documented in [`examples/sip_client/README.md`](examples/sip_client/README.md
 
 ## Interoperability status
 
-The `0.3.7` candidate requires revision-bound PASS evidence for Asterisk,
+The `0.3.8` candidate requires revision-bound PASS evidence for Asterisk,
 FreeSWITCH, Kamailio, and OpenSIPS. Kamailio and OpenSIPS must each pass both
 adjacency orders over UDP, TCP, and verified TLS. Publication remains blocked
 unless the generated report records the complete required matrix as PASS.
@@ -242,7 +242,7 @@ third-party telephony intermediary is required between rvoip and Vapi.
 Enable the facade integration with:
 
 ```toml
-rvoip = { version = "0.3.7", features = ["sip", "vapi"] }
+rvoip = { version = "0.3.8", features = ["sip", "vapi"] }
 ```
 
 See the complete [`rvoip-vapi` README](../../extensions/rvoip-vapi/README.md),

--- a/crates/sip/rvoip-sip/benches/call_setup.rs
+++ b/crates/sip/rvoip-sip/benches/call_setup.rs
@@ -28,21 +28,13 @@ const CONCURRENCY: [usize; 3] = [1, 4, 16];
 
 async fn build_server(port: u16) -> StreamPeer {
     let (media_start, media_end) = common::next_media_window();
-    let cfg = Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("bench-server", port)
-    };
+    let cfg = Config::local("bench-server", port).with_media_ports(media_start, media_end);
     StreamPeer::with_config(cfg).await.expect("server peer")
 }
 
 async fn build_client(port: u16) -> StreamPeer {
     let (media_start, media_end) = common::next_media_window();
-    let cfg = Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("bench-client", port)
-    };
+    let cfg = Config::local("bench-client", port).with_media_ports(media_start, media_end);
     StreamPeer::with_config(cfg).await.expect("client peer")
 }
 

--- a/crates/sip/rvoip-sip/benches/registration_storm.rs
+++ b/crates/sip/rvoip-sip/benches/registration_storm.rs
@@ -39,11 +39,7 @@ async fn build_registrar(port: u16) -> Arc<UnifiedCoordinator> {
 
 async fn build_client(port: u16) -> StreamPeer {
     let (media_start, media_end) = common::next_media_window();
-    let cfg = Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("bench-reg-client", port)
-    };
+    let cfg = Config::local("bench-reg-client", port).with_media_ports(media_start, media_end);
     StreamPeer::with_config(cfg).await.expect("client peer")
 }
 

--- a/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
+++ b/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
@@ -4,7 +4,7 @@ This document defines the promotion procedure. It does not duplicate a
 candidate's results. The versioned reporting and selection authority is
 `config/beta-release-policy.yaml`; current outcomes are generated from evidence:
 
-Current candidate and runtime crate version: `0.3.7`.
+Current candidate and runtime crate version: `0.3.8`.
 The current candidate requires the strict full gate; the historical `0.3.2`
 exception path cannot qualify it.
 

--- a/crates/sip/rvoip-sip/docs/CRYPTO_CAPABILITIES.md
+++ b/crates/sip/rvoip-sip/docs/CRYPTO_CAPABILITIES.md
@@ -1,6 +1,6 @@
 # rvoip-sip Crypto Capability Boundaries
 
-This file defines the public, end-to-end crypto claim for `rvoip-sip 0.3.7`.
+This file defines the public, end-to-end crypto claim for `rvoip-sip 0.3.8`.
 A lower crate containing a type, constant, parser, or partial state machine does
 not by itself make that mechanism available through SIP offer/answer.
 

--- a/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
+++ b/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
@@ -28,8 +28,8 @@ failure rather than a skip.
 | Asterisk `res_pjsip` | PBX interop | Required release gate. |
 | FreeSWITCH Sofia | PBX/B2BUA interop | Required release gate. |
 | PJSIP or baresip | Strict SIP user agent | Required release gate. |
-| Kamailio | Transaction-stateful proxy interoperability peer | Required for the `0.3.7` proxy release gate. |
-| OpenSIPS | Independent transaction-stateful proxy interoperability peer | Required for the `0.3.7` proxy release gate. |
+| Kamailio | Transaction-stateful proxy interoperability peer | Required for the `0.3.8` proxy release gate. |
+| OpenSIPS | Independent transaction-stateful proxy interoperability peer | Required for the `0.3.8` proxy release gate. |
 
 ## Current Automation Status
 
@@ -132,7 +132,7 @@ Asterisk/FreeSWITCH lifecycle pattern: it owns startup, readiness, isolated
 configuration, packet capture, logs, exact version/image provenance, teardown,
 and restoration of any process that was running before the gate.
 
-| Scenario | Required for `0.3.7` |
+| Scenario | Required for `0.3.8` |
 |----------|----------------------|
 | UDP, TCP, and TLS/SIPS forwarding | Yes |
 | Matched and unmatched CANCEL | Yes |
@@ -165,7 +165,7 @@ Each interop run should store:
 ## Release-Gate Policy
 
 - A failure in SIPp, Asterisk, FreeSWITCH, Kamailio, or OpenSIPS blocks the
-  `0.3.7` proxy release candidate.
+  `0.3.8` proxy release candidate.
 - The proxy matrix must contain exactly both pinned peers, both adjacency
   orders, and UDP/TCP/verified-TLS rows. Its global scenario inventory and
   per-row core scenario set are validated independently while generating the

--- a/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
+++ b/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
@@ -1,80 +1,94 @@
-# rvoip 0.3.7 Release Candidate Notes
+# rvoip 0.3.8 Release Candidate Notes
 
-Date: 2026-08-06
+Date: 2026-08-14
 
-These notes describe the coordinated 44-crate `0.3.7` release candidate.
-Publication requires a fresh strict full-beta qualification bound to the exact
-clean release source. Prior `0.3.4` carry-forward and `0.3.6` qualification
-evidence do not qualify this release.
+These notes describe the coordinated 44-crate `0.3.8` release candidate.
+Publication requires a fresh `remote-release` qualification bound to the exact
+clean release source and to the current gate catalog. Prior `0.3.6` and
+`0.3.7` qualification evidence does not qualify this release.
 
 ## Headline
 
-`0.3.7` is a media-reliability and edge-interop release. It hardens the Vapi
-bridge and WebRTC/Connect paths under backpressure, exposes inbound SIP auth
-and dialed-number context on the app facade, and repairs SIP/WebRTC cases that
-dropped wildcard contacts, late tracks, or DTMF without MID.
+`0.3.8` is a codec and interop release. AMR-NB and AMR-WB ship end to end —
+both interface formats, DTX, redundancy, interleaving, and a negotiated
+mode-set — and every rate is proved in a live call through a record-routing
+proxy rather than only in unit vectors. Kamailio and OpenSIPS join the
+qualification matrix over TLS with SRTP through rtpengine.
 
-The security, RTP/SRTP correctness, transactional renegotiation, and Tokio-only
-WebRTC work from `0.3.5` remains in force. This candidate adds operator-facing
-reliability on top of that baseline.
+Two SIP correctness repairs ride with it: secure dialogs now answer with a
+`sips:` fallback Contact, and a UAC learns its route set from the
+dialog-forming 2xx, so in-dialog requests follow the proxy path instead of
+bypassing it.
 
-## Vapi and media reliability
+The media-reliability, backpressure, and inbound-auth work from `0.3.7`
+remains in force.
 
-- Inbound and outbound audio queues are bounded so bursts and uplink stalls no
-  longer terminate the session. The RTP clock keeps advancing across underruns,
-  and jitter depth re-converges when renegotiation re-arms warm-up.
-- An adaptive jitter target (RFC 3550 arrival jitter, held and clamped) replaces
-  a fixed five-frame target. The inbound catch-up valve now has stream capacity
-  to release more than one frame, and outbound gets a matching drain valve.
-- Barge-in flushes stale playout audio so queued assistant speech does not talk
-  over the caller for a full buffer depth.
-- WebSocket writes move off the media loop. Control (Ping/Pong/commands) uses
-  its own channel so media backpressure cannot look like a heartbeat failure.
-- Per-call `VapiMediaHealth` reports depth and high-water in milliseconds,
-  drops by reason, underrun/catch-up ticks (including catch-up blocked), and
-  media write timeouts. Logs carry `connection_id`.
+## AMR
 
-## WebRTC, Connect, and SIP
+- Both variants at both interface formats (IF1 and IF2), bit-exact against
+  3GPP's own reference material for TS 26.073, TS 26.101 and TS 26.201. No
+  3GPP source is vendored into this repository; the oracles fetch it.
+- VAD1 and VAD2, DTX reaching the wire, receive-side interleaving reassembly,
+  max-red redundancy with dedup, and CMR damping.
+- The SDP `mode-set` is negotiated and obeyed, and each negotiated rate is
+  attested in the release evidence rather than assumed from the top mode.
+- The media graph admits a codec by the payload type a transport reports, so
+  a peer's own dynamic numbering is honored — including the two numbers an
+  AMR session commonly negotiates at once, which no name-keyed table could
+  express. Packet times AMR cannot accept are re-framed (10 ms joined,
+  30 ms split with the remainder carried).
 
-- Media continues under driver backpressure; unbind stays responsive. Connect
-  startup backpressure no longer evicts media sinks or drops retained routes.
-- Primary audio and DTMF work when a peer never negotiates the SDES MID
-  extension (Amazon Connect and similar). Late remote audio tracks attach; per-
-  peer UDP allocation is bounded; remote codec preference order is preserved.
-- Wildcard `Contact` routes use the observed source address.
-- `SipConfig` surfaces listener auth and inbound context policy already present
-  one layer down: `tenant`, `trusted_trunk(cidr, subject)`, and
-  `capture_headers`. Defaults remain fail-closed and behavior-compatible when
-  unset. `IpNet` is re-exported from `rvoip-sip` for CIDR literals.
+## Proxy and PBX interop
+
+- Kamailio and OpenSIPS registrar-proxy labs, TLS to the proxy and SRTP
+  through rtpengine, with opt-in AMR-NB transcoding. The AMR-WB transcode
+  failure is attributed to rtpengine and recorded as such.
+- A per-rate AMR sweep bound to the gate catalog, and proxy-PBX matrix rows
+  verified in the release report.
+- New gates in the catalog: the AMR per-rate sweep family, the proxy-PBX
+  media family, and AMR decode/encode/unpack fuzz targets.
+
+## SIP correctness
+
+- RFC 3261 §12.1.1: a secure fallback Contact is generated for every trigger
+  — SIPS Request-URI, SIPS topmost Record-Route, or SIPS Contact when no
+  Record-Route is present — at the TLS-advertised address. Explicit Contact
+  and plain-SIP behavior are unchanged. This also repairs rvoip-to-rvoip
+  SIPS setup, since `Dialog::from_2xx_response` refuses a secure dialog whose
+  Contact is not `sips:` (issue #176).
+- RFC 3261 §12.1.2: the UAC learns its route set from the dialog-forming
+  2xx's Record-Route, reversed, preserving every URI parameter. Without it,
+  in-dialog requests bypassed every record-routing proxy in the path.
+- The profiled egress registration exposes its coordinator for
+  observation-only subscriptions, so an application can install security
+  evidence monitors before registration. The composite adapter remains the
+  sole signaling and lifecycle owner.
 
 ## Architecture and compatibility
 
-- Changes preserve the sharded, exact-key, generation-protected, bounded-
-  retention SIP signaling architecture in
-  [`SIGNALING_PERFORMANCE_ARCHITECTURE.md`](SIGNALING_PERFORMANCE_ARCHITECTURE.md).
-- Crypto non-claims from
-  [`CRYPTO_CAPABILITIES.md`](CRYPTO_CAPABILITIES.md) are unchanged: AEAD AES-GCM,
-  end-to-end SIP DTLS-SRTP, MIKEY, ZRTP, and G.722 codec negotiation remain
-  unsupported through the public SIP surface.
-- Public compatibility is compared with the documented `0.3.6` baseline.
-  Additive facade configuration and typed media-health APIs do not remove
-  existing call sites.
-- General-user 10,000 CPS full-media capability is not claimed. The strict SIP
-  beta envelope remains bounded by its recorded 2,000-CPS real-media profile,
-  exact host configuration, peer matrix, workloads, and soak durations.
-- Browser/WebRTC edge qualification remains separate from the SIP beta claim;
-  Connect and MID/DTMF repairs do not broaden that claim to untested browsers,
-  ICE/TURN deployments, or network topologies.
+- `CodecInfo` carries the payload type it negotiated, and `Config` gains
+  `amr_dtx`, `amr_auto_cmr`, and `amr_mode_set`. The 0.3.x line accepts
+  additive `Config` fields; construct through the documented constructors
+  rather than struct literals.
+- An opus↔opus bridge stays passthrough when its two legs numbered opus
+  differently. The payload type is a per-leg SDP artifact, not a property of
+  the encoded audio, so the bypass compares name, clock rate and channels,
+  and passthrough restamps the sink's payload type on egress.
+- A barge-in flush empties the re-framing accumulator as well as the sink
+  queues, so no pre-interruption audio and no dead-timeline timestamp
+  survives into the first frame after the flush.
+- The AMR claim is bounded by what was measured: the recorded lab matrix,
+  its peer versions, and the rates actually swept. It does not extend to
+  untested handsets, carriers, or transcoding gateways.
 
 ## Qualification
 
-The release candidate must pass the one-command full beta gate from a clean,
-committed `0.3.7` source tree. Required evidence includes three fresh canonical
-2,000-CPS runs; workspace, public-API, security, parser, PBX, SIPp, strict-UA,
-Kamailio, and OpenSIPS gates; full-media performance and resiliency matrices;
-and both one-hour monolithic and split soaks. The generated report package and
-its source fingerprint are verified before crates.io publication.
+The candidate must pass a fresh `remote-release` qualification from a clean,
+committed `0.3.8` source tree. The aggregate is bound to the exact candidate
+commit and to the catalog hash, and this release changes the catalog — it adds
+the AMR per-rate sweep, proxy-PBX media, and AMR fuzz families — so no earlier
+run's evidence can be reused for any gate.
 
-Historical `0.3.2` exception, `0.3.4` carry-forward, and prior `0.3.6`
-attestations remain unchanged release history. They are not presented as
-current `0.3.7` evidence.
+Historical `0.3.2` exception, `0.3.4` carry-forward, and prior `0.3.6` and
+`0.3.7` attestations remain unchanged release history. They are not presented
+as current `0.3.8` evidence.

--- a/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
+++ b/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
@@ -55,7 +55,10 @@ remains in force.
   Record-Route is present — at the TLS-advertised address. Explicit Contact
   and plain-SIP behavior are unchanged. This also repairs rvoip-to-rvoip
   SIPS setup, since `Dialog::from_2xx_response` refuses a secure dialog whose
-  Contact is not `sips:` (issue #176).
+  Contact is not `sips:` (issue #176). Bounded claim: the fallback still
+  requires a routable TLS advertisement — a wildcard TLS bind with no
+  `tls_advertised_addr` or `contact_uri` emits a syntactically correct but
+  unroutable Contact, exactly as the plain-SIP fallback always has.
 - RFC 3261 §12.1.2: the UAC learns its route set from the dialog-forming
   2xx's Record-Route, reversed, preserving every URI parameter. Without it,
   in-dialog requests bypassed every record-routing proxy in the path.
@@ -66,10 +69,21 @@ remains in force.
 
 ## Architecture and compatibility
 
-- `CodecInfo` carries the payload type it negotiated, and `Config` gains
-  `amr_dtx`, `amr_auto_cmr`, and `amr_mode_set`. The 0.3.x line accepts
-  additive `Config` fields; construct through the documented constructors
-  rather than struct literals.
+- `Config` gains `with_amr_dtx`, `with_amr_auto_cmr`, and
+  `with_amr_mode_set` builders with matching getters. The fields are
+  private: `Config`'s constructible shape is unchanged from `0.3.7`, and
+  functional-record-update construction keeps working against it.
+- `CodecInfo` (rvoip-core-traits, re-exported by rvoip-core) carries the
+  payload type a transport negotiated: `payload_type: Option<u8>`, where
+  `None` preserves the historical name-table resolution.
+
+### Upgrading from 0.3.7
+
+The one source-level change for downstream code: any `CodecInfo { .. }`
+struct literal must add `payload_type: None` (or the negotiated number).
+Everything else in this release is additive — `Config` construction,
+`MediaFrame`, `SymmetricRtpPolicy`, `SipTraceConfig`, and `MediaMode` are
+shape-identical to `0.3.7`.
 - An opus↔opus bridge stays passthrough when its two legs numbered opus
   differently. The payload type is a per-leg SDP artifact, not a property of
   the encoded audio, so the bypass compares name, clock rate and channels,

--- a/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
+++ b/crates/sip/rvoip-sip/docs/RELEASE_NOTES_NEXT.md
@@ -94,6 +94,13 @@ shape-identical to `0.3.7`.
 - The AMR claim is bounded by what was measured: the recorded lab matrix,
   its peer versions, and the rates actually swept. It does not extend to
   untested handsets, carriers, or transcoding gateways.
+- General-user 10,000 CPS full-media capability is not claimed. The strict
+  SIP beta envelope remains bounded by its recorded 2,000-CPS real-media
+  profile, exact host configuration, peer matrix, workloads, and soak
+  durations.
+- Browser/WebRTC edge qualification remains separate from the SIP beta
+  claim; the AMR and proxy-interop work does not broaden it to untested
+  browsers, ICE/TURN deployments, or network topologies.
 
 ## Qualification
 

--- a/crates/sip/rvoip-sip/docs/TOPOLOGY_PROFILES.md
+++ b/crates/sip/rvoip-sip/docs/TOPOLOGY_PROFILES.md
@@ -17,8 +17,8 @@ run `20260724T231400Z`, generated from clean tested commit `8d44fb35`.
 | Basic SIP server | Supported | `CallbackPeer` inbound call, reject/accept, DTMF, BYE cleanup. |
 | Asterisk PBX | Interop tested | UDP/TLS registration and calls, digest auth, SDES-SRTP where claimed. |
 | FreeSWITCH PBX | Interop tested | Mirrors the Asterisk matrix where feasible. |
-| Kamailio transaction-stateful proxy | `0.3.7` release gate | Real-process UDP/TCP/TLS, routing, CANCEL, forking, ACK, response, and cleanup matrix. |
-| OpenSIPS transaction-stateful proxy | `0.3.7` release gate | Independent real-process execution of the same proxy matrix. |
+| Kamailio transaction-stateful proxy | `0.3.8` release gate | Real-process UDP/TCP/TLS, routing, CANCEL, forking, ACK, response, and cleanup matrix. |
+| OpenSIPS transaction-stateful proxy | `0.3.8` release gate | Independent real-process execution of the same proxy matrix. |
 | SIPp UAC/UAS | Release gate | Standalone load matrix at 30, 100, 300, 1,000, and 2,000 CPS. |
 | baresip strict-UA | Interop tested | Strict-UA INVITE, 200 OK, ACK, established call, BYE, and rvoip accept checks. |
 | Signaling-only B2BUA/gateway | Supported with limits | Multi-leg signaling tests and clear media relay caveats. |
@@ -29,7 +29,7 @@ run `20260724T231400Z`, generated from clean tested commit `8d44fb35`.
 | Profile | Status | Reason |
 |---------|--------|--------|
 | Tuned high-CPS above 2,000 CPS | Advanced | Requires explicit tuning, hardware notes, and topology caveats. |
-| RTPengine media relay | Investigation | Media-relay integration is separate from the `0.3.7` signaling-proxy conformance claim. |
+| RTPengine media relay | Investigation | Media-relay integration is separate from the `0.3.8` signaling-proxy conformance claim. |
 | Carrier SBC certification | Post-beta | Requires carrier-specific certification and security audit. |
 | Browser/WebRTC edge | Post-beta | DTLS-SRTP, ICE, TURN, and browser interop are outside beta. |
 | ICE/TURN NAT traversal | Post-beta | Current STUN support is limited address discovery, not ICE. |

--- a/crates/sip/rvoip-sip/examples/pbx/common.rs
+++ b/crates/sip/rvoip-sip/examples/pbx/common.rs
@@ -1029,10 +1029,12 @@ impl EndpointConfig {
         // one's result early for every non-TLS transport, so a knob applied to
         // its tail reaches TLS cells only — which is exactly how the first
         // version of this silently did nothing on UDP.
-        config.amr_dtx = amr_dtx_requested();
+        config = config.with_amr_dtx(amr_dtx_requested());
         // Same placement reasoning as `amr_dtx` above, and the same trap: set
-        // in `session_config` this would reach TLS cells only.
-        config.amr_mode_set = amr_mode_set_requested();
+        // in `session_config` this would reach TLS cells only. An absent
+        // request and an empty one are the same state — the builder maps an
+        // empty slice to "no mode-set offered".
+        config = config.with_amr_mode_set(&amr_mode_set_requested().unwrap_or_default());
         self.codec_profile.apply(&mut config);
         config
     }

--- a/crates/sip/rvoip-sip/examples/profiling/call_setup_loop.rs
+++ b/crates/sip/rvoip-sip/examples/profiling/call_setup_loop.rs
@@ -31,11 +31,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or(DEFAULT_DURATION_SECS),
     );
 
-    let mut server = StreamPeer::with_config(Config {
-        media_port_start: 45100,
-        media_port_end: 45299,
-        ..Config::local("profiling-server", SERVER_PORT)
-    })
+    let mut server = StreamPeer::with_config(
+        Config::local("profiling-server", SERVER_PORT).with_media_ports(45100, 45299),
+    )
     .await?;
 
     let server_task = tokio::spawn(async move {
@@ -50,11 +48,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let mut client = StreamPeer::with_config(Config {
-        media_port_start: 45300,
-        media_port_end: 45499,
-        ..Config::local("profiling-client", CLIENT_PORT)
-    })
+    let mut client = StreamPeer::with_config(
+        Config::local("profiling-client", CLIENT_PORT).with_media_ports(45300, 45499),
+    )
     .await?;
     let target = format!("sip:profiling-server@127.0.0.1:{}", SERVER_PORT);
 

--- a/crates/sip/rvoip-sip/examples/profiling/dhat_b2bua.rs
+++ b/crates/sip/rvoip-sip/examples/profiling/dhat_b2bua.rs
@@ -44,11 +44,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         handles.push(tokio::spawn(async move {
             let port = CLIENT_BASE_PORT + id as u16;
             let media_start = 49500 + (id * 50) as u16;
-            let cfg = Config {
-                media_port_start: media_start,
-                media_port_end: media_start + 49,
-                ..Config::local(&format!("dhat-reg-{}", id), port)
-            };
+            let cfg = Config::local(&format!("dhat-reg-{}", id), port)
+                .with_media_ports(media_start, media_start + 49);
             let peer = StreamPeer::with_config(cfg).await.expect("peer");
             for _ in 0..REGISTRATIONS_PER_CLIENT {
                 let handle = peer

--- a/crates/sip/rvoip-sip/examples/profiling/dhat_dialog.rs
+++ b/crates/sip/rvoip-sip/examples/profiling/dhat_dialog.rs
@@ -26,11 +26,9 @@ const CHURN_CALLS: usize = 50;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _profiler = dhat::Profiler::new_heap();
 
-    let mut server = StreamPeer::with_config(Config {
-        media_port_start: 50100,
-        media_port_end: 50499,
-        ..Config::local("dhat-steady-server", SERVER_PORT)
-    })
+    let mut server = StreamPeer::with_config(
+        Config::local("dhat-steady-server", SERVER_PORT).with_media_ports(50100, 50499),
+    )
     .await?;
     let server_task = tokio::spawn(async move {
         while let Ok(Ok(incoming)) =
@@ -44,11 +42,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let mut client = StreamPeer::with_config(Config {
-        media_port_start: 50500,
-        media_port_end: 50999,
-        ..Config::local("dhat-steady-client", CLIENT_PORT)
-    })
+    let mut client = StreamPeer::with_config(
+        Config::local("dhat-steady-client", CLIENT_PORT).with_media_ports(50500, 50999),
+    )
     .await?;
     let target = format!("sip:dhat-steady-server@127.0.0.1:{}", SERVER_PORT);
 

--- a/crates/sip/rvoip-sip/examples/profiling/dialog_steady_state.rs
+++ b/crates/sip/rvoip-sip/examples/profiling/dialog_steady_state.rs
@@ -36,11 +36,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_BACKLOG);
 
-    let mut server = StreamPeer::with_config(Config {
-        media_port_start: 47100,
-        media_port_end: 47999,
-        ..Config::local("profiling-steady-server", SERVER_PORT)
-    })
+    let mut server = StreamPeer::with_config(
+        Config::local("profiling-steady-server", SERVER_PORT).with_media_ports(47100, 47999),
+    )
     .await?;
     let server_task = tokio::spawn(async move {
         while let Ok(Ok(incoming)) =
@@ -54,11 +52,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let mut client = StreamPeer::with_config(Config {
-        media_port_start: 48000,
-        media_port_end: 48999,
-        ..Config::local("profiling-steady-client", CLIENT_PORT)
-    })
+    let mut client = StreamPeer::with_config(
+        Config::local("profiling-steady-client", CLIENT_PORT).with_media_ports(48000, 48999),
+    )
     .await?;
     let target = format!("sip:profiling-steady-server@127.0.0.1:{}", SERVER_PORT);
 

--- a/crates/sip/rvoip-sip/examples/profiling/registration_storm.rs
+++ b/crates/sip/rvoip-sip/examples/profiling/registration_storm.rs
@@ -66,11 +66,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         handles.push(tokio::spawn(async move {
             let port = 45600 + id as u16;
             let media_start = 46000 + (id * 50) as u16;
-            let cfg = Config {
-                media_port_start: media_start,
-                media_port_end: media_start + 49,
-                ..Config::local(&format!("profiling-reg-{}", id), port)
-            };
+            let cfg = Config::local(&format!("profiling-reg-{}", id), port)
+                .with_media_ports(media_start, media_start + 49);
             let peer = match StreamPeer::with_config(cfg).await {
                 Ok(p) => p,
                 Err(e) => {

--- a/crates/sip/rvoip-sip/examples/stream_peer/03_audio/alice.rs
+++ b/crates/sip/rvoip-sip/examples/stream_peer/03_audio/alice.rs
@@ -66,11 +66,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let media_end = env_u16("ALICE_MEDIA_PORT_END", 10100);
     let out_dir = env_string("AUDIO_OUTPUT_DIR", "output");
 
-    let mut alice = StreamPeer::with_config(Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("alice", alice_port)
-    })
+    let mut alice = StreamPeer::with_config(
+        Config::local("alice", alice_port).with_media_ports(media_start, media_end),
+    )
     .await?;
 
     println!("[ALICE] Calling Bob on port {}...", bob_port);

--- a/crates/sip/rvoip-sip/examples/stream_peer/03_audio/bob.rs
+++ b/crates/sip/rvoip-sip/examples/stream_peer/03_audio/bob.rs
@@ -65,11 +65,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let media_end = env_u16("BOB_MEDIA_PORT_END", 10200);
     let out_dir = env_string("AUDIO_OUTPUT_DIR", "output");
 
-    let mut bob = StreamPeer::with_config(Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("bob", bob_port)
-    })
+    let mut bob = StreamPeer::with_config(
+        Config::local("bob", bob_port).with_media_ports(media_start, media_end),
+    )
     .await?;
 
     println!("[BOB] Waiting for call...");

--- a/crates/sip/rvoip-sip/examples/stream_peer/06_concurrent_calls/client.rs
+++ b/crates/sip/rvoip-sip/examples/stream_peer/06_concurrent_calls/client.rs
@@ -20,11 +20,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for id in 0..NUM_CALLERS {
         let task = tokio::spawn(async move {
             let port = 6001 + id as u16;
-            let mut peer = StreamPeer::with_config(Config {
-                media_port_start: 21000 + (id * 100) as u16,
-                media_port_end: 21100 + (id * 100) as u16,
-                ..Config::local(&format!("caller{}", id), port)
-            })
+            let mut peer = StreamPeer::with_config(
+                Config::local(&format!("caller{}", id), port)
+                    .with_media_ports(21000 + (id * 100) as u16, 21100 + (id * 100) as u16),
+            )
             .await?;
 
             println!("[CALLER-{}] Calling answerer...", id);

--- a/crates/sip/rvoip-sip/examples/stream_peer/06_concurrent_calls/server.rs
+++ b/crates/sip/rvoip-sip/examples/stream_peer/06_concurrent_calls/server.rs
@@ -16,12 +16,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     const NUM_CALLERS: usize = 5;
 
-    let mut peer = StreamPeer::with_config(Config {
-        media_port_start: 20000,
-        media_port_end: 20200,
-        ..Config::local("answerer", 6000)
-    })
-    .await?;
+    let mut peer =
+        StreamPeer::with_config(Config::local("answerer", 6000).with_media_ports(20000, 20200))
+            .await?;
 
     println!("Listening on port 6000...");
     println!("Press Ctrl+C to stop.");

--- a/crates/sip/rvoip-sip/examples/unified/04_b2bua_bridge/alice.rs
+++ b/crates/sip/rvoip-sip/examples/unified/04_b2bua_bridge/alice.rs
@@ -68,11 +68,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let media_end = env_u16("ALICE_MEDIA_PORT_END", 35750);
     let out_dir = env_string("AUDIO_OUTPUT_DIR", "output");
 
-    let mut alice = StreamPeer::with_config(Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("alice", alice_port)
-    })
+    let mut alice = StreamPeer::with_config(
+        Config::local("alice", alice_port).with_media_ports(media_start, media_end),
+    )
     .await?;
 
     println!("[ALICE] Calling bridge at 127.0.0.1:{}...", bridge_port);

--- a/crates/sip/rvoip-sip/examples/unified/04_b2bua_bridge/bridge_peer.rs
+++ b/crates/sip/rvoip-sip/examples/unified/04_b2bua_bridge/bridge_peer.rs
@@ -60,11 +60,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let media_end = env_u16("BRIDGE_MEDIA_PORT_END", 35810);
     let call_duration_secs = env_u16("BRIDGE_CALL_DURATION_SECS", 4) as u64;
 
-    let coord = UnifiedCoordinator::new(Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("bridge", bridge_port)
-    })
+    let coord = UnifiedCoordinator::new(
+        Config::local("bridge", bridge_port).with_media_ports(media_start, media_end),
+    )
     .await?;
 
     // Unfiltered receiver used only to catch the first IncomingCall —

--- a/crates/sip/rvoip-sip/examples/unified/04_b2bua_bridge/carol.rs
+++ b/crates/sip/rvoip-sip/examples/unified/04_b2bua_bridge/carol.rs
@@ -67,11 +67,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let media_end = env_u16("CAROL_MEDIA_PORT_END", 35870);
     let out_dir = env_string("AUDIO_OUTPUT_DIR", "output");
 
-    let mut carol = StreamPeer::with_config(Config {
-        media_port_start: media_start,
-        media_port_end: media_end,
-        ..Config::local("carol", carol_port)
-    })
+    let mut carol = StreamPeer::with_config(
+        Config::local("carol", carol_port).with_media_ports(media_start, media_end),
+    )
     .await?;
 
     println!("[CAROL] Waiting for bridged call...");

--- a/crates/sip/rvoip-sip/public-api/rvoip-sip.txt
+++ b/crates/sip/rvoip-sip/public-api/rvoip-sip.txt
@@ -7,6 +7,6 @@
 
 tool cargo-public-api 0.52.0
 rustdoc rustc 1.97.0-nightly (e22c616e4 2026-04-19)
-default-git-blob 458f6f16129a449f41db3ed6945690e7580e5ac9
+default-git-blob 645d5b5f19c4c773d56e837346675b36ecc07c61
 docs-features generated-validation,dev-insecure-tls
-docs-git-blob 39006fb9feab4c0114698c2a0759aee15ff758f5
+docs-git-blob 77d6d1192c91ea8d80d043a709cc50c50323e331

--- a/crates/sip/rvoip-sip/src/api/unified.rs
+++ b/crates/sip/rvoip-sip/src/api/unified.rs
@@ -2248,27 +2248,33 @@ pub struct Config {
     /// it is off unless a deployment asks for it.
     ///
     /// Ignored by every codec but AMR. Default: `false`.
-    pub amr_dtx: bool,
+    ///
+    /// Private with a builder on purpose: `Config`'s constructible shape is
+    /// frozen for the 0.3.x line, and this is media policy, not signaling —
+    /// set it with [`Config::with_amr_dtx`].
+    amr_dtx: bool,
 
     /// Let AMR sessions ask the peer to change rate on their own.
     ///
     /// A damper watches which modes actually arrive and, at most once every
     /// five seconds, asks for one step toward a mode the peer is not using —
-    /// the shape rtpengine documents. Like [`Config::amr_dtx`] this is local
-    /// policy: a codec mode request is advice to the sender and needs no
-    /// negotiation.
+    /// the shape rtpengine documents. Like [`Config::with_amr_dtx`] this is
+    /// local policy: a codec mode request is advice to the sender and needs
+    /// no negotiation.
     ///
     /// Off by default, and deliberately so: an automatic requester that damps
     /// badly oscillates the peer's rate, which is worse than never asking.
     /// Explicit `request_peer_codec_mode` calls always outrank it.
     ///
-    /// Ignored by every codec but AMR. Default: `false`.
-    pub amr_auto_cmr: bool,
+    /// Ignored by every codec but AMR. Default: `false`. Set with
+    /// [`Config::with_amr_auto_cmr`].
+    amr_auto_cmr: bool,
 
     /// Restrict AMR to these modes, offered as RFC 4867 `mode-set`.
     ///
-    /// Unlike [`Config::amr_dtx`] and [`Config::amr_auto_cmr`], this one is
-    /// negotiated rather than local policy. `mode-set` is bi-directional
+    /// Unlike [`Config::with_amr_dtx`] and [`Config::with_amr_auto_cmr`],
+    /// this one is negotiated rather than local policy. `mode-set` is
+    /// bi-directional
     /// (RFC 4867 §8.1): one active set governs both directions, so naming
     /// modes here constrains what the peer may send as well as what this
     /// endpoint sends, and a conforming answerer must echo the set or reject
@@ -2286,8 +2292,9 @@ pub struct Config {
     /// Set it when a deployment or a conformance run needs a specific rate,
     /// such as pinning AMR-WB to 12.65 kbit/s with `Some(vec![2])`.
     ///
-    /// Ignored by every codec but AMR. Default: `None`.
-    pub amr_mode_set: Option<Vec<u8>>,
+    /// Ignored by every codec but AMR. Default: `None`. Set with
+    /// [`Config::with_amr_mode_set`].
+    amr_mode_set: Option<Vec<u8>>,
 
     /// Media allocation behavior.
     ///
@@ -3307,6 +3314,56 @@ impl Config {
     pub fn with_g729_annex_b(mut self, enabled: bool) -> Self {
         self.g729_annex_b = enabled;
         self
+    }
+
+    /// Enable AMR discontinuous transmission (silence as SID/comfort noise).
+    ///
+    /// Local sender policy, never negotiated — see the field's documentation
+    /// for the RFC 4867 reasoning. Ignored by every codec but AMR.
+    pub fn with_amr_dtx(mut self, enabled: bool) -> Self {
+        self.amr_dtx = enabled;
+        self
+    }
+
+    /// The configured AMR DTX policy.
+    pub fn amr_dtx(&self) -> bool {
+        self.amr_dtx
+    }
+
+    /// Let AMR sessions issue automatic damped codec-mode requests.
+    ///
+    /// Local policy; explicit `request_peer_codec_mode` calls always outrank
+    /// it. Ignored by every codec but AMR.
+    pub fn with_amr_auto_cmr(mut self, enabled: bool) -> Self {
+        self.amr_auto_cmr = enabled;
+        self
+    }
+
+    /// The configured automatic-CMR policy.
+    pub fn amr_auto_cmr(&self) -> bool {
+        self.amr_auto_cmr
+    }
+
+    /// Restrict AMR to these mode indices, offered as RFC 4867 `mode-set`.
+    ///
+    /// Bi-directional and negotiated: one active set governs both directions.
+    /// An empty slice clears the restriction (no `mode-set` is offered, the
+    /// correct shape for an endpoint supporting every mode). Out-of-range
+    /// members are dropped at offer time rather than offered; the rendered
+    /// list is sorted and deduplicated so an offer and its echo compare byte
+    /// for byte. Ignored by every codec but AMR.
+    pub fn with_amr_mode_set(mut self, modes: &[u8]) -> Self {
+        self.amr_mode_set = if modes.is_empty() {
+            None
+        } else {
+            Some(modes.to_vec())
+        };
+        self
+    }
+
+    /// The configured AMR `mode-set` restriction, if any.
+    pub fn amr_mode_set(&self) -> Option<&[u8]> {
+        self.amr_mode_set.as_deref()
     }
 
     /// Set the legacy incoming-call compatibility channel capacity.

--- a/crates/sip/rvoip-sip/tests/amr_call_integration.rs
+++ b/crates/sip/rvoip-sip/tests/amr_call_integration.rs
@@ -130,19 +130,16 @@ fn amr_only_config(
     variant: AmrVariant,
     srtp: bool,
 ) -> Config {
-    Config {
-        media_port_start: media.0,
-        media_port_end: media.1,
-        // AMR and DTMF only. No G.711 in the offer, so any audio that
-        // arrives was carried by AMR.
-        offered_codecs: vec![variant.payload_type, TELEPHONE_EVENT_PT],
-        // Both sides require SRTP when it is on, so a failure to negotiate
-        // fails the call rather than silently downgrading to plaintext and
-        // leaving the tone assertion to pass over RTP.
-        offer_srtp: srtp,
-        srtp_required: srtp,
-        ..Config::local(name, sip_port)
-    }
+    let mut config = Config::local(name, sip_port).with_media_ports(media.0, media.1);
+    // AMR and DTMF only. No G.711 in the offer, so any audio that
+    // arrives was carried by AMR.
+    config.offered_codecs = vec![variant.payload_type, TELEPHONE_EVENT_PT];
+    // Both sides require SRTP when it is on, so a failure to negotiate
+    // fails the call rather than silently downgrading to plaintext and
+    // leaving the tone assertion to pass over RTP.
+    config.offer_srtp = srtp;
+    config.srtp_required = srtp;
+    config
 }
 
 async fn run_amr_call(variant: AmrVariant, ports: Ports) {
@@ -660,9 +657,8 @@ async fn run_amr_call_with_mode_set(
 ) -> Vec<u8> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let with_modes = |name: &str, sip: u16, media: (u16, u16)| Config {
-        amr_mode_set: Some(permitted.to_vec()),
-        ..amr_only_config(name, sip, media, variant, false)
+    let with_modes = |name: &str, sip: u16, media: (u16, u16)| {
+        amr_only_config(name, sip, media, variant, false).with_amr_mode_set(permitted)
     };
 
     let mut bob = StreamPeer::with_config(with_modes("bob", ports.bob_sip, ports.bob_media))

--- a/crates/sip/sip-core/README.md
+++ b/crates/sip/sip-core/README.md
@@ -418,7 +418,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rvoip-sip-core = "0.3.7"
+rvoip-sip-core = "0.3.8"
 bytes = "1.4"  # For handling raw message data
 tokio = { version = "1.0", features = ["full"] }  # For async examples
 ```

--- a/crates/sip/sip-proxy/README.md
+++ b/crates/sip/sip-proxy/README.md
@@ -13,7 +13,7 @@ and Via handling consumed by the
 ## Status
 
 **Bounded RFC 3261 transaction-stateful proxy profile, updated by RFC 4320 and
-RFC 6026.** The coordinated `0.3.7` candidate includes
+RFC 6026.** The coordinated `0.3.8` candidate includes
 transaction-stateful forwarding, parallel/sequential forking, Via and
 Max-Forwards processing, response aggregation, CANCEL propagation, and
 Timer C. The claim is limited to the behaviors and real-peer matrix named in
@@ -36,7 +36,7 @@ you want the raw transaction-layer primitives:
 
 ```toml
 [dependencies]
-rvoip-sip-proxy = "0.3.7"
+rvoip-sip-proxy = "0.3.8"
 ```
 
 ## License

--- a/crates/sip/sip-transport/README.md
+++ b/crates/sip/sip-transport/README.md
@@ -169,7 +169,7 @@ The 0.3 API removes the unsafe `WebSocketListener::accept` escape hatch in
 favor of `Arc<WebSocketListener>::serve_concurrent`, which retains ownership of
 handshake/session admission and shutdown. See the complete before/after example
 and release guidance in [MIGRATING-0.3.md](./MIGRATING-0.3.md). The transport
-crate now carries the required 0.3.7 package version.
+crate now carries the required 0.3.8 package version.
 
 SIPS never falls back to a plaintext transport: `sips:...;transport=tcp` means
 TLS-over-TCP, `transport=wss` means secure WebSocket, and explicit `udp` or

--- a/docs/PRODUCTION_HARDENING_ROADMAP.md
+++ b/docs/PRODUCTION_HARDENING_ROADMAP.md
@@ -1,7 +1,7 @@
 # rvoip Production-Hardening Roadmap
 
 **Status:** P0 + P1 implemented (2026-07-01); P2/P3 open. Target: open-internet / hostile-network exposure for `rtp-core`.
-**Scope:** `rvoip-sip` (beta-ready within its documented envelope) and `rtp-core` (media transport). Both ship on the unified `0.3.7` train; SIP is beta-qualified by product scope rather than by a version suffix.
+**Scope:** `rvoip-sip` (beta-ready within its documented envelope) and `rtp-core` (media transport). Both ship on the unified `0.3.8` train; SIP is beta-qualified by product scope rather than by a version suffix.
 
 ## Implementation status (2026-07-01)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,7 +12,7 @@ remain experimental.
 ## Prepare
 
 Use the **Prepare release PR** workflow with the next version, for example
-`0.3.7`. It checks out the current `main`, runs the unified preparation and
+`0.3.8`. It checks out the current `main`, runs the unified preparation and
 release-tooling tests, and opens a draft release pull request. The release PR
 must pass the normal `PR Gate`; it is never pushed directly to `main`.
 

--- a/examples/01-quickstart-p2p/Cargo.toml
+++ b/examples/01-quickstart-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-quickstart-p2p"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
@@ -12,8 +12,8 @@ publish = false
 # version + path: builds against the LOCAL tree now (so the example always
 # reflects current code and breaks loudly on API drift) while recording the
 # crates.io version used at publish time. Copying this example into your own
-# project? Drop the `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# project? Drop the `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/02-softphone-audio/Cargo.toml
+++ b/examples/02-softphone-audio/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-softphone-audio"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/03-register-to-pbx/Cargo.toml
+++ b/examples/03-register-to-pbx/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-register-to-pbx"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/04-call-control/Cargo.toml
+++ b/examples/04-call-control/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-call-control"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/05-blind-transfer/Cargo.toml
+++ b/examples/05-blind-transfer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-blind-transfer"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/06-attended-transfer/Cargo.toml
+++ b/examples/06-attended-transfer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-attended-transfer"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/07-secure-call-srtp/Cargo.toml
+++ b/examples/07-secure-call-srtp/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-secure-call-srtp"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/08-tls-transport/Cargo.toml
+++ b/examples/08-tls-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-tls-transport"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
@@ -10,7 +10,7 @@ publish = false
 # run against a self-signed dev cert. PRODUCTION builds must omit this feature
 # so rustls always validates server certs.
 # Copying into your own project? Drop `path` and keep just the version+features.
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip", features = ["dev-insecure-tls"] }
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip", features = ["dev-insecure-tls"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/09-ivr-server/Cargo.toml
+++ b/examples/09-ivr-server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-ivr-server"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/10-call-center-b2bua/Cargo.toml
+++ b/examples/10-call-center-b2bua/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rvoip-example-call-center-b2bua"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
 
 [dependencies]
-# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.7"
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
+# Copying into your own project? Drop `path` and keep: rvoip-sip = "0.3.8"
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/11-ai-harness-demo/Cargo.toml
+++ b/examples/11-ai-harness-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-ai-harness-demo"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
@@ -9,7 +9,7 @@ publish = false
 async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-rvoip-core-traits = { version = "0.3.7", path = "../../crates/foundation/rvoip-core-traits" }
-rvoip-harness = { version = "0.3.7", path = "../../crates/extensions/rvoip-harness" }
-rvoip-vcon = { version = "0.3.7", path = "../../crates/extensions/rvoip-vcon" }
+rvoip-core-traits = { version = "0.3.8", path = "../../crates/foundation/rvoip-core-traits" }
+rvoip-harness = { version = "0.3.8", path = "../../crates/extensions/rvoip-harness" }
+rvoip-vcon = { version = "0.3.8", path = "../../crates/extensions/rvoip-vcon" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/12-customer-escalation-sip-webrtc/Cargo.toml
+++ b/examples/12-customer-escalation-sip-webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-customer-escalation-sip-webrtc"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
@@ -10,11 +10,11 @@ bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 futures-util = "0.3"
-rvoip = { version = "0.3.7", path = "../../crates/rvoip", features = ["app"] }
-rvoip-core = { version = "0.3.7", path = "../../crates/foundation/rvoip-core" }
-rvoip-media-core = { version = "0.3.7", path = "../../crates/media/media-core", features = ["opus"] }
-rvoip-sip = { version = "0.3.7", path = "../../crates/sip/rvoip-sip" }
-rvoip-webrtc = { version = "0.3.7", path = "../../crates/webrtc/rvoip-webrtc", features = ["signaling-ws"] }
+rvoip = { version = "0.3.8", path = "../../crates/rvoip", features = ["app"] }
+rvoip-core = { version = "0.3.8", path = "../../crates/foundation/rvoip-core" }
+rvoip-media-core = { version = "0.3.8", path = "../../crates/media/media-core", features = ["opus"] }
+rvoip-sip = { version = "0.3.8", path = "../../crates/sip/rvoip-sip" }
+rvoip-webrtc = { version = "0.3.8", path = "../../crates/webrtc/rvoip-webrtc", features = ["signaling-ws"] }
 rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/12-customer-escalation-sip-webrtc/src/main.rs
+++ b/examples/12-customer-escalation-sip-webrtc/src/main.rs
@@ -373,13 +373,26 @@ async fn run_media_proof(
         .peer
         .local_audio_ssrc()
         .ok_or("customer WebRTC peer has no local audio SSRC")?;
+    // The payload type this leg carries opus on. Stated once and handed to
+    // both the codec and the stream: `CodecInfo` reports what was negotiated
+    // so the media graph keys and labels frames by that number rather than
+    // guessing it from the codec name.
+    const OPUS_PAYLOAD_TYPE: u8 = 111;
     let codec = CodecInfo {
         name: "opus".into(),
         clock_rate_hz: 48000,
         channels: 2,
         fmtp: None,
+        payload_type: Some(OPUS_PAYLOAD_TYPE),
     };
-    let customer_stream = from_tracks(StreamId::new(), codec, local_track, local_ssrc, 111, None);
+    let customer_stream = from_tracks(
+        StreamId::new(),
+        codec,
+        local_track,
+        local_ssrc,
+        OPUS_PAYLOAD_TYPE,
+        None,
+    );
 
     verify_webrtc_to_sip(alice, alice_session, &customer_stream).await?;
     verify_sip_to_webrtc(alice, alice_session, &customer.peer, &customer_stream).await?;

--- a/examples/13-sip-to-amazon-connect/Cargo.toml
+++ b/examples/13-sip-to-amazon-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-sip-to-amazon-connect"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
@@ -12,7 +12,7 @@ aws-live = ["rvoip-amazon-connect/aws-control"]
 
 [dependencies]
 # `server` pulls the batteries-included SIP UAS + media bridge.
-rvoip-amazon-connect = { version = "0.3.7", path = "../../crates/webrtc/rvoip-amazon-connect", features = ["server"] }
+rvoip-amazon-connect = { version = "0.3.8", path = "../../crates/webrtc/rvoip-amazon-connect", features = ["server"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/examples/14-vapi-agent/Cargo.toml
+++ b/examples/14-vapi-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvoip-example-vapi-agent"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.91"
 publish = false
@@ -8,8 +8,8 @@ publish = false
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 # Copying into your own project? Drop `path` and keep:
-# rvoip = { version = "0.3.7", features = ["app", "vapi"] }
-rvoip = { version = "0.3.7", path = "../../crates/rvoip", default-features = false, features = ["app", "vapi"] }
+# rvoip = { version = "0.3.8", features = ["app", "vapi"] }
+rvoip = { version = "0.3.8", path = "../../crates/rvoip", default-features = false, features = ["app", "vapi"] }
 rustls = "0.23"
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3807,7 +3807,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rvoip"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "axum",
  "bytes",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-amazon-connect"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-auth-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-codec-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "opus",
  "thiserror 1.0.69",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-core-traits"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-ai-harness-demo"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-attended-transfer"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rvoip-sip",
  "tokio",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-blind-transfer"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rvoip-sip",
  "tokio",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-call-center-b2bua"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "rvoip-sip",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-call-control"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "rvoip-sip",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-customer-escalation-sip-webrtc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-ivr-server"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rvoip-sip",
  "tokio",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-quickstart-p2p"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "rvoip-sip",
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-register-to-pbx"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rvoip-sip",
  "tokio",
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-secure-call-srtp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "rvoip-sip",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-sip-to-amazon-connect"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "rvoip-amazon-connect",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-softphone-audio"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-tls-transport"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "rvoip-sip",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-example-vapi-agent"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "rustls",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-harness"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-infra-common"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-media-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "apodize",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-quic"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "bytes",
  "hex",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-rtp-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-dialog"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-proxy"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-registrar"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-sip-transport"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-uctp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vapi"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-vcon"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webrtc-stack"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-websocket"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "rvoip-webtransport"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bytes",

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ The source of truth is
 
 - **Self-contained projects.** Each example is its own Cargo workspace and uses
   local rvoip crates from this checkout through `path`. The paired `version`
-  tracks the unified workspace train (`0.3.7`). When copying an example into
+  tracks the unified workspace train (`0.3.8`). When copying an example into
   your own project, drop `path` and select the published version you intend to
   use.
 - **`./run_demo.sh`** builds release binaries, boots every process with port


### PR DESCRIPTION
Prepares the coordinated 44-crate `0.3.8` release.

## What's in it

- `scripts/release.sh prepare --version 0.3.8`: workspace version, the 44
  internal dependency pins, both lockfiles, and the three active release
  metadata files.
- The hand sweep prepare doesn't reach, matching 0.3.7's `228a4aff`: 14
  example manifests + `examples/Cargo.lock`, ten crate READMEs, the
  rvoip-sip docs set, `docs/RELEASING.md`, and the workflow's version hint.
  Two references deliberately stay at 0.3.7: `check_public_api.sh`'s
  semver baseline (the *previous* release is the comparison target) and
  the OpenSIPS TLS provenance note (a historical statement).
- CHANGELOG `0.3.8` entry and a rewritten `RELEASE_NOTES_NEXT.md`,
  including an **Upgrading from 0.3.7** section: the one source-level
  change for downstream code is `CodecInfo` literals adding
  `payload_type: None`. Every other consumer-constructed type
  (`MediaFrame`, `SymmetricRtpPolicy`, `SipTraceConfig`, `MediaMode`) was
  diffed against `v0.3.7` and is shape-identical.
- A pre-publish API review moved the three new AMR knobs off `Config`'s
  public fields onto `with_amr_dtx` / `with_amr_auto_cmr` /
  `with_amr_mode_set` builders (private fields — the constructible shape
  stays frozen at 0.3.7's). Fifteen in-repo functional-record-update
  construction sites were converted to the documented constructors.
  `cargo semver-checks` vs `v0.3.7`: **no semver update required**.
- Example 12 fixed for the `CodecInfo` field addition (it had never
  compiled since the field landed; only main-ci builds all 14 examples).

## Issue triage folded in

All ten bug-shaped open issues were evaluated against this branch:
#176 is fixed by this release (closed); #163, #166, #167 were fixed in
0.3.7 and are now closed against their evidence; #177 and #170 updated
as partially addressed; #169, #168, #86, #164 confirmed valid and open;
follow-ups #184, #185, #186 filed from the verification residuals.

None of the open issues is a 0.3.8 regression; nothing new rides this
release beyond the API-shape corrections above.

## After merge

`remote-preflight`, then `remote-release` qualification with
`first_candidate=true` — the gate catalog changed (+17 gates), so the
catalog hash is fresh and no prior evidence reuses. Publish follows the
protected workflow. Bridgefu's pin bump has a prepared 7-site patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b114fefb00ce01c116ea7689782a7855f7d85a6f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->