### PR TITLE
freeswitch runner: build the transcoding profile twins the harness expects

### DIFF
--- a/infra/release-runners/interop-lifecycle.sh
+++ b/infra/release-runners/interop-lifecycle.sh
@@ -180,6 +180,11 @@ FREESWITCH_UDP_ADDR=127.0.0.1:5062
 FREESWITCH_TLS_ADDR=127.0.0.1:5063
 FREESWITCH_UDP_SIP_PORT=5062
 FREESWITCH_TLS_SIP_PORT=5063
+# Transcoding-enabled profile twins. run.sh redirects amr_transcode_call here,
+# because the profiles above pin disable-transcoding and would refuse a call
+# whose two legs share no codec -- which is exactly what that row asks for.
+FREESWITCH_XCODE_UDP_ADDR=127.0.0.1:5064
+FREESWITCH_XCODE_TLS_ADDR=127.0.0.1:5065
 FREESWITCH_RTP_START=16384
 FREESWITCH_RTP_END=16484
 FREESWITCH_PASSWORD=1234

--- a/infra/release-runners/pbx/freeswitch/docker-entrypoint.sh
+++ b/infra/release-runners/pbx/freeswitch/docker-entrypoint.sh
@@ -77,6 +77,12 @@ write_rvoip_profile() {
   local_rtp_ip=$7
   external_sip_ip=$8
   external_rtp_ip=$9
+  # "true" pins disable-transcoding, which REFUSES a call whose legs cannot
+  # share a codec. That is what the matrix wants almost everywhere -- a row
+  # that quietly transcodes proves nothing about codec negotiation -- but the
+  # amr_transcode_call row needs the opposite, so it registers against the
+  # _xcode twins written below.
+  disable_transcoding=${10:-true}
   secure_media_line=""
   if [ "$secure_media" = "true" ]; then
     secure_media_line='    <param name="rtp_secure_media" value="mandatory"/>'
@@ -106,7 +112,7 @@ write_rvoip_profile() {
     <param name="inbound-codec-prefs" value="AMR-WB,AMR,G729,PCMU,PCMA"/>
     <param name="outbound-codec-prefs" value="AMR-WB,AMR,G729,PCMU,PCMA"/>
     <param name="inbound-late-negotiation" value="true"/>
-    <param name="disable-transcoding" value="true"/>
+    <param name="disable-transcoding" value="$disable_transcoding"/>
     <param name="rtp-timer-name" value="soft"/>
     <param name="auth-calls" value="true"/>
     <param name="auth-subscriptions" value="false"/>
@@ -140,11 +146,26 @@ write_rvoip_profiles() {
   external_rtp_ip=$3
   udp_port=${FS_RVOIP_UDP_SIP_PORT:-5062}
   tls_port=${FS_RVOIP_TLS_SIP_PORT:-5063}
+  udp_xcode_port=${FS_RVOIP_UDP_XCODE_SIP_PORT:-5064}
+  tls_xcode_port=${FS_RVOIP_TLS_XCODE_SIP_PORT:-5065}
 
   write_rvoip_profile rvoip_udp "$udp_port" false false false "$tls_port" \
-    "$local_rtp_ip" "$external_sip_ip" "$external_rtp_ip"
+    "$local_rtp_ip" "$external_sip_ip" "$external_rtp_ip" true
   write_rvoip_profile rvoip_tls_srtp "$tls_port" true true true "$tls_port" \
-    "$local_rtp_ip" "$external_sip_ip" "$external_rtp_ip"
+    "$local_rtp_ip" "$external_sip_ip" "$external_rtp_ip" true
+
+  # Transcoding twins, on their own ports.
+  #
+  # amr_transcode_call bridges two legs that deliberately share no codec
+  # (AMR-NB one side, PCMU the other) and asks the PBX to convert between
+  # them. The profiles above pin disable-transcoding, so such a call is
+  # refused rather than converted -- correct for every other row, fatal for
+  # this one. run.sh redirects that scenario to FREESWITCH_XCODE_*_ADDR, and
+  # these are the profiles those addresses point at.
+  write_rvoip_profile rvoip_udp_xcode "$udp_xcode_port" false false false \
+    "$tls_xcode_port" "$local_rtp_ip" "$external_sip_ip" "$external_rtp_ip" false
+  write_rvoip_profile rvoip_tls_srtp_xcode "$tls_xcode_port" true true true \
+    "$tls_xcode_port" "$local_rtp_ip" "$external_sip_ip" "$external_rtp_ip" false
 }
 
 write_rvoip_user() {


### PR DESCRIPTION
`amr_transcode_call` bridges two legs with disjoint codecs (AMR-NB / PCMU) and needs the PBX to transcode. `run.sh` already redirects that row to `FREESWITCH_XCODE_UDP_ADDR`/`_TLS_ADDR`, and the local lab env has documented those addresses since the labs landed — but the release-runner image never built the profiles they point at, and `interop-lifecycle.sh` never exported them. The redirect was a no-op, the call hit a `disable-transcoding` profile, and the PCMU-only callee correctly answered `SDPNegotiationFailed`.

`write_rvoip_profile` now takes the transcoding flag; `write_rvoip_profiles` emits `rvoip_udp_xcode` (5064) and `rvoip_tls_srtp_xcode` (5065) with it disabled. Ports match the local lab and stay in the sub-5070 daemon block.

This row had never run before — the matrix used to die at the AMR probe, so the gap was invisible until `mod_amr` started loading. Third defect of the same shape in this branch's runner image: configured locally, missing on the runner.

**Verified on a rebuilt image:** all four profiles RUNNING, `disable-transcoding` true on the base pair and false on the twins, AMR probe still `amr=yes amrwb=yes`.

Qualification 31909428777 reached 16/18 shards and 26/28 FreeSWITCH rows with this as the only blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e330520adc36013e2619cd3311a9cd221a735a1e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->