### PR TITLE
freeswitch runner: let the transcoding twins actually transcode

### DIFF
--- a/infra/release-runners/pbx/freeswitch/docker-entrypoint.sh
+++ b/infra/release-runners/pbx/freeswitch/docker-entrypoint.sh
@@ -83,6 +83,18 @@ write_rvoip_profile() {
   # amr_transcode_call row needs the opposite, so it registers against the
   # _xcode twins written below.
   disable_transcoding=${10:-true}
+  # Late negotiation defers codec selection so the inbound offer can be handed
+  # to the B-leg untouched -- which is what a relay wants, and precisely what
+  # makes transcoding impossible. The two settings express the same choice
+  # (relay vs convert), so they must agree: a transcoding profile that left
+  # late negotiation on would forward the caller's AMR offer to a PCMU-only
+  # callee and get a correct SDPNegotiationFailed back, having converted
+  # nothing.
+  if [ "$disable_transcoding" = "true" ]; then
+    late_negotiation=true
+  else
+    late_negotiation=false
+  fi
   secure_media_line=""
   if [ "$secure_media" = "true" ]; then
     secure_media_line='    <param name="rtp_secure_media" value="mandatory"/>'
@@ -111,7 +123,7 @@ write_rvoip_profile() {
     <param name="ext-rtp-ip" value="$external_rtp_ip"/>
     <param name="inbound-codec-prefs" value="AMR-WB,AMR,G729,PCMU,PCMA"/>
     <param name="outbound-codec-prefs" value="AMR-WB,AMR,G729,PCMU,PCMA"/>
-    <param name="inbound-late-negotiation" value="true"/>
+    <param name="inbound-late-negotiation" value="$late_negotiation"/>
     <param name="disable-transcoding" value="$disable_transcoding"/>
     <param name="rtp-timer-name" value="soft"/>
     <param name="auth-calls" value="true"/>
@@ -212,6 +224,19 @@ write_rvoip_dialplan() {
   cat > "$CONF_DIR/dialplan/rvoip.xml" <<'EOF'
 <include>
   <context name="rvoip">
+    <!-- Calls arriving on the *_xcode (transcoding) profiles offer the
+         originated leg the whole codec list instead of inheriting the
+         A-leg's codec: FreeSWITCH's bridge otherwise offers only what the
+         calling leg negotiated, and a B-leg endpoint that cannot speak that
+         codec is refused before the transcoder gets a say. nolocal: keeps
+         the A-leg's own negotiation untouched. continue=true so the call
+         falls through to the ordinary extensions below. -->
+    <extension name="rvoip_xcode_codec_export" continue="true">
+      <condition field="${sofia_profile_name}" expression="^rvoip_(udp|tls_srtp)_xcode$" break="never">
+        <action application="export" data="nolocal:absolute_codec_string=PCMU,PCMA,AMR,AMR-WB"/>
+      </condition>
+    </extension>
+
     <extension name="rvoip_tls_srtp_extensions">
       <condition field="destination_number" expression="^(100[1-3])$">
         <action application="set" data="dialed_extension=$1"/>


### PR DESCRIPTION
Building the `_xcode` profiles ([#195](https://github.com/eisenzopf/rvoip/pull/195)) was necessary but not sufficient. `amr_transcode_call` still failed qualification with `SDPNegotiationFailed`, and the receipts showed why: the PCMU-only callee was offered **255 bytes** of SDP where the working lab offers **472**. It was handed the caller's AMR-only offer verbatim and refused the call before the transcoder was ever consulted.

Two settings drive that. The hand-maintained lab had both; the release-runner entrypoint had neither.

- **`inbound-late-negotiation` must be off wherever transcoding is on.** With it on, FreeSWITCH hasn't chosen the A-leg codec when it originates the B-leg, so it forwards the A-leg's offer instead of its own prefs.
- **`rvoip_xcode_codec_export` dialplan rule** exports `nolocal:absolute_codec_string` for calls on the `_xcode` profiles, so the originated leg sees the full codec list instead of inheriting the A-leg's single negotiated codec.

The generated profile and dialplan are now byte-identical to the lab's — the only configuration these rows have ever passed under.

## Verification

Run on the **release-runner image itself**, not just by inspecting generated XML:

| | |
|---|---|
| `amr_transcode_call` cells | **8/8 PASS** (NB + WB × UDP + TLS) |
| Offer seen by callee | **472 bytes** (was 255) |

The previous fix was verified structurally — profiles present, flag set — which is exactly how a profile that could not transcode still looked correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 141153fec90e691ce9dcd4e11c755585a5ecf07f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->