### PR TITLE
fix(perf): resolve canonical worker home without environment

### DIFF
--- a/crates/sip/rvoip-sip/scripts/canonical_2k_release_eval.sh
+++ b/crates/sip/rvoip-sip/scripts/canonical_2k_release_eval.sh
@@ -8,6 +8,11 @@ WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 RUNNER="${SCRIPT_DIR}/perf_call_setup_2k_profile.sh"
 EVIDENCE_TOOL="${SCRIPT_DIR}/canonical_2k_evidence.py"
 OUTPUT="${RVOIP_CANONICAL_EVAL_OUTPUT:?RVOIP_CANONICAL_EVAL_OUTPUT is required}"
+RVOIP_CANONICAL_LOGIN_HOME="$(python3 -c 'import os, pwd; print(pwd.getpwuid(os.getuid()).pw_dir)')"
+if [[ -z "${RVOIP_CANONICAL_LOGIN_HOME}" || ! -d "${RVOIP_CANONICAL_LOGIN_HOME}" ]]; then
+  echo "unable to resolve the current account's home directory" >&2
+  exit 1
+fi
 
 mkdir -p "${OUTPUT}/run-logs"
 python3 "${EVIDENCE_TOOL}" fingerprint \
@@ -18,7 +23,7 @@ run_dirs=()
 for pass in 1 2 3; do
   log="${OUTPUT}/run-logs/pass-${pass}.log"
   worker_env=(
-    HOME="${HOME}"
+    HOME="${RVOIP_CANONICAL_LOGIN_HOME}"
     USER="${USER:-}"
     LOGNAME="${LOGNAME:-${USER:-}}"
     PATH="${PATH}"

--- a/crates/sip/rvoip-sip/scripts/test_canonical_2k_evidence.py
+++ b/crates/sip/rvoip-sip/scripts/test_canonical_2k_evidence.py
@@ -197,6 +197,14 @@ class CanonicalEvidenceTests(unittest.TestCase):
         ).stdout.strip()
         self.assertEqual(self.source["git_tree"], expected)
 
+    def test_release_wrapper_does_not_require_inherited_home(self):
+        wrapper = (SCRIPT_DIR / "canonical_2k_release_eval.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("pwd.getpwuid(os.getuid()).pw_dir", wrapper)
+        self.assertIn('HOME="${RVOIP_CANONICAL_LOGIN_HOME}"', wrapper)
+        self.assertNotIn('HOME="${HOME}"', wrapper)
+
     def test_nonpass_manifest_is_rejected(self):
         self.rewrite_manifest(
             self.runs[1], lambda manifest: manifest.update(overall_status="FAIL")


### PR DESCRIPTION
## Summary
- resolve the canonical evaluator home directory from the current OS account instead of inherited `$HOME`
- preserve the deliberately clean `env -i` performance environment
- fail clearly if the account home cannot be resolved
- add regression coverage forbidding the inherited-HOME dependency

## Root cause
The first full 0.3.10 release evaluation ran `perf.canonical-2k-current` on a hardened worker with `HOME` intentionally unset. The wrapper used `${HOME}` under `set -u` before launching pass 1, so the gate failed without executing a performance pass. The controller then stopped the interop and second long-soak shards; those were collateral partials.

## Verification
- `bash -n crates/sip/rvoip-sip/scripts/canonical_2k_release_eval.sh`
- `python3 crates/sip/rvoip-sip/scripts/test_canonical_2k_evidence.py` (12 passed)
- `python3 scripts/ci/run_checks.py policy --name policy --output /tmp/rvoip-canonical-home-policy.json` (111 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to release eval script wiring and a static wrapper test; no runtime SIP or auth behavior changes.
> 
> **Overview**
> Fixes canonical 2k release evaluation on hardened workers where **`HOME` is unset** under `set -u`, which previously aborted the wrapper before any perf pass ran.
> 
> **`canonical_2k_release_eval.sh`** now resolves the login home via **`pwd.getpwuid(os.getuid()).pw_dir`**, validates that directory exists, and passes **`HOME="${RVOIP_CANONICAL_LOGIN_HOME}"`** into the existing **`env -i`** worker env instead of **`${HOME}`**. The clean perf recipe is unchanged; only the home path source differs.
> 
> **`test_canonical_2k_evidence.py`** adds a regression test that the release wrapper must use account-derived home and must not reference inherited **`HOME="${HOME}"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c5a5ed668ec8f298c0f9e9a5604a4a758f2a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->