### PR TITLE
amazon-connect test: the Chime server tolerates the client leaving

### DIFF
--- a/crates/webrtc/rvoip-amazon-connect/src/media.rs
+++ b/crates/webrtc/rvoip-amazon-connect/src/media.rs
@@ -610,11 +610,39 @@ mod tests {
     }
 
     async fn send_test_frame(ws: &mut WebSocketStream<TcpStream>, frame: SdkSignalFrame) {
-        let mut bytes = vec![TEST_FRAME_TYPE_RTC];
-        frame.encode(&mut bytes).expect("encode Chime frame");
-        ws.send(WsMessage::Binary(bytes.into()))
+        try_send_test_frame(ws, frame)
             .await
             .expect("send Chime frame");
+    }
+
+    /// Send without asserting the peer is still there.
+    ///
+    /// Only the keepalive loop uses this. The connector pings every
+    /// `keepalive_interval`, so a ping can arrive while the client is already
+    /// tearing the socket down; writing the pong then fails with
+    /// `ConnectionReset` through no fault of the code under test. Every
+    /// handshake send stays on [`send_test_frame`], where a failure is a real
+    /// protocol break and must still panic.
+    async fn try_send_test_frame(
+        ws: &mut WebSocketStream<TcpStream>,
+        frame: SdkSignalFrame,
+    ) -> std::result::Result<(), tokio_tungstenite::tungstenite::Error> {
+        let mut bytes = vec![TEST_FRAME_TYPE_RTC];
+        frame.encode(&mut bytes).expect("encode Chime frame");
+        ws.send(WsMessage::Binary(bytes.into())).await
+    }
+
+    /// Receive, treating a closed socket as "the client left" rather than a
+    /// failure. Same reasoning as [`try_send_test_frame`]: at teardown the
+    /// stream can end before the loop observes a `Leave`.
+    async fn try_recv_test_frame(ws: &mut WebSocketStream<TcpStream>) -> Option<SdkSignalFrame> {
+        loop {
+            let message = ws.next().await?.ok()?;
+            if let WsMessage::Binary(bytes) = message {
+                assert_eq!(bytes.first().copied(), Some(TEST_FRAME_TYPE_RTC));
+                return Some(SdkSignalFrame::decode(&bytes[1..]).expect("valid Chime frame"));
+            }
+        }
     }
 
     fn local_webrtc_config() -> WebRtcConfig {
@@ -762,14 +790,18 @@ mod tests {
                     .expect("send delayed remote DTMF");
             });
 
-            loop {
-                let frame = recv_test_frame(&mut ws).await;
+            // Keepalive service until the client leaves. A `None` frame or a
+            // failed pong both mean the socket went away during teardown,
+            // which is the same outcome as `Leave` for this test and must not
+            // be reported as a failure — the assertions that matter are the
+            // handshake above and the media checks below.
+            while let Some(frame) = try_recv_test_frame(&mut ws).await {
                 if frame.r#type == FrameType::Leave as i32 {
                     break;
                 }
                 if let Some(ping) = frame.ping_pong {
-                    if ping.r#type == SdkPingPongType::Ping as i32 {
-                        send_test_frame(
+                    if ping.r#type == SdkPingPongType::Ping as i32
+                        && try_send_test_frame(
                             &mut ws,
                             SdkSignalFrame {
                                 timestamp_ms: 3,
@@ -781,7 +813,10 @@ mod tests {
                                 ..Default::default()
                             },
                         )
-                        .await;
+                        .await
+                        .is_err()
+                    {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
`production_connector_uses_local_chime_and_rvoip_webrtc_only` failed **two of five** release qualification runs with `send Chime frame: Io(ConnectionReset)` at the pong write.

The connector pings every 20ms in this test, so a ping arrives while the client is tearing the socket down; the in-test Chime server writes a pong to a closed peer and panics. Nothing under test is wrong.

The keepalive loop now treats a closed socket like `Leave` in both directions. Handshake sends keep the strict `send_test_frame` — a write failure there is a real protocol break and still panics, so the tolerance is scoped to teardown only.

Verified: **25 consecutive runs** of the previously flaky test all pass, plus the crate's full gate command (63 lib tests) and clippy clean.

Closes the amazon-connect half of #192. Fixing the race rather than widening `retry_on_exit_codes` keeps the gate honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7e67ca6f10a3bc695b535188dd832b399d736a78. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->