### PR TITLE
Allow exact-candidate Rust CodeQL to finish

### DIFF
--- a/.github/workflows/release-qualify.yml
+++ b/.github/workflows/release-qualify.yml
@@ -58,10 +58,11 @@ jobs:
   plan:
     name: Plan exact-candidate gates
     runs-on: ubuntu-latest
-    # Exact-main Rust CodeQL normally takes about 24 minutes. Keep the job
-    # deadline above the policy poll window so a post-merge dispatch cannot be
-    # cancelled by the runner before the policy emits its own receipt.
-    timeout-minutes: 30
+    # Exact-main Rust CodeQL has exceeded 20 minutes and approached 30 on a
+    # hosted runner. Keep the job deadline above the one-hour policy poll
+    # window so a post-merge dispatch cannot fail while the authoritative
+    # analysis is still making progress.
+    timeout-minutes: 75
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
       hosted_matrix: ${{ steps.plan.outputs.hosted_matrix }}
@@ -132,7 +133,7 @@ jobs:
           python3 scripts/ci/check_codeql_release_policy.py
           --repository "${{ github.repository }}"
           --candidate "$(git rev-parse HEAD)"
-          --timeout-seconds 1200
+          --timeout-seconds 3600
           --receipt target/release-plan/codeql-policy.json
 
       - name: Download prior qualification evidence

--- a/docs/RELEASE_0_3_10_HARDENING_PLAN.md
+++ b/docs/RELEASE_0_3_10_HARDENING_PLAN.md
@@ -216,7 +216,10 @@ profile or silently broaden its claim.
    qualification with
    `first_candidate=true`. Evidence reuse from 0.3.9 is not accepted for this
    hardening release, and the new current-candidate performance evaluation is
-   mandatory.
+   mandatory. The qualification planner waits up to one hour for the exact
+   merged commit's Rust CodeQL analysis; a cold hosted analysis can approach
+   30 minutes and must not be mistaken for stale evidence while it is still
+   running.
 7. Run protected publication dry-run and live publication against that same
    qualified SHA and qualification run ID.
 8. Verify all 45 crates and docs on crates.io plus the protected tag and

--- a/scripts/ci/check_codeql_release_policy.py
+++ b/scripts/ci/check_codeql_release_policy.py
@@ -136,7 +136,7 @@ def main() -> int:
     parser.add_argument("--repository", required=True)
     parser.add_argument("--candidate", required=True)
     parser.add_argument("--receipt", type=Path, required=True)
-    parser.add_argument("--timeout-seconds", type=int, default=1_200)
+    parser.add_argument("--timeout-seconds", type=int, default=3_600)
     parser.add_argument("--poll-seconds", type=int, default=20)
     parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
     args = parser.parse_args()

--- a/scripts/ci/test_workflow_policy.py
+++ b/scripts/ci/test_workflow_policy.py
@@ -449,8 +449,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()
         plan = workflow.split("  plan:\n", maxsplit=1)[1].split("\n  gate-hosted:\n", maxsplit=1)[0]
 
-        self.assertIn("timeout-minutes: 30", plan)
-        self.assertIn("--timeout-seconds 1200", plan)
+        self.assertIn("timeout-minutes: 75", plan)
+        self.assertIn("--timeout-seconds 3600", plan)
 
     def test_remote_diagnostics_are_exact_gate_fresh_and_non_publishing(self) -> None:
         workflow = (ROOT / ".github/workflows/release-qualify.yml").read_text()


### PR DESCRIPTION
## Summary

- extend the release planner timeout to 75 minutes
- allow the exact-candidate CodeQL policy to poll for one hour
- record the observed cold-run timing in the 0.3.10 hardening plan

## Root cause

The first exact-main 0.3.10 qualification timed out after 1,200 seconds while the authoritative Rust CodeQL analysis was still running. The same lane took more than 27 minutes on the version PR, so the release planner deadline was shorter than a normal analysis.

## Verification

- `git diff --check`
- `python3 scripts/ci/test_codeql_release_policy.py`
- `python3 scripts/ci/test_workflow_policy.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI timeout and documentation changes only; no runtime, auth, or release publication logic is modified.
> 
> **Overview**
> Release qualification was failing when **exact-candidate Rust CodeQL** on `main` took longer than the old **20-minute** policy poll and **30-minute** planner job limits (observed runs approaching **30 minutes**).
> 
> This PR **raises the CodeQL policy wait to one hour** (`--timeout-seconds 3600` in `release-qualify.yml` and as the default in `check_codeql_release_policy.py`) and **extends the `plan` job timeout to 75 minutes** so the workflow does not cancel while polling is still valid. The **0.3.10 hardening plan** documents the one-hour wait and cold-run timing, and **workflow policy tests** assert the new limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44c8a36c17f18605b8a2e742c84980c09f7dddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->