### PR TITLE
fix(release): install libvpx for all-features docs

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Install release validation dependencies
         run: >-
           sudo apt-get update && sudo apt-get install -y
-          libasound2-dev libopus-dev libssl-dev protobuf-compiler pkg-config cmake
+          libasound2-dev libopus-dev libssl-dev libvpx-dev
+          protobuf-compiler pkg-config cmake
 
       - name: Establish local main branch
         run: git checkout -B main origin/main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Install package build dependencies
         run: >-
           sudo apt-get update && sudo apt-get install -y
-          libasound2-dev libopus-dev libssl-dev protobuf-compiler pkg-config cmake
+          libasound2-dev libopus-dev libssl-dev libvpx-dev
+          protobuf-compiler pkg-config cmake
 
       - name: Establish exact local main
         run: git checkout -B main origin/main

--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -263,7 +263,8 @@ jobs:
         if: matrix.hosted
         run: >-
           sudo apt-get update && sudo apt-get install -y
-          libasound2-dev libopus-dev libssl-dev protobuf-compiler pkg-config cmake
+          libasound2-dev libopus-dev libssl-dev libvpx-dev
+          protobuf-compiler pkg-config cmake
 
       - name: Install Chromium for the BridgeFu DTMF regression
         if: matrix.needs_chromium

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -113,6 +113,11 @@ auto-delete disk. A separate cleanup job sweeps interrupted runs. The workers
 never receive the crates.io token and no release worker remains provisioned
 between qualifications.
 
+Hosted qualification, release preparation, and publication runners install the
+native ALSA, Opus, OpenSSL, libvpx, and Protobuf development packages before
+building. `libvpx-dev` is required by the WebRTC VP8/VP9 dependency graph when
+the release rustdoc gate compiles the complete workspace with `--all-features`.
+
 The current full profile is balanced across six `n2-standard-8` short-performance
 workers, two `n2-standard-8` one-hour-soak workers, seven `n2-standard-4`
 burst/soak workers, one `n2-standard-4` stateful interoperability worker, and

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -189,12 +189,25 @@ class WorkflowPolicyTests(unittest.TestCase):
             "libasound2-dev",
             "libopus-dev",
             "libssl-dev",
+            "libvpx-dev",
             "protobuf-compiler",
             "pkg-config",
             "cmake",
         ):
             with self.subTest(package=package):
                 self.assertIn(package, text[dependency_step:validation_step])
+
+    def test_release_all_features_paths_install_libvpx(self) -> None:
+        workflows = (
+            ("release-qualify.yml", "Install hosted-runner native dependencies", "Run gate shard"),
+            ("release-publish.yml", "Install package build dependencies", "Establish exact local main"),
+        )
+        for filename, dependency_name, next_step_name in workflows:
+            with self.subTest(workflow=filename):
+                text = (ROOT / ".github/workflows" / filename).read_text()
+                dependency_step = text.index(dependency_name)
+                next_step = text.index(next_step_name, dependency_step)
+                self.assertIn("libvpx-dev", text[dependency_step:next_step])
 
     def test_parallel_gcp_workspace_is_ephemeral_and_fail_closed(self) -> None:
         workflow = (ROOT / ".github/workflows/gcp-qualification-pilot.yml").read_text()


### PR DESCRIPTION
## Summary
- install `libvpx-dev` in hosted release qualification, preparation, and publication paths
- document why the VP8/VP9 native dependency is required for all-features rustdoc
- add workflow-policy coverage so the release dependency cannot drift out again

## Root cause
The first full 0.3.10 qualification reached `build.rustdoc`, which runs `cargo doc --workspace --all-features --no-deps`. The all-features WebRTC graph activates `env-libvpx-sys`, but the hosted release runner lacked `libvpx-dev`, so pkg-config could not resolve `vpx.pc`.

This is a release-environment prerequisite correction. The failed run continues through its independent shards and mandatory GCP cleanup; it is not valid qualification evidence.

## Verification
- `python3 scripts/ci/test_workflow_policy.py`
- `python3 scripts/ci/run_checks.py policy --name policy --output /tmp/rvoip-libvpx-policy.json`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI runner package lists and release documentation only; no application logic, auth, or publication rules change.
> 
> **Overview**
> Adds **`libvpx-dev`** to the hosted-runner `apt-get` dependency steps in **release qualification**, **release prepare**, and **release publish**, so pkg-config can satisfy the WebRTC VP8/VP9 stack when the **`build.rustdoc`** gate runs `cargo doc --workspace --all-features`.
> 
> **`docs/RELEASING.md`** now states that hosted paths install ALSA, Opus, OpenSSL, libvpx, and Protobuf dev packages, and why libvpx is required for all-features rustdoc.
> 
> **`scripts/ci/test_workflow_policy.py`** asserts `libvpx-dev` in the prepare dependency list and in qualify/publish install steps so the package cannot drop out of workflows unnoticed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 735b6106494bf835761956d1a47976227fef42c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->