### PR TITLE
release: let planner await exact-main CodeQL

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -58,7 +58,10 @@ jobs:
   plan:
     name: Plan exact-candidate gates
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Exact-main Rust CodeQL normally takes about 24 minutes. Keep the job
+    # deadline above the policy poll window so a post-merge dispatch cannot be
+    # cancelled by the runner before the policy emits its own receipt.
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
       hosted_matrix: ${{ steps.plan.outputs.hosted_matrix }}
@@ -129,6 +132,7 @@ jobs:
           python3 scripts/ci/check_codeql_release_policy.py
           --repository "${{ github.repository }}"
           --candidate "$(git rev-parse HEAD)"
+          --timeout-seconds 1200
           --receipt target/release-plan/codeql-policy.json
 
       - name: Download prior qualification evidence

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -33,6 +33,12 @@ limits, tool installation, repository checkout, GCS evidence transfer,
 controller reconciliation, and cleanup fail within a target of 15 minutes.
 The preflight is deliberately non-publishing and is not release evidence.
 
+For `remote-release`, the planner waits up to 20 minutes for all five CodeQL
+categories to bind to the exact protected-main commit. Its 30-minute job
+deadline intentionally outlives that poll window, so a qualification started
+immediately after merge fails with a policy receipt rather than being cancelled
+while the Rust analysis is still running.
+
 Use `remote-core` for a hosted-runner dry run and `remote-release` for the
 complete release profile. Do not start the full profile unless the exact
 release machinery has a recent successful preflight. The first candidate

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -432,6 +432,13 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('test -z "${CRATES_IO_TOKEN:-}"', probe)
         self.assertIn('"publishing_credentials_present": False', probe)
 
+    def test_release_planner_outlives_exact_candidate_codeql_poll(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
+        plan = workflow.split("  plan:\n", maxsplit=1)[1].split("\n  gate-hosted:\n", maxsplit=1)[0]
+
+        self.assertIn("timeout-minutes: 30", plan)
+        self.assertIn("--timeout-seconds 1200", plan)
+
     def test_remote_diagnostics_are_exact_gate_fresh_and_non_publishing(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
         publication = (ROOT / ".github/workflows/release-publish.yml").read_text()


### PR DESCRIPTION
## Summary
- give the release planner a 30-minute job deadline while retaining the 20-minute exact-candidate CodeQL poll
- test the timeout relationship so orchestration drift fails in CI
- document the protected-main security wait

## Root cause
The first 0.3.10 remote-release attempt (run 34016642879) was cancelled before provisioning workers because the plan job had a 15-minute timeout, shorter than its own 20-minute CodeQL poll. The post-merge Rust scan was still healthy and running.

## Verification
- `python3 scripts/ci/test_workflow_policy.py` (32 passed)
- `git diff --check`
- remote preflight and remote release will be rerun after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release CI timing and documentation only; no changes to security policy logic beyond aligning job and script timeouts.
> 
> **Overview**
> Fixes **release qualification** aborting during the `remote-release` plan step when post-merge CodeQL is still running: the **plan** job deadline moves from **15 to 30 minutes**, with workflow comments tying that to the ~24-minute Rust CodeQL run and the policy wait.
> 
> The **Require exact-candidate CodeQL** step now passes **`--timeout-seconds 1200`** (20 minutes) into `check_codeql_release_policy.py`, making the poll window explicit in the workflow so the runner is not killed before the script can emit a **policy receipt** on failure.
> 
> **`docs/RELEASING.md`** documents the 20-minute bind wait and why the 30-minute plan timeout must exceed it. **`test_release_planner_outlives_exact_candidate_codeql_poll`** locks in that relationship so future workflow edits cannot reintroduce a shorter job timeout than the CodeQL poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577dcb96d334e92e2d1c619f3f86506261eb621e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->