### PR TITLE
Harden performance evidence and release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 - Pinned the canonical performance client's app-session dispatcher shape so
   exact-candidate results cannot change with the release worker's detected CPU
   count.
+- Reconciled current performance results from authoritative per-worker output
+  instead of nested provenance copies, staged the required high-density burst
+  evidence into the generated evaluation, and made the one-hour 500-call split
+  soak an explicit machine-validated release result.
 
 ### Interoperability and release evidence
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
   instead of nested provenance copies, staged the required high-density burst
   evidence into the generated evaluation, and made the one-hour 500-call split
   soak an explicit machine-validated release result.
+- Preserved intentional prior-release and qualification references when
+  preparing candidate-aware documentation, while still advancing live crate
+  dependency examples and the current workspace runtime marker.
 
 ### Interoperability and release evidence
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@
 - Reconciled current performance results from authoritative per-worker output
   instead of nested provenance copies, staged the required high-density burst
   evidence into the generated evaluation, and made the one-hour 500-call split
-  soak an explicit machine-validated release result.
+  soak an explicit machine-validated release result. A missing authoritative
+  result tree now fails through the structured gate path rather than an
+  uncaught filesystem exception.
 - Preserved intentional prior-release and qualification references when
   preparing candidate-aware documentation, while still advancing live crate
   dependency examples and the current workspace runtime marker.

--- a/crates/sip/rvoip-sip/README.md
+++ b/crates/sip/rvoip-sip/README.md
@@ -337,7 +337,7 @@ Operational references:
   from the 0.3.2 claim and that has not changed.
 - WebRTC/browser interop, TURN, and WSS outbound remain outside the SIP beta
   claim unless separately completed and tested. SIP DTLS-SRTP is a distinct
-  feature-gated 0.3.9 candidate capability whose claim depends on fresh
+  feature-gated 0.3.10 candidate capability whose claim depends on fresh
   protected release evidence.
 - The default full-media performance claim is bounded to the documented
   beta release profiles and artifacts. Higher tuned-profile results need

--- a/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
+++ b/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
@@ -6,7 +6,7 @@ candidate's results. The versioned reporting and selection authority is
 
 Current workspace runtime crate version: `0.3.9`.
 Current qualified runtime crate version: `0.3.9`.
-Next planned candidate runtime crate version: `0.3.10`.
+Release candidate runtime crate version: `0.3.10`.
 Its protected remote-release run passed 208/208 gates and covered all 108
 requirements in the strict legacy ledger. The historical `0.3.2` exception
 path did not qualify it.

--- a/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
+++ b/crates/sip/rvoip-sip/docs/BETA_RELEASE_CHECKLIST.md
@@ -6,6 +6,7 @@ candidate's results. The versioned reporting and selection authority is
 
 Current workspace runtime crate version: `0.3.9`.
 Current qualified runtime crate version: `0.3.9`.
+Next planned candidate runtime crate version: `0.3.10`.
 Its protected remote-release run passed 208/208 gates and covered all 108
 requirements in the strict legacy ledger. The historical `0.3.2` exception
 path did not qualify it.

--- a/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
+++ b/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
@@ -191,7 +191,8 @@ Each interop run should store:
 ## Release-Gate Policy
 
 - A failure in SIPp, Asterisk, FreeSWITCH, Jambonz, Kamailio, or OpenSIPS
-  blocks the applicable release. Jambonz becomes mandatory in 0.3.10.
+  blocks the applicable release. Jambonz was not part of the mandatory 0.3.9
+  matrix and becomes mandatory in 0.3.10.
 - The proxy matrix must contain exactly both pinned peers, both adjacency
   orders, and UDP/TCP/verified-TLS rows. Its global scenario inventory and
   per-row core scenario set are validated independently while generating the

--- a/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
+++ b/crates/sip/rvoip-sip/docs/INTEROP_CI_PLAN.md
@@ -29,8 +29,8 @@ failure rather than a skip.
 | FreeSWITCH Sofia | PBX/B2BUA interop | Required release gate. |
 | Latest stable Jambonz OSS | SBC/B2BUA, registrar, and anchored-media interop | Required 0.3.10 release gate; currently component line 0.9.9. |
 | PJSIP or baresip | Strict SIP user agent | Required release gate. |
-| Kamailio | Transaction-stateful proxy interoperability peer | Required for the `0.3.9` proxy release gate. |
-| OpenSIPS | Independent transaction-stateful proxy interoperability peer | Required for the `0.3.9` proxy release gate. |
+| Kamailio | Transaction-stateful proxy interoperability peer | Required for the `0.3.10` proxy release gate. |
+| OpenSIPS | Independent transaction-stateful proxy interoperability peer | Required for the `0.3.10` proxy release gate. |
 
 ## Current Automation Status
 
@@ -158,7 +158,7 @@ Asterisk/FreeSWITCH lifecycle pattern: it owns startup, readiness, isolated
 configuration, packet capture, logs, exact version/image provenance, teardown,
 and restoration of any process that was running before the gate.
 
-| Scenario | Required for `0.3.9` |
+| Scenario | Required for `0.3.10` |
 |----------|----------------------|
 | UDP, TCP, and TLS/SIPS forwarding | Yes |
 | Matched and unmatched CANCEL | Yes |

--- a/crates/sip/rvoip-sip/docs/TOPOLOGY_PROFILES.md
+++ b/crates/sip/rvoip-sip/docs/TOPOLOGY_PROFILES.md
@@ -19,8 +19,8 @@ run `33969263241`, generated from clean tested commit
 | Asterisk PBX | Interop tested | UDP/TLS registration and calls, digest auth, SDES-SRTP where claimed. |
 | FreeSWITCH PBX | Interop tested | Mirrors the Asterisk matrix where feasible. |
 | Jambonz OSS SBC/B2BUA | Required for 0.3.10 | Latest stable OSS line (currently 0.9.9), pinned per run; authenticated registration, SIP dialog/control, anchored RTP/audio, carrier admission, and cleanup evidence over UDP. |
-| Kamailio transaction-stateful proxy | `0.3.9` release gate | Real-process UDP/TCP/TLS, routing, CANCEL, forking, ACK, response, and cleanup matrix. |
-| OpenSIPS transaction-stateful proxy | `0.3.9` release gate | Independent real-process execution of the same proxy matrix. |
+| Kamailio transaction-stateful proxy | `0.3.10` release gate | Real-process UDP/TCP/TLS, routing, CANCEL, forking, ACK, response, and cleanup matrix. |
+| OpenSIPS transaction-stateful proxy | `0.3.10` release gate | Independent real-process execution of the same proxy matrix. |
 | SIPp UAC/UAS | Release gate | Standalone load matrix at 30, 100, 300, 1,000, and 2,000 CPS. |
 | baresip strict-UA | Interop tested | Strict-UA INVITE, 200 OK, ACK, established call, BYE, and rvoip accept checks. |
 | Signaling-only B2BUA/gateway | Supported with limits | Multi-leg signaling tests and clear media relay caveats. |
@@ -31,7 +31,7 @@ run `33969263241`, generated from clean tested commit
 | Profile | Status | Reason |
 |---------|--------|--------|
 | Tuned high-CPS above 2,000 CPS | Advanced | Requires explicit tuning, hardware notes, and topology caveats. |
-| RTPengine media relay | Investigation | Media-relay integration is separate from the `0.3.9` signaling-proxy conformance claim. |
+| RTPengine media relay | Investigation | Media-relay integration is separate from the `0.3.10` signaling-proxy conformance claim. |
 | Carrier SBC certification | Post-beta | Requires carrier-specific certification and security audit. |
 | Browser/WebRTC edge | Post-beta | DTLS-SRTP, ICE, TURN, and browser interop are outside beta. |
 | ICE/TURN NAT traversal | Post-beta | Current STUN support is limited address discovery, not ICE. |

--- a/crates/sip/rvoip-sip/scripts/beta_performance_gate_metrics.py
+++ b/crates/sip/rvoip-sip/scripts/beta_performance_gate_metrics.py
@@ -672,6 +672,231 @@ def monolithic_metrics(
     }
 
 
+def split_soak_metrics(
+    perf_root: pathlib.Path,
+    expected_duration: int,
+    expected_active_calls: int,
+    expected_rss_limit: float,
+    required: bool,
+) -> dict[str, Any]:
+    caller_path = perf_root / "perf_soak_caller.json"
+    receiver_path = perf_root / "perf_soak_receiver.json"
+    if not caller_path.is_file() or not receiver_path.is_file():
+        if required:
+            raise MetricsError("required split-soak caller/receiver artifacts are missing")
+        return {"enabled": False, "required": False, "passed": True}
+
+    caller = load_json(caller_path)
+    receiver = load_json(receiver_path)
+    caller_results = caller.get("results", {})
+    receiver_results = receiver.get("results", {})
+    caller_gate = caller_results.get("rss_gate", {})
+    receiver_gate = receiver_results.get("rss_gate", {})
+    caller_limit = (
+        caller_gate.get("effective_mb_per_hr")
+        if isinstance(caller_gate, dict)
+        else None
+    )
+    receiver_limit = (
+        receiver_gate.get("effective_mb_per_hr")
+        if isinstance(receiver_gate, dict)
+        else None
+    )
+    caller_duration = caller_results.get("duration_secs")
+    receiver_duration = receiver_results.get(
+        "duration_secs", receiver_results.get("configured_duration_secs")
+    )
+    caller_offered = caller_results.get("calls_offered")
+    caller_succeeded = caller_results.get("calls_succeeded")
+    receiver_completed = receiver_results.get("bob_completed_audio_receivers")
+    caller_skip = (
+        caller.get("diagnostics", {})
+        .get("media_receive", {})
+        .get("skip_audio_frame_delivery")
+    )
+    receiver_skip = (
+        receiver.get("diagnostics", {})
+        .get("media_receive", {})
+        .get("skip_audio_frame_delivery")
+    )
+    checks: list[dict[str, Any]] = []
+    for metric, requirement, observed, passed in (
+        (
+            "duration_secs",
+            f"exactly {expected_duration} for caller and receiver",
+            {"caller": caller_duration, "receiver": receiver_duration},
+            caller_duration == expected_duration
+            and receiver_duration == expected_duration,
+        ),
+        (
+            "active_calls_target",
+            f"exactly {expected_active_calls} for caller and receiver",
+            {
+                "caller": caller_results.get("active_calls_target"),
+                "receiver": receiver_results.get("active_calls_target"),
+            },
+            caller_results.get("active_calls_target") == expected_active_calls
+            and receiver_results.get("active_calls_target") == expected_active_calls,
+        ),
+        (
+            "rss_limit_mb_per_hr",
+            f"exactly {expected_rss_limit:g} for caller and receiver",
+            {"caller": caller_limit, "receiver": receiver_limit},
+            finite_number(caller_limit) == expected_rss_limit
+            and finite_number(receiver_limit) == expected_rss_limit,
+        ),
+        (
+            "full_audio_frame_delivery",
+            "enabled for caller and receiver",
+            {"caller_skip": caller_skip, "receiver_skip": receiver_skip},
+            caller_skip is False and receiver_skip is False,
+        ),
+        (
+            "call_completion",
+            "every offered call succeeds and completes at the receiver",
+            {
+                "offered": caller_offered,
+                "succeeded": caller_succeeded,
+                "receiver_completed": receiver_completed,
+            },
+            isinstance(caller_offered, int)
+            and caller_offered > 0
+            and caller_succeeded == caller_offered
+            and receiver_completed == caller_offered,
+        ),
+        (
+            "errors",
+            "0",
+            caller_results.get("errors"),
+            all_numeric_errors_are_zero(caller_results.get("errors")),
+        ),
+        (
+            "retained_after_drain",
+            "0 for caller and receiver",
+            {
+                "caller": caller_results.get("retained_objects_after_drain"),
+                "receiver": receiver_results.get("retained_objects_after_drain"),
+            },
+            caller_results.get("retained_objects_after_drain") == 0
+            and receiver_results.get("retained_objects_after_drain") == 0,
+        ),
+        (
+            "receiver_active_audio_receivers_after_drain",
+            "0",
+            receiver_results.get("bob_active_audio_receivers"),
+            receiver_results.get("bob_active_audio_receivers") == 0,
+        ),
+        (
+            "transaction_managers_after_drain",
+            "0 for caller and receiver",
+            {
+                "caller": caller_results.get("transaction_manager_active_after_drain"),
+                "receiver": receiver_results.get(
+                    "transaction_manager_active_after_drain"
+                ),
+            },
+            caller_results.get("transaction_manager_active_after_drain") == 0
+            and receiver_results.get("transaction_manager_active_after_drain") == 0,
+        ),
+        (
+            "transaction_runners_after_drain",
+            "0 for caller and receiver",
+            {
+                "caller": caller_results.get("transaction_runner_active_after_drain"),
+                "receiver": receiver_results.get(
+                    "transaction_runner_active_after_drain"
+                ),
+            },
+            caller_results.get("transaction_runner_active_after_drain") == 0
+            and receiver_results.get("transaction_runner_active_after_drain") == 0,
+        ),
+        (
+            "receiver_stop_seen",
+            "true",
+            receiver_results.get("stop_seen"),
+            receiver_results.get("stop_seen") is True,
+        ),
+        (
+            "rss_gate_window",
+            "active_tail_1200s for caller and receiver",
+            {
+                "caller": caller_results.get("rss_gate_window"),
+                "receiver": receiver_results.get("rss_gate_window"),
+            },
+            caller_results.get("rss_gate_window") == "active_tail_1200s"
+            and receiver_results.get("rss_gate_window") == "active_tail_1200s",
+        ),
+        (
+            "rss_active_tail_window_complete",
+            "true for caller and receiver",
+            {
+                "caller": caller_results.get("rss_active_tail_window_complete"),
+                "receiver": receiver_results.get("rss_active_tail_window_complete"),
+            },
+            caller_results.get("rss_active_tail_window_complete") is True
+            and receiver_results.get("rss_active_tail_window_complete") is True,
+        ),
+    ):
+        add_check(checks, metric, requirement, observed, passed)
+
+    frames = receiver_results.get("bob_received_frames")
+    add_check(
+        checks,
+        "delivered_audio_frames",
+        "> 0",
+        frames,
+        isinstance(frames, int) and frames > 0,
+    )
+    for role, results in (("caller", caller_results), ("receiver", receiver_results)):
+        tail_window = finite_number(results.get("rss_active_tail_window_secs"))
+        add_check(
+            checks,
+            f"{role}_rss_active_tail_window_secs",
+            ">= 1190",
+            tail_window,
+            tail_window is not None and tail_window >= 1190.0,
+        )
+        growth = finite_number(results.get("rss_gate_growth_mb_per_hr"))
+        add_check(
+            checks,
+            f"{role}_rss_gate_growth_mb_per_hr",
+            f"<= {expected_rss_limit:g}",
+            growth,
+            growth is not None and growth <= expected_rss_limit,
+        )
+
+    return {
+        "enabled": True,
+        "required": required,
+        "passed": all(check["passed"] for check in checks),
+        "evidence": {
+            "caller": caller_path.relative_to(perf_root).as_posix(),
+            "receiver": receiver_path.relative_to(perf_root).as_posix(),
+        },
+        "policy": {
+            "duration_secs": expected_duration,
+            "active_calls_target": expected_active_calls,
+            "rss_limit_mb_per_hr": expected_rss_limit,
+            "full_audio_frame_delivery": True,
+        },
+        "observed": {
+            "calls_offered": caller_offered,
+            "calls_succeeded": caller_succeeded,
+            "receiver_completed_audio_receivers": receiver_completed,
+            "asr": caller_results.get("asr"),
+            "errors": caller_results.get("errors"),
+            "delivered_audio_frames": frames,
+            "caller_rss_gate_mb_per_hr": caller_results.get(
+                "rss_gate_growth_mb_per_hr"
+            ),
+            "receiver_rss_gate_mb_per_hr": receiver_results.get(
+                "rss_gate_growth_mb_per_hr"
+            ),
+        },
+        "checks": checks,
+    }
+
+
 def markdown(metrics: dict[str, Any]) -> str:
     lines = [
         "## Performance Gate Metrics",
@@ -684,6 +909,7 @@ def markdown(metrics: dict[str, Any]) -> str:
         ("canonical_2k", "Canonical 2,000-CPS evaluation"),
         ("high_density_media_burst", "High-density media burst"),
         ("monolithic_soak", "Monolithic soak"),
+        ("split_soak", "Split soak"),
     ):
         section = metrics[key]
         lines.extend([f"### {title}", ""])
@@ -728,8 +954,11 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--rss-limit-mb-per-hr", type=float, default=15.0)
     result.add_argument("--monolithic-duration-secs", type=int, default=3600)
     result.add_argument("--monolithic-active-calls", type=int, default=30)
+    result.add_argument("--split-duration-secs", type=int, default=3600)
+    result.add_argument("--split-active-calls", type=int, default=500)
     result.add_argument("--require-high-density", action="store_true")
     result.add_argument("--require-monolithic", action="store_true")
+    result.add_argument("--require-split", action="store_true")
     result.add_argument("--require-canonical", action="store_true")
     return result
 
@@ -761,6 +990,13 @@ def main() -> int:
                 args.rss_limit_mb_per_hr,
                 args.require_monolithic,
             ),
+            "split_soak": split_soak_metrics(
+                root,
+                args.split_duration_secs,
+                args.split_active_calls,
+                args.rss_limit_mb_per_hr,
+                args.require_split,
+            ),
         }
         metrics["passed"] = all(
             metrics[key]["passed"]
@@ -768,6 +1004,7 @@ def main() -> int:
                 "canonical_2k",
                 "high_density_media_burst",
                 "monolithic_soak",
+                "split_soak",
             )
         )
         output_json = pathlib.Path(args.output_json)

--- a/crates/sip/rvoip-sip/scripts/test_beta_performance_gate_metrics.py
+++ b/crates/sip/rvoip-sip/scripts/test_beta_performance_gate_metrics.py
@@ -100,6 +100,54 @@ class BetaPerformanceGateMetricsTests(unittest.TestCase):
         (self.root / "perf_soak_30min.json").write_text(
             json.dumps(monolithic), encoding="utf-8"
         )
+        split_caller = {
+            "diagnostics": {"media_receive": {"skip_audio_frame_delivery": False}},
+            "results": {
+                "duration_secs": 3600,
+                "active_calls_target": 500,
+                "calls_offered": 9904,
+                "calls_succeeded": 9904,
+                "asr": 1.0,
+                "errors": {
+                    "call_failed": 0,
+                    "media_setup_failed": 0,
+                    "teardown_failed": 0,
+                },
+                "rss_gate": {"effective_mb_per_hr": 15.0},
+                "rss_gate_window": "active_tail_1200s",
+                "rss_active_tail_window_secs": 1200.0,
+                "rss_active_tail_window_complete": True,
+                "rss_gate_growth_mb_per_hr": 5.0,
+                "retained_objects_after_drain": 0,
+                "transaction_manager_active_after_drain": 0,
+                "transaction_runner_active_after_drain": 0,
+            },
+        }
+        split_receiver = {
+            "diagnostics": {"media_receive": {"skip_audio_frame_delivery": False}},
+            "results": {
+                "configured_duration_secs": 3600,
+                "active_calls_target": 500,
+                "bob_completed_audio_receivers": 9904,
+                "bob_received_frames": 80_000_000,
+                "bob_active_audio_receivers": 0,
+                "rss_gate": {"effective_mb_per_hr": 15.0},
+                "rss_gate_window": "active_tail_1200s",
+                "rss_active_tail_window_secs": 1200.0,
+                "rss_active_tail_window_complete": True,
+                "rss_gate_growth_mb_per_hr": 9.0,
+                "retained_objects_after_drain": 0,
+                "transaction_manager_active_after_drain": 0,
+                "transaction_runner_active_after_drain": 0,
+                "stop_seen": True,
+            },
+        }
+        (self.root / "perf_soak_caller.json").write_text(
+            json.dumps(split_caller), encoding="utf-8"
+        )
+        (self.root / "perf_soak_receiver.json").write_text(
+            json.dumps(split_receiver), encoding="utf-8"
+        )
         canonical = self.root / "canonical-2k"
         canonical.mkdir()
         self.candidate_sha = "c" * 40
@@ -166,9 +214,11 @@ class BetaPerformanceGateMetricsTests(unittest.TestCase):
         )
         burst = metrics.high_density_metrics(self.root, 160.0, 0.995, 15.0, True)
         soak = metrics.monolithic_metrics(self.root, 3600, 30, 15.0, True)
+        split = metrics.split_soak_metrics(self.root, 3600, 500, 15.0, True)
         self.assertTrue(canonical["passed"])
         self.assertTrue(burst["passed"])
         self.assertTrue(soak["passed"])
+        self.assertTrue(split["passed"])
         self.assertIn(
             "full_audio_frame_delivery",
             metrics.markdown(
@@ -176,6 +226,7 @@ class BetaPerformanceGateMetricsTests(unittest.TestCase):
                     "canonical_2k": canonical,
                     "high_density_media_burst": burst,
                     "monolithic_soak": soak,
+                    "split_soak": split,
                 }
             ),
         )
@@ -186,6 +237,7 @@ class BetaPerformanceGateMetricsTests(unittest.TestCase):
                     "canonical_2k": canonical,
                     "high_density_media_burst": burst,
                     "monolithic_soak": soak,
+                    "split_soak": split,
                 }
             ),
         )
@@ -250,6 +302,15 @@ class BetaPerformanceGateMetricsTests(unittest.TestCase):
         value["results"]["errors"]["timeout"] = 100
         path.write_text(json.dumps(value), encoding="utf-8")
         result = metrics.high_density_metrics(self.root, 160.0, 0.995, 15.0, True)
+        self.assertFalse(result["passed"])
+
+    def test_split_soak_requires_cross_role_completion_and_drain(self):
+        path = self.root / "perf_soak_receiver.json"
+        value = json.loads(path.read_text(encoding="utf-8"))
+        value["results"]["bob_completed_audio_receivers"] = 9903
+        value["results"]["retained_objects_after_drain"] = 1
+        path.write_text(json.dumps(value), encoding="utf-8")
+        result = metrics.split_soak_metrics(self.root, 3600, 500, 15.0, True)
         self.assertFalse(result["passed"])
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -84,6 +84,10 @@ DEPENDENCY_EXAMPLE_VERSION = re.compile(
     r'(?:"(?P<plain>[0-9]+\.[0-9]+\.[0-9]+)"|'
     r'\{[^\n}]*\bversion\s*=\s*"(?P<table>[0-9]+\.[0-9]+\.[0-9]+)"[^\n}]*\})'
 )
+CURRENT_WORKSPACE_RELEASE_VERSION = re.compile(
+    r"(?m)^(?P<prefix>Current workspace runtime crate version:\s*`)"
+    r"[0-9]+\.[0-9]+\.[0-9]+(?P<suffix>`\.)$"
+)
 LIVE_DEPENDENCY_SCAN_SUFFIXES = frozenset({".toml"})
 LIVE_DEPENDENCY_SCAN_IGNORED_DIRS = frozenset({".git", "target"})
 VERIFICATION_RECEIPT_SCHEMA = "rvoip-unified-release-verification-v4"
@@ -591,7 +595,14 @@ def planned_version_edits(
 def planned_release_metadata_edits(
     root: Path, current_version: str, version: str
 ) -> dict[Path, bytes]:
-    """Update current-version references in the active release documents."""
+    """Update active release references without rewriting historical evidence.
+
+    Candidate-aware documents can intentionally mention both the published
+    version and the next version.  In those files, only live dependency
+    examples are mechanical release metadata; the remaining version prose is
+    author-owned history or qualification context.  Documents that do not yet
+    mention the target retain the legacy all-marker update.
+    """
     validate_active_release_metadata(root, current_version)
     changes: dict[Path, bytes] = {}
     for relative_path in ACTIVE_RELEASE_METADATA_FILES:
@@ -603,7 +614,17 @@ def planned_release_metadata_edits(
                 f"active release metadata in {relative_path} does not reference "
                 f"workspace version {current_version}"
             )
-        updated = text.replace(current_version, version)
+        if version in text:
+            updated = DEPENDENCY_EXAMPLE_VERSION.sub(
+                lambda match: match.group(0).replace(current_version, version),
+                text,
+            )
+            updated = CURRENT_WORKSPACE_RELEASE_VERSION.sub(
+                lambda match: f"{match.group('prefix')}{version}{match.group('suffix')}",
+                updated,
+            )
+        else:
+            updated = text.replace(current_version, version)
         changes[path] = updated.encode()
     return changes
 

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -1046,10 +1046,18 @@ def reconcile_performance_regression(root: Path, evidence_root: Path, artifact: 
     for value in comparison_paths:
         if not isinstance(value, str) or Path(value).is_absolute() or ".." in Path(value).parts:
             raise GateError(f"unsafe performance comparison path: {value!r}")
+        # Worker result collection has one authoritative root per shard:
+        # `_perf-results/<shard>/<comparison-path>`.  Some gates also retain
+        # complete nested provenance packages (for example, each canonical
+        # run's output tree and reviewed baseline).  Those copies are evidence
+        # to index, but they are not independent current measurements and must
+        # never participate in regression-result selection.
         matches = sorted(
             path
-            for path in (evidence_root / "_perf-results").rglob(Path(value).name)
-            if path.as_posix().endswith("/" + value)
+            for shard_root in (evidence_root / "_perf-results").iterdir()
+            if shard_root.is_dir()
+            for path in (shard_root / value,)
+            if path.is_file()
         )
         if len(matches) != 1:
             raise GateError(
@@ -1117,12 +1125,43 @@ def reconcile_performance_metrics(
                     raise GateError(
                         f"conflicting exact-candidate performance artifact: {key}"
                     )
-                continue
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(path, destination)
+            else:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(path, destination)
             indexed[f"performance-results/{key}"] = digest
     if not indexed:
         raise GateError("exact-candidate performance artifact set is empty")
+
+    # The split media-burst gates write their structured result tree directly
+    # into the gate artifact directory rather than `target/perf-results`.
+    # Stage the one release-required high-density profile into the canonical
+    # metrics layout while retaining the original gate evidence unchanged.
+    high_density_gate = evidence_root / "perf.media-burst.high-density-media-burst"
+    high_density_runs = sorted(
+        path
+        for path in high_density_gate.glob(
+            "perf_burst_matrix/burst_*/high-density-media-burst"
+        )
+        if path.is_dir()
+    )
+    if len(high_density_runs) != 1:
+        raise GateError(
+            "current performance evaluation requires exactly one high-density "
+            f"media-burst result, found {len(high_density_runs)}"
+        )
+    high_density_run = high_density_runs[0]
+    for filename in (
+        "perf_burst_caller_high-density-media-burst.json",
+        "perf_burst_receiver_high-density-media-burst.json",
+    ):
+        source_path = high_density_run / filename
+        if not source_path.is_file():
+            raise GateError(f"required high-density performance artifact is missing: {filename}")
+        relative = source_path.relative_to(high_density_gate)
+        destination = combined / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination)
+        indexed[f"performance-results/{relative.as_posix()}"] = file_sha256(source_path)
 
     canonical_index = (
         evidence_root
@@ -1212,8 +1251,13 @@ def reconcile_performance_metrics(
             "3600",
             "--monolithic-active-calls",
             "30",
+            "--split-duration-secs",
+            "3600",
+            "--split-active-calls",
+            "500",
             "--require-high-density",
             "--require-monolithic",
+            "--require-split",
             "--require-canonical",
         ],
         root=root,

--- a/scripts/release/gates.py
+++ b/scripts/release/gates.py
@@ -1040,6 +1040,9 @@ def reconcile_performance_regression(root: Path, evidence_root: Path, artifact: 
     comparison_paths = payload.get("comparison_paths")
     if not isinstance(comparison_paths, list) or not comparison_paths:
         raise GateError("packaged performance baseline has no comparison paths")
+    results_root = evidence_root / "_perf-results"
+    if not results_root.is_dir():
+        raise GateError("exact-candidate performance results directory is missing")
     current = artifact / "current-performance"
     current.mkdir(parents=True, exist_ok=True)
     selected = {}
@@ -1054,7 +1057,7 @@ def reconcile_performance_regression(root: Path, evidence_root: Path, artifact: 
         # never participate in regression-result selection.
         matches = sorted(
             path
-            for shard_root in (evidence_root / "_perf-results").iterdir()
+            for shard_root in results_root.iterdir()
             if shard_root.is_dir()
             for path in (shard_root / value,)
             if path.is_file()

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -421,6 +421,35 @@ rvoip-rtc = { path = "../rvoip-rtc" }
                         root, "0.3.5", "0.3.6"
                     )
 
+    def test_candidate_aware_metadata_preserves_historical_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = root / "README.md"
+            path.write_text(
+                "# 0.3.10 candidate\n"
+                "Current workspace runtime crate version: `0.3.9`.\n"
+                "Current qualified runtime crate version: `0.3.9`.\n"
+                "0.3.9 remains the latest published release.\n"
+                'rvoip = { version = "0.3.9", features = ["sip"] }\n',
+                encoding="utf-8",
+            )
+            with mock.patch.object(
+                release, "ACTIVE_RELEASE_METADATA_FILES", (Path("README.md"),)
+            ):
+                edits = release.planned_release_metadata_edits(
+                    root, "0.3.9", "0.3.10"
+                )
+
+            updated = edits[path].decode()
+            self.assertIn(
+                "Current workspace runtime crate version: `0.3.10`", updated
+            )
+            self.assertIn(
+                "Current qualified runtime crate version: `0.3.9`", updated
+            )
+            self.assertIn("0.3.9 remains the latest published release", updated)
+            self.assertIn('rvoip = { version = "0.3.10"', updated)
+
     def test_active_release_metadata_rejects_stale_dependency_example(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -1073,6 +1073,25 @@ class GateFrameworkTests(unittest.TestCase):
             ):
                 gates.reconcile_performance_regression(ROOT, evidence, artifact)
 
+    def test_performance_reconciliation_rejects_missing_results_directory(
+        self,
+    ) -> None:
+        baseline_root = (
+            ROOT / "crates/sip/rvoip-sip/perf-baselines/20260706T181609Z"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory) / "evidence"
+            packaged = evidence / "baseline-gate/perf-regression-baseline"
+            packaged.mkdir(parents=True)
+            shutil.copy2(baseline_root / "manifest.json", packaged / "manifest.json")
+            artifact = evidence / "collect-report.regression-audit"
+
+            with self.assertRaisesRegex(
+                gates.GateError,
+                "exact-candidate performance results directory is missing",
+            ):
+                gates.reconcile_performance_regression(ROOT, evidence, artifact)
+
     def test_current_performance_reconciliation_fails_without_candidate_artifacts(
         self,
     ) -> None:

--- a/scripts/test_release_gates.py
+++ b/scripts/test_release_gates.py
@@ -994,6 +994,85 @@ class GateFrameworkTests(unittest.TestCase):
                 set(result["selected_results"]), set(manifest["comparison_paths"])
             )
 
+    def test_performance_reconciliation_ignores_nested_provenance_copies(
+        self,
+    ) -> None:
+        baseline_root = (
+            ROOT / "crates/sip/rvoip-sip/perf-baselines/20260706T181609Z"
+        )
+        manifest = json.loads((baseline_root / "manifest.json").read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory) / "evidence"
+            packaged = evidence / "baseline-gate/perf-regression-baseline"
+            packaged.mkdir(parents=True)
+            shutil.copy2(baseline_root / "manifest.json", packaged / "manifest.json")
+            for relative in manifest["comparison_paths"]:
+                source = baseline_root / relative
+                baseline_target = packaged / "perf-results" / relative
+                current_target = evidence / "_perf-results/matrix-shard" / relative
+                provenance_current = (
+                    evidence
+                    / "_perf-results/canonical-shard/profiles/run-1/output-target/perf-results"
+                    / relative
+                )
+                provenance_baseline = (
+                    evidence
+                    / "_perf-results/canonical-shard/profiles/run-1/reviewed-baseline"
+                    / relative
+                )
+                for target in (
+                    baseline_target,
+                    current_target,
+                    provenance_current,
+                    provenance_baseline,
+                ):
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(source, target)
+            artifact = evidence / "collect-report.regression-audit"
+            artifact.mkdir()
+            result = gates.reconcile_performance_regression(
+                ROOT, evidence, artifact
+            )
+            self.assertEqual(
+                set(result["selected_results"]), set(manifest["comparison_paths"])
+            )
+
+    def test_performance_reconciliation_rejects_duplicate_authoritative_results(
+        self,
+    ) -> None:
+        baseline_root = (
+            ROOT / "crates/sip/rvoip-sip/perf-baselines/20260706T181609Z"
+        )
+        manifest = json.loads((baseline_root / "manifest.json").read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory) / "evidence"
+            packaged = evidence / "baseline-gate/perf-regression-baseline"
+            packaged.mkdir(parents=True)
+            shutil.copy2(baseline_root / "manifest.json", packaged / "manifest.json")
+            for relative in manifest["comparison_paths"]:
+                source = baseline_root / relative
+                baseline_target = packaged / "perf-results" / relative
+                current_target = evidence / "_perf-results/matrix-shard" / relative
+                baseline_target.parent.mkdir(parents=True, exist_ok=True)
+                current_target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, baseline_target)
+                shutil.copy2(source, current_target)
+            duplicate = (
+                evidence
+                / "_perf-results/duplicate-shard"
+                / manifest["comparison_paths"][0]
+            )
+            duplicate.parent.mkdir(parents=True)
+            shutil.copy2(
+                baseline_root / manifest["comparison_paths"][0], duplicate
+            )
+            artifact = evidence / "collect-report.regression-audit"
+            artifact.mkdir()
+            with self.assertRaisesRegex(
+                gates.GateError, "has 2 exact-candidate results"
+            ):
+                gates.reconcile_performance_regression(ROOT, evidence, artifact)
+
     def test_current_performance_reconciliation_fails_without_candidate_artifacts(
         self,
     ) -> None:
@@ -1001,6 +1080,21 @@ class GateFrameworkTests(unittest.TestCase):
             root = Path(directory)
             with self.assertRaisesRegex(
                 gates.GateError, "exact-candidate performance artifacts are missing"
+            ):
+                gates.reconcile_performance_metrics(
+                    ROOT, root, root / "artifact", "c" * 40
+                )
+
+    def test_current_performance_reconciliation_requires_one_high_density_run(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            shard = root / "_perf-results/shard"
+            shard.mkdir(parents=True)
+            (shard / "result.json").write_text("{}\n")
+            with self.assertRaisesRegex(
+                gates.GateError, "exactly one high-density media-burst result"
             ):
                 gates.reconcile_performance_metrics(
                     ROOT, root, root / "artifact", "c" * 40
@@ -1014,6 +1108,16 @@ class GateFrameworkTests(unittest.TestCase):
             shard = root / "_perf-results/shard"
             shard.mkdir(parents=True)
             (shard / "result.json").write_text("{}\n")
+            burst = (
+                root
+                / "perf.media-burst.high-density-media-burst"
+                / "perf_burst_matrix/burst_fixture/high-density-media-burst"
+            )
+            burst.mkdir(parents=True)
+            for role in ("caller", "receiver"):
+                (burst / f"perf_burst_{role}_high-density-media-burst.json").write_text(
+                    "{}\n"
+                )
             with self.assertRaisesRegex(
                 gates.GateError, "exact-candidate canonical 2,000-CPS evidence index"
             ):


### PR DESCRIPTION
## Summary

- select authoritative per-worker regression results without misclassifying nested canonical provenance copies
- stage the required high-density burst artifacts into the generated current evaluation
- validate the 3,600-second 500-call split soak explicitly, including completion, audio delivery, RSS slope, and drain state
- preserve strict duplicate rejection and make repeated aggregation idempotent

## Verification

- 126 release-tooling and performance-metrics tests pass
- downloaded evidence from protected run 34044372378 replays as 213 fresh gates passing
- split soak: 9,904/9,904 calls, 89,709,441 delivered frames, 5.82/9.01 MB/hour caller/receiver RSS slopes, zero retained objects
- git diff --check passes

The original run remains immutable and red; this PR fixes the collector rather than altering its evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release qualification and performance gate pass/fail logic; bugs could block or mis-evaluate releases, but production SIP/runtime behavior is unchanged.
> 
> **Overview**
> Fixes **release performance evidence collection** so regression reconciliation picks **one authoritative file per shard** under `_perf-results/<shard>/…`, ignores nested canonical provenance copies, rejects duplicates, and fails with a structured gate error when the results tree is missing. The current-performance collector also **stages the required high-density media-burst JSON** from the gate artifact into the combined metrics layout and makes shard aggregation **idempotent** when the same path appears twice with identical content.
> 
> Adds an explicit **split soak** section to `beta_performance_gate_metrics.py`: machine validation of the **one-hour / 500-active-call** caller+receiver soak (`perf_soak_caller.json` / `perf_soak_receiver.json`), including completion, full audio delivery, RSS slope/window checks, and post-drain cleanup. Release evaluation now runs with **`--require-split`** alongside the existing canonical, burst, and monolithic requirements.
> 
> **Release metadata prep** (`planned_release_metadata_edits`) no longer blanket-replaces version strings when a doc already mentions the next candidate; it advances **live dependency examples** and the **current workspace runtime** line while leaving intentional qualified/prior-release prose intact.
> 
> Docs/changelog updates align **0.3.10** release-gate wording (Jambonz mandatory, Kamailio/OpenSIPS proxy matrix on **0.3.10**, DTLS-SRTP candidate note).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fabf4233f4f4050b339a6b801adf9c465a149c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->