### PR TITLE
proxy interop: keep the evidence, and retry a scenario once

### DIFF
--- a/crates/sip/sip-proxy/tests/interop/scripts/run.sh
+++ b/crates/sip/sip-proxy/tests/interop/scripts/run.sh
@@ -749,18 +749,68 @@ route-strict|route-loose-record-route|auth-aggregation|capacity-overload)
     --expected-peer-sent-by "$PEER_ADDRESS:$PROXY_INTEROP_PEER_PORT"
 }
 
+# Run one externally-driven scenario, keeping its output whatever happens.
+#
+# Two properties this has to have, both learned from a release qualification
+# that failed here and left nothing to read:
+#
+#   - the driver's stdout/stderr lands in the scenario directory, so a failure
+#     is diagnosable from the evidence bundle alone. Previously it went to the
+#     harness's own stdout, which the gate runner does not fold into the
+#     per-scenario artifacts -- a failed scenario produced a bare non-zero exit
+#     and no explanation anywhere in the archive;
+#   - a failure that is environmental (a container that lost a race, a socket
+#     that was still draining) gets exactly one retry, and the retry is
+#     RECORDED. A deterministic failure still fails, because it fails twice;
+#     a flake costs seconds instead of taking a 206-gate candidate down with
+#     it. `retry.log` existing at all is the signal that a row was unstable,
+#     so a flake can never pass silently as if it were clean.
 run_captured_external_scenario() {
   local scenario=$1
   shift
-  mkdir -p "$row_dir/scenarios/$scenario"
-  start_captures "$scenario" || return
-  local result=0
-  "$@" || result=$?
-  stop_captures
-  if [[ "$result" -ne 0 ]]; then
-    return "$result"
-  fi
-  validate_scenario_packet_evidence "$scenario"
+  local scenario_dir="$row_dir/scenarios/$scenario"
+  mkdir -p "$scenario_dir"
+
+  local attempts=${PROXY_INTEROP_SCENARIO_ATTEMPTS:-2}
+  local attempt result=0
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    local driver_log="$scenario_dir/driver.stdout.log"
+    if [[ "$attempt" -gt 1 ]]; then
+      driver_log="$scenario_dir/driver.attempt-$attempt.stdout.log"
+    fi
+
+    # `|| result=$?` rather than `if ! ...`: inside an `if !` branch `$?` is the
+    # negation's own status, which is always 0 — it would report every capture
+    # failure as a success.
+    result=0
+    start_captures "$scenario" >>"$driver_log" 2>&1 || result=$?
+    if [[ "$result" -ne 0 ]]; then
+      printf 'scenario %s: packet capture failed to start (exit %s)\n' \
+        "$scenario" "$result" >>"$driver_log"
+    else
+      "$@" >>"$driver_log" 2>&1 || result=$?
+      stop_captures
+    fi
+
+    if [[ "$result" -eq 0 ]]; then
+      validate_scenario_packet_evidence "$scenario" || return
+      if [[ "$attempt" -gt 1 ]]; then
+        printf 'scenario %s passed on attempt %s of %s\n' \
+          "$scenario" "$attempt" "$attempts" >>"$scenario_dir/retry.log"
+        echo "scenario $scenario passed on attempt $attempt (see retry.log)" >&2
+      fi
+      return 0
+    fi
+
+    printf 'scenario %s attempt %s of %s exited %s\n' \
+      "$scenario" "$attempt" "$attempts" "$result" >>"$scenario_dir/retry.log"
+    if [[ "$attempt" -lt "$attempts" ]]; then
+      echo "scenario $scenario failed (exit $result); retrying once" >&2
+    fi
+  done
+
+  echo "scenario $scenario failed after $attempts attempt(s); see $scenario_dir" >&2
+  return "$result"
 }
 
 sipp_mode() {

--- a/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
@@ -266,9 +266,26 @@ class RunFailStopTests(unittest.TestCase):
         wrapper_start = self.source.index("\nrun_captured_external_scenario() {")
         wrapper_end = self.source.index("\n}\n\nsipp_mode", wrapper_start)
         wrapper = normalized(self.source[wrapper_start:wrapper_end])
-        self.assertIn('start_captures "$scenario" || return', wrapper)
+        # Each scenario still owns its own capture lifecycle: started for that
+        # scenario, stopped, and validated. The capture-start failure is
+        # captured into `result` rather than tested with `if !`, where `$?`
+        # would be the negation's status and every failure would read as a
+        # success.
+        self.assertIn('start_captures "$scenario"', wrapper)
+        self.assertIn("|| result=$?", wrapper)
         self.assertIn("stop_captures", wrapper)
         self.assertIn('validate_scenario_packet_evidence "$scenario"', wrapper)
+
+        # A failed scenario has to leave something to read. A qualification
+        # run failed here once and the evidence bundle held only a non-zero
+        # exit, because the driver wrote to the harness's stdout.
+        self.assertIn("driver.stdout.log", wrapper)
+
+        # The retry is bounded and always recorded, so an unstable row cannot
+        # read as clean, and a deterministic failure still fails: it fails on
+        # every attempt and the driver's own exit code is what propagates.
+        self.assertIn("retry.log", wrapper)
+        self.assertIn('return "$result"', wrapper)
 
         core_start = self.source.index("\nrun_core_scenarios() {")
         core_end = self.source.index("\n}\n\nadvanced_scenarios_for_row", core_start)


### PR DESCRIPTION
A qualification run failed on `interop.remote-proxies.opensips.peer-first.tcp` and left nothing to read — the driver's output went to the harness's stdout, which the gate runner doesn't fold into per-scenario artifacts. It turned out to be a flake (the same gate passed one run earlier on byte-identical dialog code), but characterising that took four archives and a cross-run comparison.

**Evidence:** `run_captured_external_scenario` now writes driver stdout/stderr to `driver.stdout.log` in the scenario directory, including when packet capture fails to start (which previously returned with no record at all).

**Retry:** a failed scenario is retried once, always recorded in `retry.log`. A deterministic failure still fails — it fails twice and the original exit code propagates — so this cannot mask a regression; only a flake gets a second chance. `PROXY_INTEROP_SCENARIO_ATTEMPTS` restores single-shot behaviour.

**Not done deliberately:** widening `retry_on_exit_codes` at the gate level. It holds only `75` (emitted by `gcp-release-startup.sh` on evidence-upload failure) and applies to *every* gate — widening it would let an intermittently broken unit test pass on a second roll. Tracked with the remaining amazon-connect flake in #192.

Verified by extracting the function and exercising it against three cases: passes-first (no retry.log), flaky (passes on attempt 2, recorded), deterministic (exit code 7 preserved, both attempts logged). Gate catalog regenerates byte-identical, so no catalog-hash churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6e46f8e0e3c578b07739ebbcaf52c2bc2131ad9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->