### PR TITLE
interop: let the retry cover the failure it was built for

### DIFF
--- a/crates/sip/sip-proxy/tests/interop/scripts/run.sh
+++ b/crates/sip/sip-proxy/tests/interop/scripts/run.sh
@@ -792,8 +792,19 @@ run_captured_external_scenario() {
       stop_captures
     fi
 
+    # Evidence validation is a scenario outcome like any other, so it has to be
+    # retryable too. This class of failure lands here rather than on the
+    # driver's exit code: the call completes, SIPp reports success, and the
+    # assertion that fails is the packet one -- a capture window that opened
+    # after a reused TLS connection's handshake sees mid-stream bytes tshark
+    # will not label application data for that hop. A bare `return` here
+    # abandoned the retry the moment the driver succeeded but the evidence did
+    # not, which is exactly the case the retry exists for.
     if [[ "$result" -eq 0 ]]; then
-      validate_scenario_packet_evidence "$scenario" || return
+      validate_scenario_packet_evidence "$scenario" || result=$?
+    fi
+
+    if [[ "$result" -eq 0 ]]; then
       if [[ "$attempt" -gt 1 ]]; then
         printf 'scenario %s passed on attempt %s of %s\n' \
           "$scenario" "$attempt" "$attempts" >>"$scenario_dir/retry.log"

--- a/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
+++ b/crates/sip/sip-proxy/tests/interop/scripts/test_run_fail_stop.py
@@ -383,6 +383,31 @@ class RunFailStopTests(unittest.TestCase):
         self.assertIn("sipp_path:", self.source)
         self.assertIn("first_nonempty_line", self.source)
 
+    def test_evidence_validation_failure_is_retryable(self) -> None:
+        """A scenario whose driver succeeds but whose packet evidence fails
+        must still get its recorded retry.
+
+        The flake this retry exists for lands on the packet assertion, not on
+        the driver's exit code: the call completes and SIPp reports success,
+        so a bare `return` after validation abandoned the retry in precisely
+        the case it was built for. Validation must feed `$result` like every
+        other step, and the success path must be guarded by `$result` alone.
+        """
+        start = self.source.index("\nrun_captured_external_scenario() {")
+        end = self.source.index("\n}\n", start)
+        body = self.source[start:end]
+
+        self.assertIn("validate_scenario_packet_evidence \"$scenario\" || result=$?", body)
+        # The abandoning form must not come back.
+        self.assertNotRegex(
+            body, r"validate_scenario_packet_evidence[^\n]*\|\|\s*return\b"
+        )
+        # Validation has to run before the success path is taken, so that a
+        # failed assertion still reaches the retry.
+        validation = body.index("validate_scenario_packet_evidence")
+        success = body.index("return 0")
+        self.assertLess(validation, success)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Qualification [31920892355](https://github.com/eisenzopf/rvoip/actions/runs/31920892355) lost a 206-gate candidate to `interop.remote-proxies.opensips.rvoip-first.tls`. The driver capture added last week finally showed what happens there.

**The call is fine.** SIPp reports one successful call on both ends, the full INVITE/180/200/ACK/BYE/200 exchange is present, and every routing and record-route assertion passes. Exactly one assertion fails:

```
tls-application-data-on-every-encrypted-hop
  observed:  25070, 25180, 45826, 51164
  required:  25060, 25070, 25180        ← 25060 missing
```

**The retry never fired**, because of a bug in the retry itself:

```bash
validate_scenario_packet_evidence "$scenario" || return
```

A bare `return` leaves the function with the current status, abandoning the loop the moment the driver exits 0 but the evidence does not hold. That isn't an edge case — it is this entire class of failure, since the driver *cannot* fail when the call succeeds. The retry only ever covered capture-start and driver failures, which are the cases least likely to be flaky.

Validation now feeds `$result` like every other step: an unstable row gets its one recorded retry, a deterministic one still fails twice, and `retry.log` remains the signal that a row was unstable.

The guard test gains an invariant for this, **verified in both directions** — it fails against the bare-return form and passes against the fix (19 tests green).

This does not explain why 25060 lacked application data in that window; the plausible reading is a capture that opened after a reused TLS connection's handshake. The retry is what tells us which it is: a flake passes on the second attempt and records it, a real defect fails twice.

Refs #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the interop test harness retry logic and a guard unit test; no production proxy or security paths.
> 
> **Overview**
> Fixes **interop scenario retries** so they cover **packet evidence failures**, not only capture-start or driver exits.
> 
> In `run_captured_external_scenario`, **`validate_scenario_packet_evidence` now sets `$result`** (via `|| result=$?`) when the driver and SIPp succeed but TLS/packet assertions fail—e.g. missing application data on a hop when capture starts mid-stream on a reused TLS connection. The old **`|| return`** path skipped the retry loop in exactly that case. Success (`return 0`) and **`retry.log`** recording now depend on **`$result` after validation**, same as other steps.
> 
> Adds **`test_evidence_validation_failure_is_retryable`** in `test_run_fail_stop.py` to lock in the pattern and reject the bare-return form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d453037060500a627e689f07648b4fd3e9d05918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->