### PR TITLE
Fix release report baseline classification

### DIFF
--- a/scripts/release/render_qualification_reports.py
+++ b/scripts/release/render_qualification_reports.py
@@ -101,6 +101,12 @@ def milliseconds(value: Any) -> str:
     return number(value / 1_000_000, 3)
 
 
+def is_reviewed_performance_baseline(path: Path, perf_root: Path) -> bool:
+    """Return whether *path* is a historical comparison-baseline artifact."""
+    relative = path.relative_to(perf_root)
+    return "reviewed-baseline" in relative.parts[:-1]
+
+
 def load_bundle(
     *,
     catalog_path: Path,
@@ -263,6 +269,12 @@ def load_bundle(
     if not perf_root.is_dir() and fresh_performance_gates > 0:
         raise ReportError("qualification bundle has no archived performance results")
     for path in sorted(perf_root.rglob("*.json")) if perf_root.is_dir() else ():
+        # Canonical performance gates retain their historical comparison input
+        # beside the current output so the audit is reproducible.  Those
+        # reviewed-baseline files remain part of the qualification evidence,
+        # but they are neither current measurements nor exact-candidate output.
+        if is_reviewed_performance_baseline(path, perf_root):
+            continue
         payload = read_object(path, "performance result")
         scenario = payload.get("scenario")
         environment = payload.get("environment")

--- a/scripts/test_render_qualification_reports.py
+++ b/scripts/test_render_qualification_reports.py
@@ -212,6 +212,45 @@ class QualificationReportTests(unittest.TestCase):
                 version="0.3.9",
             )
 
+    def test_ignores_reviewed_baseline_but_validates_nested_current_output(
+        self,
+    ) -> None:
+        profile = self.evidence / "_perf-results/gcp-soak/profiles/run-1"
+        current = profile / "output-target/perf-results/perf_call_setup/100.json"
+        baseline = profile / "reviewed-baseline/perf_call_setup/100.json"
+        current.parent.mkdir(parents=True)
+        baseline.parent.mkdir(parents=True)
+        source = self.evidence / "_perf-results/host/perf_call_setup.json"
+        current.write_bytes(source.read_bytes())
+        historical = json.loads(source.read_text())
+        historical["environment"]["git_commit"] = "b" * 40
+        historical["environment"]["rvoip_sip_version"] = "0.3.8"
+        baseline.write_text(json.dumps(historical))
+
+        _, _, measurements = reports.load_bundle(
+            catalog_path=self.catalog_path,
+            plan_path=self.plan_path,
+            aggregate_path=self.aggregate_path,
+            evidence_root=self.evidence,
+            version="0.3.9",
+        )
+
+        paths = {measurement["path"] for measurement in measurements}
+        self.assertIn(current.relative_to(self.evidence).as_posix(), paths)
+        self.assertNotIn(baseline.relative_to(self.evidence).as_posix(), paths)
+
+        current_payload = json.loads(current.read_text())
+        current_payload["environment"]["git_commit"] = "c" * 40
+        current.write_text(json.dumps(current_payload))
+        with self.assertRaisesRegex(reports.ReportError, "not exact-candidate"):
+            reports.load_bundle(
+                catalog_path=self.catalog_path,
+                plan_path=self.plan_path,
+                aggregate_path=self.aggregate_path,
+                evidence_root=self.evidence,
+                version="0.3.9",
+            )
+
     def test_rejects_missing_gate_receipt(self) -> None:
         (self.evidence / "source.clean/receipt.json").unlink()
         with self.assertRaisesRegex(reports.ReportError, "exactly one exact-candidate receipt"):


### PR DESCRIPTION
## Summary

- exclude nested `reviewed-baseline` JSON from current-candidate performance report validation while retaining it in the qualification evidence bundle
- continue validating adjacent nested current output against the exact candidate
- cover the production evidence-tree shape with a regression test

## Verification

- replayed the renderer against failed qualification artifact from run 34074372543: 213/213 fresh gates, 59 current measurements, 0 reviewed-baseline paths in the report
- 132 release-tooling tests pass
- 135 SIP evidence-helper tests pass
- `git diff --check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-tooling-only change to performance JSON classification during report generation; behavior is covered by a targeted unit test.
> 
> **Overview**
> Fixes qualification report rendering when performance evidence nests **historical comparison baselines** next to current run output under `_perf-results`.
> 
> `load_bundle` now uses `is_reviewed_performance_baseline` to **skip** JSON under a `reviewed-baseline` directory segment. Those files stay in the evidence bundle for audit reproducibility but are no longer treated as current measurements or checked against the exact release candidate commit/version.
> 
> **Adjacent nested current output** (e.g. under `output-target/perf-results/`) is still included in the performance report and must pass exact-candidate validation. A regression test mirrors the production tree shape: wrong-commit baseline is ignored, current path is listed, and tampering current output still raises `not exact-candidate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f206ce2b960cd7b23f658218008419c9506347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->