### PR TITLE
doc examples: build Config through its constructor, not a record update

### DIFF
--- a/crates/sip/rvoip-sip/src/api/callback_peer.rs
+++ b/crates/sip/rvoip-sip/src/api/callback_peer.rs
@@ -1559,7 +1559,7 @@ impl CallbackPeerControl {
 ///     }
 /// }
 ///
-/// let config = Config { sip_port: 5060, ..Default::default() };
+/// let config = Config::local("router", 5060);
 /// let peer = CallbackPeer::new(Router, config).await?;
 /// peer.run().await?;
 /// # Ok(())
@@ -1658,10 +1658,8 @@ impl<H: CallHandler> CallbackPeer<H> {
     /// use rvoip_sip::{CallbackPeer, Config, SipClientAuth};
     /// use rvoip_sip::api::handlers::AutoAnswerHandler;
     ///
-    /// let config = Config {
-    ///     auth: Some(SipClientAuth::digest("alice", "secret")),
-    ///     ..Config::default()
-    /// };
+    /// let mut config = Config::local("alice", 5060);
+    /// config.auth = Some(SipClientAuth::digest("alice", "secret"));
     /// let peer = CallbackPeer::new(AutoAnswerHandler, config).await?;
     /// # Ok(())
     /// # }


### PR DESCRIPTION
Two doc examples in `callback_peer.rs` built `Config` with functional record update, which stopped compiling when 0.3.8 made the three AMR fields private (E0451).

Caught by the release pipeline's `test.sip-doctest` gate on qualification run 31859767703 — the only check in the tree that compiles doc examples. `cargo check --all-targets` does not, which is why local verification missed it.

Both now use `Config::local(..)`. `cargo test --locked -p rvoip-sip --doc` (the gate's exact command) passes 213/213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6f39d042e266ca92df525e27f300f56755f1a500. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->