### PR TITLE
fix(security): avoid logging authentication result fields

### DIFF
--- a/crates/identity/users-core/examples/basic_usage.rs
+++ b/crates/identity/users-core/examples/basic_usage.rs
@@ -51,10 +51,6 @@ async fn main() -> Result<()> {
 
     println!("✅ Authentication successful!");
     println!("   Access token issued (value redacted)");
-    println!(
-        "   Token expires in: {} seconds",
-        auth_result.expires_in.as_secs()
-    );
     println!("   Refresh token issued (value redacted)");
 
     // Simulate token expiration and refresh


### PR DESCRIPTION
## Summary
- remove the remaining log of a field derived from an authentication result
- retain only fixed, redacted issuance messages in the example
- close the final exact-main CodeQL alert before release qualification

## Verification
- `cargo fmt --all -- --check`
- `cargo check --locked -p rvoip-users-core --example users_core_basic_usage`
- `git diff --check`

This is a fail-closed release-security follow-up discovered by the exact-main scan after PR #218.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only logging change with no runtime auth or API behavior impact.
> 
> **Overview**
> Removes the post-login **stdout** line that printed `auth_result.expires_in` from the `users-core` **basic usage** example, so no field from the authentication result is emitted after login.
> 
> Token issuance output stays limited to fixed, redacted messages (access and refresh), matching the release-security/CodeQL follow-up after PR #218.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fb93c60f559d975d63dd9b4e346d063631c599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->