### PR TITLE
freeswitch runner: autoload the AMR modules the image already builds

### DIFF
--- a/crates/sip/rvoip-sip/examples/pbx/amr_probe.sh
+++ b/crates/sip/rvoip-sip/examples/pbx/amr_probe.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env sh
 # Does this PBX support AMR? Asked before every AMR interop cell, because the
-# answer differs by *image*, not by provider: the local lab containers carry
-# AMR (Asterisk source-built with the traud patches, FreeSWITCH with
-# mod_amr/mod_amrwb) while the committed release-runner images do not — the
-# packaged Alpine Asterisk cannot take the patches at all.
+# answer differs by *image*, not by provider: both the local lab containers
+# and the committed release-runner images now build AMR from source (Asterisk
+# with the traud patches, FreeSWITCH with mod_amr/mod_amrwb against the
+# Apache-2.0 codec libraries), but a third-party or packaged image generally
+# will not — the packaged Alpine Asterisk cannot take the patches at all.
 #
 # A cell that would fail for "this image has no AMR" is not interop evidence
 # of anything, so the runner records it as SKIP instead. Two guards keep the

--- a/infra/release-runners/pbx/freeswitch/docker-entrypoint.sh
+++ b/infra/release-runners/pbx/freeswitch/docker-entrypoint.sh
@@ -245,6 +245,15 @@ write_modules_conf() {
     <load module="mod_say_en"/>
     <load module="mod_xml_rpc"/>
     <load module="mod_g729"/>
+    <!-- Built and installed by the image (modules.conf lists codecs/mod_amr
+         and codecs/mod_amrwb, and the builder carries the opencore/vo-amrwbenc
+         dev packages), but this file replaces FreeSWITCH's sample autoload
+         list wholesale — so a codec missing here is a codec the running
+         switch does not have, however well it compiled. Leaving them out is
+         what made `show codec` report neither, and the AMR interop rows fail
+         against a PBX that could not have answered them. -->
+    <load module="mod_amr"/>
+    <load module="mod_amrwb"/>
   </modules>
 </configuration>
 EOF


### PR DESCRIPTION
The release-runner FreeSWITCH image builds `mod_amr`/`mod_amrwb` but the entrypoint overwrites `modules.conf.xml` with a fixed list ending at `mod_g729`, so they were never loaded. `show codec` reported neither, the capability probe answered `amr=no`, and `PBX_REQUIRE_AMR=1` correctly failed the AMR interop row.

Asterisk's image is wired correctly and passed with the same flag — that isolates it to the FreeSWITCH entrypoint.

Also fixes `amr_probe.sh`'s stale header claiming release-runner images carry no AMR.

Found by qualification run 31863624827, where this one row was the entire failure: the two missing long-soak results were the controller deliberately stopping deferred workers after the bounded lane failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ccf165253c895feb1e2b441167ebf11e739a4f15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->