### PR TITLE
fix(security): redact remaining diagnostic credentials

### DIFF
--- a/crates/identity/users-core/examples/basic_usage.rs
+++ b/crates/identity/users-core/examples/basic_usage.rs
@@ -50,18 +50,12 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("✅ Authentication successful!");
-    println!(
-        "   Access token (first 50 chars): {}...",
-        &auth_result.access_token[..50]
-    );
+    println!("   Access token issued (value redacted)");
     println!(
         "   Token expires in: {} seconds",
         auth_result.expires_in.as_secs()
     );
-    println!(
-        "   Refresh token (first 50 chars): {}...",
-        &auth_result.refresh_token[..50]
-    );
+    println!("   Refresh token issued (value redacted)");
 
     // Simulate token expiration and refresh
     println!("\n🔄 Refreshing access token...");
@@ -72,10 +66,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("✅ Token refreshed!");
-    println!(
-        "   New access token (first 50 chars): {}...",
-        &refreshed.access_token[..50]
-    );
+    println!("   New access token issued (value redacted)");
     println!(
         "   Token is different: {}",
         refreshed.access_token != auth_result.access_token

--- a/crates/webrtc/rvoip-amazon-connect/src/bin/chime_decode.rs
+++ b/crates/webrtc/rvoip-amazon-connect/src/bin/chime_decode.rs
@@ -80,8 +80,11 @@ fn print_frame(dir: &str, f: &SdkSignalFrame, byte_len: usize) {
 
     if let Some(j) = &f.join {
         println!(
-            "      JOIN: protocol_version={:?} flags={:?} wants_compressed_sdp={:?} audio_session_id={:?}",
-            j.protocol_version, j.flags, j.wants_compressed_sdp, j.audio_session_id
+            "      JOIN: protocol_version={:?} flags={:?} wants_compressed_sdp={:?} audio_session_id_present={}",
+            j.protocol_version,
+            j.flags,
+            j.wants_compressed_sdp,
+            j.audio_session_id.is_some()
         );
         if let Some(cd) = &j.client_details {
             println!(

--- a/crates/webrtc/rvoip-amazon-connect/src/bin/chime_decode.rs
+++ b/crates/webrtc/rvoip-amazon-connect/src/bin/chime_decode.rs
@@ -80,11 +80,8 @@ fn print_frame(dir: &str, f: &SdkSignalFrame, byte_len: usize) {
 
     if let Some(j) = &f.join {
         println!(
-            "      JOIN: protocol_version={:?} flags={:?} wants_compressed_sdp={:?} audio_session_id_present={}",
-            j.protocol_version,
-            j.flags,
-            j.wants_compressed_sdp,
-            j.audio_session_id.is_some()
+            "      JOIN: protocol_version={:?} flags={:?} wants_compressed_sdp={:?}",
+            j.protocol_version, j.flags, j.wants_compressed_sdp
         );
         if let Some(cd) = &j.client_details {
             println!(


### PR DESCRIPTION
## Summary
- stop printing access and refresh token prefixes in the users-core example
- report only whether an Amazon Chime audio session ID is present

## Verification
- `cargo check --locked -p rvoip-users-core --example users_core_basic_usage`
- `cargo check --locked -p rvoip-amazon-connect --bin chime-decode`
- `git diff --check`

These are the genuine logging issues found while adjudicating the newly populated exact-main CodeQL baseline. Test/example fixtures and analyzer field-sensitivity false positives will receive individual durable GitHub adjudications; no release policy is weakened.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes in an example and a dev diagnostic binary; no auth, signaling, or release behavior changes.
> 
> **Overview**
> Tightens **example and debug logging** so sensitive values are not written to stdout during local runs or frame dumps.
> 
> In the `users-core` basic usage example, access and refresh tokens (including after refresh) are no longer printed as partial strings; output now only states that tokens were issued, while expiry and “token changed” checks are unchanged.
> 
> In the `chime-decode` JOIN frame printer, **`audio_session_id` is dropped from the diagnostic line**, so that session identifier is no longer echoed alongside protocol version, flags, and SDP compression preferences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60c9a174b6df306252a9cd92bb298b61b027209c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->